### PR TITLE
fix(deps): bump brace-expansion to patch moderate DoS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3998,9 +3998,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

Bumps \`brace-expansion\` to the patched version, addressing the moderate-severity DoS advisory [GHSA-jxxr-4gwj-5jf2](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2). Non-breaking — applied via \`npm audit fix\`, only \`package-lock.json\` changed.

After this PR lands, \`npm audit\` reports 4 low-severity vulnerabilities remaining (all in the elliptic / browserify-sign / crypto-browserify / create-ecdh chain). Those are NOT addressed here — \`npm audit fix --force\` was tested and made things worse (downgrading \`crypto-browserify\` introduced 2 critical \`sha.js\` vulns). Follow-up to remove the elliptic chain entirely if \`crypto-browserify\` is unused will be filed as a separate issue.

## Test plan

- [x] \`npx vitest run\` — 219/219 pass
- [x] \`npm run test:lint\` — 0 errors (20 pre-existing warnings, not from this change)
- [x] \`npm run typecheck\` — clean
- [x] \`npm audit\` post-fix — brace-expansion gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)