### PR TITLE
Fixes onChange breaking when called

### DIFF
--- a/src/containers/MusicDashboard/index.tsx
+++ b/src/containers/MusicDashboard/index.tsx
@@ -53,6 +53,7 @@ export class MusicDashboard extends Component<MusicDashboardProps, MusicDashboar
   componentDidMount(): void { this.commonUtils.setTitleAndScroll('Music Dashboard', window.screen.width); }
 
   onChange(evt: React.ChangeEvent<HTMLInputElement>): void {
+    evt.persist();
     const { editTour } = this.props;
     if (editTour.venue !== undefined) this.checkEdit();
     this.setState((prevState) => ({ ...prevState, [evt.target.id]: evt.target.value }));

--- a/test/containers/MusicDashboard/index.spec.tsx
+++ b/test/containers/MusicDashboard/index.spec.tsx
@@ -32,7 +32,7 @@ describe('Dashboard Container', () => {
     wrapper.instance().checkEdit = jest.fn();
     wrapper.instance().setState = jest.fn();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const evt:any = { preventDefault: () => { }, target: { id: 'hi', value: 11 } };
+    const evt:any = { preventDefault: () => { }, persist: jest.fn(), target: { id: 'hi', value: 11 } };
     wrapper.instance().onChange(evt);
     expect(wrapper.instance().setState).toHaveBeenCalled();
   });
@@ -50,7 +50,7 @@ describe('Dashboard Container', () => {
     );
     wrapper2.instance().checkEdit = jest.fn();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const evt:any = { preventDefault: () => { }, target: { id: 'hi', value: '11' } };
+    const evt:any = { preventDefault: () => { }, persist: jest.fn(), target: { id: 'hi', value: '11' } };
     wrapper2.instance().onChange(evt);
     expect(wrapper2.instance().checkEdit).toHaveBeenCalled();
   });


### PR DESCRIPTION
onChange was causing AdminDashboard to break when inputs were being called, because events weren't being allowed to persist through changes.