### PR TITLE
feat: refresh home copy per issue #1038

### DIFF
--- a/src/containers/Music/intro.tsx
+++ b/src/containers/Music/intro.tsx
@@ -65,8 +65,9 @@ export function Intro(props:IintroProps): JSX.Element {
       <h5 style={{ marginTop: '10px', marginBottom: '6px', fontWeight: 'normal' }}>
         <strong>Josh and Maria</strong>
         {' '}
-        have been performing their music together for over 11 years now!
-        Whether it is at church, charity events, public venues, or outdoor festivals, this couple will blow your socks off.
+        &mdash; acoustic husband-and-wife duo from Salem, Virginia. Originals plus a wide-ranging cover set across folk,
+        rock, country, Christian, and Americana. We play churches, taprooms, festivals, weddings, and private events across
+        the East Coast &mdash; Virginia, North Carolina, and South Carolina.
       </h5>
     </div>
   );

--- a/src/containers/Music/intro.tsx
+++ b/src/containers/Music/intro.tsx
@@ -63,12 +63,19 @@ export function Intro(props:IintroProps): JSX.Element {
         setShowEditPic={setShowEditPic}
       />
       <h5 style={{ marginTop: '10px', marginBottom: '6px', fontWeight: 'normal' }}>
-        <strong>Josh and Maria</strong>
+        We&rsquo;re
         {' '}
-        &mdash; acoustic husband-and-wife duo from Salem, Virginia. Originals plus a wide-ranging cover set across folk,
-        rock, country, Christian, and Americana. We play churches, taprooms, festivals, weddings, and private events across
-        the East Coast &mdash; Virginia, North Carolina, and South Carolina.
+        <strong>Josh and Maria Sherman</strong>
+        {' '}
+        &mdash; an acoustic husband-and-wife duo based in Salem, Virginia. Our music blends original songs with an
+        eclectic mix of folk, rock, country, Christian, and Americana favorites. Whether we&rsquo;re playing a church
+        service, taproom, festival, farmer&rsquo;s market, or private event, our goal is simple: to create a warm,
+        memorable experience that feels personal and genuine.
       </h5>
+      <p style={{ marginTop: 0, marginBottom: '6px', textAlign: 'center' }}>
+        We perform throughout Virginia, North Carolina, and South Carolina, bringing a mix of strong harmonies,
+        acoustic energy, and songs people love to sing along with.
+      </p>
     </div>
   );
 }

--- a/src/containers/Music/joshBio.tsx
+++ b/src/containers/Music/joshBio.tsx
@@ -3,18 +3,11 @@ import Instruments from './instruments';
 
 const BioText = () => (
   <p className="bioText" style={{ paddingLeft: 10, paddingRight: 5 }}>
-    Josh began playing the trumpet when he was in third grade. He became skilled with the trumpet,
-    continuing with his musical stylings through high school where he was first chair and regular
-    soloist on the marching field. In college Josh studied music and picked up the guitar. He was
-    primarily self-taught on the guitar, although he received help from his many musical relatives,
-    especially his Uncle Mike. Josh went on to found several bands while living in central Florida.
-    He recorded two cds and was played on the local radio stations. Josh also played in many
-    venues including the Sun Cruise casino ship and the Battle of the Bands. His career took a
-    different turn when he moved to Virginia. Leaving his band behind, Josh performed at the annual Bent Mountain pig
-    roast every year since. He joined the College Lutheran Church choir and was a member of the Salem Choral Society.
-    He also performed solo acoustic at local coffee shops.
-    Josh started singing with Maria in the fall of 2011. They fell in love and were married
-    in July of 2012. Vive l’amore!
+    Josh plays guitar and trumpet, writes most of the originals, and runs the duo&rsquo;s tech side. He started on
+    trumpet in third grade, picked up guitar in college, and led several bands in central Florida &mdash; recording two
+    CDs and playing venues from local coffee shops to the Sun Cruise casino ship &mdash; before moving to Virginia.
+    Since the move he&rsquo;s been a fixture at the Bent Mountain Pig Roast and a member of the College Lutheran choir
+    and Salem Choral Society.
   </p>
 );
 

--- a/src/containers/Music/joshBio.tsx
+++ b/src/containers/Music/joshBio.tsx
@@ -2,20 +2,25 @@
 import Instruments from './instruments';
 
 const BioText = () => (
-  <p className="bioText" style={{ paddingLeft: 10, paddingRight: 5 }}>
-    Josh plays guitar and trumpet, writes most of the originals, and runs the duo&rsquo;s tech side. He started on
-    trumpet in third grade, picked up guitar in college, and led several bands in central Florida &mdash; recording two
-    CDs and playing venues from local coffee shops to the Sun Cruise casino ship &mdash; before moving to Virginia.
-    Since the move he&rsquo;s been a fixture at the Bent Mountain Pig Roast and a member of the College Lutheran choir
-    and Salem Choral Society.
-  </p>
+  <div className="bioText" style={{ paddingLeft: 10, paddingRight: 5 }}>
+    <p>
+      On stage, Josh plays guitar and harmonica, and sings vocals. Off stage, he writes most of our original music and
+      handles the behind-the-scenes tech side of the duo. His musical journey started with trumpet in third grade, but
+      when he picked up guitar in college, he never looked back.
+    </p>
+    <p>
+      Before moving to Virginia, Josh led several bands in central Florida, recording two CDs and performing everywhere
+      from cozy coffee shops to the SunCruz casino ship. Since settling in Virginia, he&rsquo;s become a familiar face
+      around Salem and continues to share his love of music throughout the area.
+    </p>
+  </div>
 );
 
 function JoshBio(): JSX.Element {
   return (
     <div className="joshBio">
       <div style={{ height: '10px' }}><p>{' '}</p></div>
-      <h4 id="joshbio" style={{ marginBottom: '4px', marginTop: '8px', textAlign: 'center' }}>Josh Sherman</h4>
+      <h4 id="joshbio" style={{ marginBottom: '4px', marginTop: '8px', textAlign: 'center' }}>Meet Josh</h4>
       <div>
         <img
           style={{ paddingLeft: 10, paddingRight: 10, float: 'left' }}

--- a/src/containers/Music/mariaBio.tsx
+++ b/src/containers/Music/mariaBio.tsx
@@ -3,14 +3,10 @@ import Instruments from './instruments';
 
 const BioText = () => (
   <p className="bioText" style={{ paddingLeft: 10, paddingRight: 10 }}>
-    Maria started her singing career at the age of 4 when she performed at the JaMar Rec
-    Center in St. Petersburg, Florida. Maria continued adding to her musical repertoire
-    by learning piano, alto saxophone, tenor saxophone, bassoon, and marching tenors.
-    She earned a minor in voice at Roanoke College and did a variety of chorus, musical theatre,
-    and solo performances while teaching in the Roanoke County Schools. Although classically
-    trained, Maria loves singing rock and Christian music with Josh. She is currently playing bass
-    guitar and plays accordian. Josh is the most wonderful husband and is the driving
-    force for the couple; Maria is a fabulous wife and is the organization behind the duo.
+    Maria sings lead, plays bass and accordion, and is the duo&rsquo;s organizer-in-chief. Classically trained &mdash;
+    voice minor at Roanoke College, with piano, alto and tenor sax, and bassoon from her school years. She taught in
+    Roanoke County Schools and now works remotely. Although her training is classical, her favorite stage is next to
+    Josh playing rock, Americana, and Christian music.
   </p>
 );
 

--- a/src/containers/Music/mariaBio.tsx
+++ b/src/containers/Music/mariaBio.tsx
@@ -2,18 +2,28 @@
 import Instruments from './instruments';
 
 const BioText = () => (
-  <p className="bioText" style={{ paddingLeft: 10, paddingRight: 10 }}>
-    Maria sings lead, plays bass and accordion, and is the duo&rsquo;s organizer-in-chief. Classically trained &mdash;
-    voice minor at Roanoke College, with piano, alto and tenor sax, and bassoon from her school years. She taught in
-    Roanoke County Schools and now works remotely. Although her training is classical, her favorite stage is next to
-    Josh playing rock, Americana, and Christian music.
-  </p>
+  <div className="bioText" style={{ paddingLeft: 10, paddingRight: 10 }}>
+    <p>
+      Maria sings and plays bass and also contributes to the songwriting process. She studied voice at Roanoke College
+      and spent years playing piano, alto and tenor saxophone, drums, and bassoon, developing a diverse musical
+      background that still influences her music today.
+    </p>
+    <p>
+      After teaching math and science in Roanoke County Schools, she transitioned to remote work, but music has always
+      remained close to her heart. Maria&rsquo;s favorite place to perform is onstage with Josh, singing and playing
+      rock, Americana, and Christian music for live audiences.
+    </p>
+    <p>
+      Known for her warm stage presence and strong vocals, Maria loves connecting with audiences and helping create
+      performances that feel relaxed, personal, and fun.
+    </p>
+  </div>
 );
 
 function MariaBio(): JSX.Element {
   return (
     <div className="mariaBio">
-      <h4 id="mariabio" style={{ marginBottom: '4px', marginTop: '8px', textAlign: 'center' }}>Maria Sherman</h4>
+      <h4 id="mariabio" style={{ marginBottom: '4px', marginTop: '8px', textAlign: 'center' }}>Meet Maria</h4>
       <div>
         <img
           style={{ paddingLeft: 10, paddingRight: 10, float: 'left' }}

--- a/test/containers/Music/__snapshots__/index.spec.tsx.snap
+++ b/test/containers/Music/__snapshots__/index.spec.tsx.snap
@@ -56,7 +56,7 @@ exports[`/music > renders the component 1`] = `
           Josh and Maria
         </strong>
          
-        have been performing their music together for over 11 years now! Whether it is at church, charity events, public venues, or outdoor festivals, this couple will blow your socks off.
+        — acoustic husband-and-wife duo from Salem, Virginia. Originals plus a wide-ranging cover set across folk, rock, country, Christian, and Americana. We play churches, taprooms, festivals, weddings, and private events across the East Coast — Virginia, North Carolina, and South Carolina.
       </h5>
     </div>
     <div
@@ -1087,7 +1087,7 @@ exports[`/music > renders the component 1`] = `
             }
           }
         >
-          Josh began playing the trumpet when he was in third grade. He became skilled with the trumpet, continuing with his musical stylings through high school where he was first chair and regular soloist on the marching field. In college Josh studied music and picked up the guitar. He was primarily self-taught on the guitar, although he received help from his many musical relatives, especially his Uncle Mike. Josh went on to found several bands while living in central Florida. He recorded two cds and was played on the local radio stations. Josh also played in many venues including the Sun Cruise casino ship and the Battle of the Bands. His career took a different turn when he moved to Virginia. Leaving his band behind, Josh performed at the annual Bent Mountain pig roast every year since. He joined the College Lutheran Church choir and was a member of the Salem Choral Society. He also performed solo acoustic at local coffee shops. Josh started singing with Maria in the fall of 2011. They fell in love and were married in July of 2012. Vive l’amore!
+          Josh plays guitar and trumpet, writes most of the originals, and runs the duo’s tech side. He started on trumpet in third grade, picked up guitar in college, and led several bands in central Florida — recording two CDs and playing venues from local coffee shops to the Sun Cruise casino ship — before moving to Virginia. Since the move he’s been a fixture at the Bent Mountain Pig Roast and a member of the College Lutheran choir and Salem Choral Society.
         </p>
         <blockquote
           style={
@@ -1182,7 +1182,7 @@ exports[`/music > renders the component 1`] = `
             }
           }
         >
-          Maria started her singing career at the age of 4 when she performed at the JaMar Rec Center in St. Petersburg, Florida. Maria continued adding to her musical repertoire by learning piano, alto saxophone, tenor saxophone, bassoon, and marching tenors. She earned a minor in voice at Roanoke College and did a variety of chorus, musical theatre, and solo performances while teaching in the Roanoke County Schools. Although classically trained, Maria loves singing rock and Christian music with Josh. She is currently playing bass guitar and plays accordian. Josh is the most wonderful husband and is the driving force for the couple; Maria is a fabulous wife and is the organization behind the duo.
+          Maria sings lead, plays bass and accordion, and is the duo’s organizer-in-chief. Classically trained — voice minor at Roanoke College, with piano, alto and tenor sax, and bassoon from her school years. She taught in Roanoke County Schools and now works remotely. Although her training is classical, her favorite stage is next to Josh playing rock, Americana, and Christian music.
         </p>
         <blockquote
           style={

--- a/test/containers/Music/__snapshots__/index.spec.tsx.snap
+++ b/test/containers/Music/__snapshots__/index.spec.tsx.snap
@@ -52,12 +52,25 @@ exports[`/music > renders the component 1`] = `
           }
         }
       >
+        We’re
+         
         <strong>
-          Josh and Maria
+          Josh and Maria Sherman
         </strong>
          
-        — acoustic husband-and-wife duo from Salem, Virginia. Originals plus a wide-ranging cover set across folk, rock, country, Christian, and Americana. We play churches, taprooms, festivals, weddings, and private events across the East Coast — Virginia, North Carolina, and South Carolina.
+        — an acoustic husband-and-wife duo based in Salem, Virginia. Our music blends original songs with an eclectic mix of folk, rock, country, Christian, and Americana favorites. Whether we’re playing a church service, taproom, festival, farmer’s market, or private event, our goal is simple: to create a warm, memorable experience that feels personal and genuine.
       </h5>
+      <p
+        style={
+          {
+            "marginBottom": "6px",
+            "marginTop": 0,
+            "textAlign": "center",
+          }
+        }
+      >
+        We perform throughout Virginia, North Carolina, and South Carolina, bringing a mix of strong harmonies, acoustic energy, and songs people love to sing along with.
+      </p>
     </div>
     <div
       className="createNewPicDialog"
@@ -1061,7 +1074,7 @@ exports[`/music > renders the component 1`] = `
             }
           }
         >
-          Josh Sherman
+          Meet Josh
         </h4>
         <div>
           <img
@@ -1078,7 +1091,7 @@ exports[`/music > renders the component 1`] = `
             width="288px"
           />
         </div>
-        <p
+        <div
           className="bioText"
           style={
             {
@@ -1087,8 +1100,13 @@ exports[`/music > renders the component 1`] = `
             }
           }
         >
-          Josh plays guitar and trumpet, writes most of the originals, and runs the duo’s tech side. He started on trumpet in third grade, picked up guitar in college, and led several bands in central Florida — recording two CDs and playing venues from local coffee shops to the Sun Cruise casino ship — before moving to Virginia. Since the move he’s been a fixture at the Bent Mountain Pig Roast and a member of the College Lutheran choir and Salem Choral Society.
-        </p>
+          <p>
+            On stage, Josh plays guitar and harmonica, and sings vocals. Off stage, he writes most of our original music and handles the behind-the-scenes tech side of the duo. His musical journey started with trumpet in third grade, but when he picked up guitar in college, he never looked back.
+          </p>
+          <p>
+            Before moving to Virginia, Josh led several bands in central Florida, recording two CDs and performing everywhere from cozy coffee shops to the SunCruz casino ship. Since settling in Virginia, he’s become a familiar face around Salem and continues to share his love of music throughout the area.
+          </p>
+        </div>
         <blockquote
           style={
             {
@@ -1156,7 +1174,7 @@ exports[`/music > renders the component 1`] = `
             }
           }
         >
-          Maria Sherman
+          Meet Maria
         </h4>
         <div>
           <img
@@ -1173,7 +1191,7 @@ exports[`/music > renders the component 1`] = `
             width="288px"
           />
         </div>
-        <p
+        <div
           className="bioText"
           style={
             {
@@ -1182,8 +1200,16 @@ exports[`/music > renders the component 1`] = `
             }
           }
         >
-          Maria sings lead, plays bass and accordion, and is the duo’s organizer-in-chief. Classically trained — voice minor at Roanoke College, with piano, alto and tenor sax, and bassoon from her school years. She taught in Roanoke County Schools and now works remotely. Although her training is classical, her favorite stage is next to Josh playing rock, Americana, and Christian music.
-        </p>
+          <p>
+            Maria sings and plays bass and also contributes to the songwriting process. She studied voice at Roanoke College and spent years playing piano, alto and tenor saxophone, drums, and bassoon, developing a diverse musical background that still influences her music today.
+          </p>
+          <p>
+            After teaching math and science in Roanoke County Schools, she transitioned to remote work, but music has always remained close to her heart. Maria’s favorite place to perform is onstage with Josh, singing and playing rock, Americana, and Christian music for live audiences.
+          </p>
+          <p>
+            Known for her warm stage presence and strong vocals, Maria loves connecting with audiences and helping create performances that feel relaxed, personal, and fun.
+          </p>
+        </div>
         <blockquote
           style={
             {


### PR DESCRIPTION
## Summary
- Replaces the "11 years" intro with the East Coast acoustic-duo blurb from the issue
- Rewrites Josh and Maria bios to lead with present-tense activity
- Drops "fall of 2011 / July 2012 / Vive l'amore" and the "fabulous wife / wonderful husband" framing per the issue's acceptance criteria

Closes #1038

## Test plan
- [x] `npm test` — all 47 files / 216 tests pass; Music snapshot updated
- [ ] Visual smoke on joshandmariamusic.com (Music container)
- [ ] Visual smoke on web-jam.com (same Music container)

🤖 Generated with [Claude Code](https://claude.com/claude-code)