### PR TITLE
Splits into responsive 2/1 col layout

### DIFF
--- a/src/containers/BuyMusic/index.tsx
+++ b/src/containers/BuyMusic/index.tsx
@@ -22,25 +22,37 @@ export default class BuyMusic extends Component {
         >
           Buy Music
         </h3>
-        <Jsb />
-        <p style={{ fontSize: '8pt' }}>{' '}</p>
-        <Jss />
+        <div className="row">
+          <div className="col">
+            <Jsb />
+          </div>
+          <p style={{ fontSize: '8pt' }}>{' '}</p>
+          <div className="col">
+            <Jss />
+          </div>
+        </div>
         <p style={{ fontSize: '24pt' }}>{' '}</p>
         <div style={{ margin: 'auto', textAlign: 'center' }}>
           <h5>Also On Spotify</h5>
-          <iframe
-            src="https://open.spotify.com/embed/artist/4XGcA7sSHYypVflLH48KCx"
-            width="320"
-            height="500"
-            title="soloAcoustic"
-          />
-          <p style={{ fontSize: '1pt' }}>{' '}</p>
-          <iframe
-            src="https://open.spotify.com/embed/artist/5IvBs06z4RksIE1WvqLULs"
-            width="320"
-            height="500"
-            title="soloAcoustic"
-          />
+          <div className="row">
+            <div className="col">
+              <iframe
+                src="https://open.spotify.com/embed/artist/4XGcA7sSHYypVflLH48KCx"
+                width="320"
+                height="500"
+                title="soloAcoustic"
+              />
+            </div>
+            <p style={{ fontSize: '1pt' }}>{' '}</p>
+            <div className="col">
+              <iframe
+                src="https://open.spotify.com/embed/artist/5IvBs06z4RksIE1WvqLULs"
+                width="320"
+                height="500"
+                title="soloAcoustic"
+              />
+            </div>
+          </div>
         </div>
       </div>
     );


### PR DESCRIPTION
Changes to more of a layout like we have for current projects, splitting between Buy Music/Also on Spotify.

On mobile, it splits back to singular rows like it was before.