### PR TITLE
Adds max height stipulation for production

### DIFF
--- a/static/_MuiTheme.scss
+++ b/static/_MuiTheme.scss
@@ -1,5 +1,5 @@
-.MUIDataTable-responsiveBase-5 {
-  max-height: 4.3in;
+.jss5, .MUIDataTable-responsiveBase-5 {
+  max-height: 413px;
 }
 
 th.MuiTableCell-root.MuiTableCell-head.MUIDataTableHeadCell-root-64 {


### PR DESCRIPTION
I'm still not sure what MaterialUI/MUIDataTables uses to calculate the class names for tables and their components, but they're consistent enough to target the same way on Production as they are on development.

Long term solution would be figuring out how to target them specifically, to make sure they're the same on both, but this is a quick fix for the time being.