### PR TITLE
fix(inquiry): show visible error when inquiry POST fails (closes #1040)

### DIFF
--- a/src/containers/Homepage/Inquiry/index.tsx
+++ b/src/containers/Homepage/Inquiry/index.tsx
@@ -39,10 +39,11 @@ export function CommentsSection(props: IcommentsSectionProps) {
 
 interface IformActionsProps {
   setHasSubmitted: (arg0: boolean) => void,
+  setSubmitError: (arg0: boolean) => void,
   formData: IinquiryFormData,
 }
 export function FormActions(props: IformActionsProps) {
-  const { setHasSubmitted, formData } = props;
+  const { setHasSubmitted, setSubmitError, formData } = props;
   return (
     <div className="inquiryValidation input-field col" style={{ marginBottom: '12px' }}>
       <span className="inquiryValidation">* Required</span>
@@ -52,7 +53,7 @@ export function FormActions(props: IformActionsProps) {
         id="sendEmailButton"
         disabled={utils.validateForm(formData)}
         onClick={(evt) => {
-          utils.handleSubmit(evt, formData, setHasSubmitted);
+          utils.handleSubmit(evt, formData, setHasSubmitted, setSubmitError);
         }}
       >
         Submit
@@ -137,13 +138,14 @@ export function TableSection(props: ItableSectionProps): JSX.Element {
 
 interface IinquiryFormProps {
   setHasSubmitted: (arg0: boolean) => void,
+  setSubmitError: (arg0: boolean) => void,
   setFormData: (arg0: IinquiryFormData) => void,
   formData: IinquiryFormData,
   staticCountry?:string
 }
 export function InquiryForm(props: IinquiryFormProps): JSX.Element {
   // eslint-disable-next-line object-curly-newline
-  const { formData, setFormData, setHasSubmitted, staticCountry } = props;
+  const { formData, setFormData, setHasSubmitted, setSubmitError, staticCountry } = props;
   const { country, uSAstate, zipcode } = formData;
   return (
     <form id="new-contact" className="col">
@@ -189,10 +191,26 @@ export function InquiryForm(props: IinquiryFormProps): JSX.Element {
       />
       <p style={{ margin: 0 }}>&nbsp;</p>
       <CommentsSection formData={formData} setFormData={setFormData} />
-      <FormActions setHasSubmitted={setHasSubmitted} formData={formData} />
+      <FormActions setHasSubmitted={setHasSubmitted} setSubmitError={setSubmitError} formData={formData} />
     </form>
   );
 }
+
+export const InquiryError = () => (
+  <p
+    className="inquiryError"
+    role="alert"
+    style={{
+      color: '#b00020', textAlign: 'center', margin: '14px', paddingBottom: '4px', fontWeight: 'bold',
+    }}
+  >
+    Sorry &mdash; we couldn&rsquo;t deliver your inquiry. Please try again, or email
+    {' '}
+    <a href="mailto:joshua.v.sherman@gmail.com">joshua.v.sherman@gmail.com</a>
+    {' '}
+    directly.
+  </p>
+);
 
 export const ContactRequest = () => (
   <div className="page-content contacted">
@@ -205,16 +223,18 @@ export const ContactRequest = () => (
 );
 interface IcontactFormProps {
   hasSubmitted: boolean,
+  submitError: boolean,
   hideTitle?: boolean,
   country?: string,
   setHasSubmitted: (arg0: boolean) => void
+  setSubmitError: (arg0: boolean) => void
   formData: IinquiryFormData,
   setFormData: (arg0: IinquiryFormData) => void
 }
 
 export function ContactForm(props: IcontactFormProps) {
   const {
-    hasSubmitted, hideTitle, country, setHasSubmitted, formData, setFormData,
+    hasSubmitted, submitError, hideTitle, country, setHasSubmitted, setSubmitError, formData, setFormData,
   } = props;
   return (
     <div
@@ -231,7 +251,14 @@ export function ContactForm(props: IcontactFormProps) {
           >
             {hideTitle ? '' : 'Contact Us'}
           </h4>
-          <InquiryForm staticCountry={country} setHasSubmitted={setHasSubmitted} formData={formData} setFormData={setFormData} />
+          {submitError ? <InquiryError /> : null}
+          <InquiryForm
+            staticCountry={country}
+            setHasSubmitted={setHasSubmitted}
+            setSubmitError={setSubmitError}
+            formData={formData}
+            setFormData={setFormData}
+          />
         </div>
       ) : (
         <ContactRequest />
@@ -241,9 +268,10 @@ export function ContactForm(props: IcontactFormProps) {
 }
 export function Inquiry({ country, hideTitle }:{ country?:string, hideTitle?:boolean }): JSX.Element {
   const [hasSubmitted, setHasSubmitted] = useState(false);
+  const [submitError, setSubmitError] = useState(false);
   const [formData, setFormData] = useState({} as IinquiryFormData);
   const props = {
-    hasSubmitted, hideTitle, country, setHasSubmitted, formData, setFormData,
+    hasSubmitted, submitError, hideTitle, country, setHasSubmitted, setSubmitError, formData, setFormData,
   };
   return (
     <ContactForm {...props} />

--- a/src/containers/Homepage/Inquiry/utils.tsx
+++ b/src/containers/Homepage/Inquiry/utils.tsx
@@ -12,19 +12,24 @@ function handleCountryChange(
 async function createEmailApi(
   emailForm: IinquiryFormData,
   setHasSubmitted:(arg0:boolean)=>void,
+  setSubmitError:(arg0:boolean)=>void,
 ): Promise<void> {
   try {
     await superagent.post(`${process.env.BackendUrl}/inquiry`)
       .set('Content-Type', 'application/json')
       .send(emailForm);
     setHasSubmitted(true);
-  } catch (e) { console.log((e as Error).message); }
+  } catch (e) {
+    console.log((e as Error).message);
+    setSubmitError(true);
+  }
 }
 
 async function handleSubmit(
   evt: React.MouseEvent<HTMLButtonElement, MouseEvent>,
   formData:IinquiryFormData,
   setHasSubmitted:(arg0:boolean)=>void,
+  setSubmitError:(arg0:boolean)=>void,
 ): Promise<void> {
   const {
     firstname, lastname, emailaddress, uSAstate, country, phonenumber, zipcode, comments,
@@ -39,7 +44,7 @@ async function handleSubmit(
     zipcode,
     comments: (comments).trim(),
   };
-  await createEmailApi(emailForm, setHasSubmitted);
+  await createEmailApi(emailForm, setHasSubmitted, setSubmitError);
 }
 
 function handleInputChange(

--- a/test/containers/Homepage/Inquiry/index.spec.tsx
+++ b/test/containers/Homepage/Inquiry/index.spec.tsx
@@ -1,6 +1,6 @@
 import renderer from 'react-test-renderer';
 import {
-  CommentsSection, ContactForm, ContactRequest, EmailPhoneRow, FormActions, Inquiry, InquiryForm, TableSection,
+  CommentsSection, ContactForm, ContactRequest, EmailPhoneRow, FormActions, Inquiry, InquiryError, InquiryForm, TableSection,
 } from 'src/containers/Homepage/Inquiry';
 
 describe('Inquiry', () => {
@@ -33,7 +33,10 @@ describe('Inquiry', () => {
       comments: '',
     };
     const setHasSubmitted = jest.fn();
-    const result = renderer.create(<FormActions formData={formData} setHasSubmitted={setHasSubmitted} />).root;
+    const setSubmitError = jest.fn();
+    const result = renderer.create(
+      <FormActions formData={formData} setHasSubmitted={setHasSubmitted} setSubmitError={setSubmitError} />,
+    ).root;
     const tree = result.findByProps({ id: 'sendEmailButton' }).props.onClick();
     console.log(tree);
     expect(true).toBe(true);
@@ -120,6 +123,7 @@ describe('Inquiry', () => {
       },
       setFormData: jest.fn(),
       setHasSubmitted: jest.fn(),
+      setSubmitError: jest.fn(),
     };
     const evt = { target: { value: 'country' } };
     const result = renderer.create(<InquiryForm {...props} />).root;
@@ -140,6 +144,7 @@ describe('Inquiry', () => {
       },
       setFormData: jest.fn(),
       setHasSubmitted: jest.fn(),
+      setSubmitError: jest.fn(),
     };
     const evt = { target: { value: 'state' } };
     const result = renderer.create(<InquiryForm {...props} />).root;
@@ -160,6 +165,7 @@ describe('Inquiry', () => {
       },
       setFormData: jest.fn(),
       setHasSubmitted: jest.fn(),
+      setSubmitError: jest.fn(),
     };
     const evt = { target: { value: 'zip' } };
     const result = renderer.create(<InquiryForm {...props} />).root;
@@ -182,7 +188,14 @@ describe('Inquiry', () => {
       comments: '',
     };
     const props = {
-      hasSubmitted: false, hideTitle: true, country: '', setHasSubmitted: jest.fn(), formData, setFormData: jest.fn(),
+      hasSubmitted: false,
+      submitError: false,
+      hideTitle: true,
+      country: '',
+      setHasSubmitted: jest.fn(),
+      setSubmitError: jest.fn(),
+      formData,
+      setFormData: jest.fn(),
     };
     const result: any = renderer.create(<ContactForm {...props} />).toJSON();
     expect(result.type).toBe('div');
@@ -199,7 +212,14 @@ describe('Inquiry', () => {
       comments: '',
     };
     const props = {
-      hasSubmitted: true, hideTitle: false, country: '', setHasSubmitted: jest.fn(), formData, setFormData: jest.fn(),
+      hasSubmitted: true,
+      submitError: false,
+      hideTitle: false,
+      country: '',
+      setHasSubmitted: jest.fn(),
+      setSubmitError: jest.fn(),
+      formData,
+      setFormData: jest.fn(),
     };
     const result: any = renderer.create(<ContactForm {...props} />).toJSON();
     expect(result.children[0].props.className).toBe('page-content contacted');
@@ -221,10 +241,72 @@ describe('Inquiry', () => {
       comments: '',
     };
     const props = {
-      hasSubmitted: false, hideTitle: false, country: '', setHasSubmitted: jest.fn(), formData, setFormData: jest.fn(),
+      hasSubmitted: false,
+      submitError: false,
+      hideTitle: false,
+      country: '',
+      setHasSubmitted: jest.fn(),
+      setSubmitError: jest.fn(),
+      formData,
+      setFormData: jest.fn(),
     };
     const result: any = renderer.create(<ContactForm {...props} />).toJSON();
     expect(result.children[0].children[0].children[0]).toBe('Contact Us');
+  });
+  it('renders InquiryError standalone', () => {
+    const result: any = renderer.create(<InquiryError />).toJSON();
+    expect(result.type).toBe('p');
+    expect(result.props.className).toBe('inquiryError');
+    expect(result.props.role).toBe('alert');
+  });
+  it('ContactForm renders InquiryError when submitError is true', () => {
+    const formData = {
+      firstname: '',
+      lastname: '',
+      emailaddress: '',
+      uSAstate: '',
+      country: '',
+      phonenumber: '',
+      zipcode: '',
+      comments: '',
+    };
+    const props = {
+      hasSubmitted: false,
+      submitError: true,
+      hideTitle: true,
+      country: '',
+      setHasSubmitted: jest.fn(),
+      setSubmitError: jest.fn(),
+      formData,
+      setFormData: jest.fn(),
+    };
+    const root = renderer.create(<ContactForm {...props} />).root;
+    const error = root.findByProps({ className: 'inquiryError' });
+    expect(error).toBeTruthy();
+  });
+  it('ContactForm does NOT render InquiryError when submitError is false', () => {
+    const formData = {
+      firstname: '',
+      lastname: '',
+      emailaddress: '',
+      uSAstate: '',
+      country: '',
+      phonenumber: '',
+      zipcode: '',
+      comments: '',
+    };
+    const props = {
+      hasSubmitted: false,
+      submitError: false,
+      hideTitle: true,
+      country: '',
+      setHasSubmitted: jest.fn(),
+      setSubmitError: jest.fn(),
+      formData,
+      setFormData: jest.fn(),
+    };
+    const root = renderer.create(<ContactForm {...props} />).root;
+    expect(root.findAllByProps({ className: 'inquiryError' })).toHaveLength(0);
   });
 });
 

--- a/test/containers/Homepage/Inquiry/utils.spec.tsx
+++ b/test/containers/Homepage/Inquiry/utils.spec.tsx
@@ -34,10 +34,12 @@ describe('Inquiry utils', () => {
       comments: 'none',
     };
     const setHasSubmitted = jest.fn();
+    const setSubmitError = jest.fn();
     const mockPost = jest.fn().mockResolvedValueOnce({});
     (superagent.post as jest.Mock).mockReturnValueOnce({ set: jest.fn().mockReturnValueOnce({ send: mockPost }) });
-    await utils.createEmailApi(emailForm, setHasSubmitted);
+    await utils.createEmailApi(emailForm, setHasSubmitted, setSubmitError);
     expect(setHasSubmitted).toHaveBeenCalledWith(true);
+    expect(setSubmitError).toHaveBeenCalledTimes(0);
   });
   it('catches error for createEmailApi', async () => {
     const emailForm = {
@@ -51,11 +53,13 @@ describe('Inquiry utils', () => {
       comments: 'none',
     };
     const setHasSubmitted = jest.fn();
+    const setSubmitError = jest.fn();
     const err = 'error';
     const mockPost = jest.fn().mockRejectedValueOnce(new Error(err));
     (superagent.post as jest.Mock).mockReturnValueOnce({ set: jest.fn().mockReturnValueOnce({ send: mockPost }) });
-    await utils.createEmailApi(emailForm, setHasSubmitted);
+    await utils.createEmailApi(emailForm, setHasSubmitted, setSubmitError);
     expect(setHasSubmitted).toHaveBeenCalledTimes(0);
+    expect(setSubmitError).toHaveBeenCalledWith(true);
   });
   it('handleSubmit', async () => {
     const evt: any = { target: { value: 'mouse' } };
@@ -70,9 +74,10 @@ describe('Inquiry utils', () => {
       comments: 'none',
     };
     const setHasSubmitted = jest.fn();
+    const setSubmitError = jest.fn();
     const mockPost = jest.fn().mockResolvedValueOnce({});
     const createEmailApi = (superagent.post as jest.Mock).mockReturnValueOnce({ set: jest.fn().mockReturnValueOnce({ send: mockPost }) });
-    await utils.handleSubmit(evt, emailForm, setHasSubmitted);
+    await utils.handleSubmit(evt, emailForm, setHasSubmitted, setSubmitError);
     expect(createEmailApi).toHaveBeenCalled();
   });
   it('handleInputChange', () => {


### PR DESCRIPTION
## Summary

- Surface inquiry POST failures to the user instead of silently swallowing them in `console.log`.
- New `InquiryError` component rendered above the form when `submitError === true`. Includes a direct `mailto:joshua.v.sherman@gmail.com` fallback so users have an escape hatch even if the backend stays broken.
- Both mount points (homepage Inquiry + Book Us page) get the fix automatically — they share the `Inquiry` component.

## Why now

Companion to the web-jam-back PR #753 (SendGrid → nodemailer + Gmail SMTP) that just merged. The backend fix removes the known failure mode (SendGrid credit exhaustion), but if anything else ever fails on the POST path, users would still see a silent dead form. This PR closes that gap.

## Test plan

- [x] `npm test` — 219/219 pass (216 baseline + 3 new tests)
- [ ] Manual: deploy to staging, point `BackendUrl` at a non-existent endpoint, submit a test inquiry, confirm the red error message + mailto link render above the form and the form remains visible for retry.
- [ ] Manual: same test on the Book Us page.

Closes #1040.

🤖 Generated with [Claude Code](https://claude.com/claude-code)