### PR TITLE
Updated Slideshow + iPad Scrolling

### DIFF
--- a/src/components/pic-slider.js
+++ b/src/components/pic-slider.js
@@ -11,9 +11,9 @@ class PicSlider extends Component {
     super(props);
     this.settings = {
       autoplay: true,
-      autoplaySpeed: 2000,
+      autoplaySpeed: 3000,
       infinite: true,
-      speed: 500,
+      speed: 1000,
       slidesToShow: 1,
       slidesToScroll: 1,
       arrows: false,

--- a/static/styles.scss
+++ b/static/styles.scss
@@ -1,5 +1,6 @@
 * {
   box-sizing: border-box;
+  -webkit-overflow-scrolling: touch;
 }
 
 body {
@@ -1029,7 +1030,6 @@ button.on {
 }
 
 .tourTable {
-  overflow-y: scroll;
   -webkit-overflow-scrolling: touch;
 }
 


### PR DESCRIPTION
-Slowed down animation speed and transition speed to give a smoother, more pleasant feeling.
-Added smooth scrolling to top document body. (Should apply it to the entire document, and fix scrolling issues.)
-Removed extra scrollbar on tour table caused from previous iPad update.

(Just a quick update. If this doesn't fix the smooth scrolling issue, if it's not an immediate priority, I'll play around with it later. Only took me a few minutes, so if it is fixed, no time lost ^^

Also, if the animation timing still is too fast, or I can tweak the numbers a little more. Autoplay is default time now, and the animation speed is slowed down a tiny bit to make it transition smoother.)