### PR TITLE
fix: disable pointer events on player iframe (#1029)

### DIFF
--- a/src/containers/Songs/MusicPlayer/musicPlayer.scss
+++ b/src/containers/Songs/MusicPlayer/musicPlayer.scss
@@ -8,6 +8,8 @@
 }
 
 
+#mainPlayer iframe { pointer-events: none; }
+
 #play-pause.on { background-color: red; color: black; }
 
 #play-buttons { margin-bottom:10px;}


### PR DESCRIPTION
## Summary
- Closes #1029. YouTube's center play-button overlay was clickable and started playback inside the iframe, leaving the React `playing` state out of sync with the player.
- Adds one SCSS rule (`#mainPlayer iframe { pointer-events: none; }`) so iframe-based embeds (YouTube, Vimeo, etc.) ignore direct clicks. The page's Play/Pause, Next, and Prev buttons continue to work because they manipulate React state, not the iframe.
- Audio files render an `<audio>` element (no iframe) and are unaffected.

## Test plan
- [x] `npm run test:stylelint` passes
- [x] `npm run test` — 193/193 passing (incl. 15 MusicPlayer tests)
- [ ] Manual: open a YouTube song in the player; confirm clicking the embed does nothing and the page's Play/Pause button toggles playback correctly
- [ ] Manual: open a non-YouTube audio song; confirm Play/Pause/Next/Prev still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)