### PR TITLE
feat(admin): Admin Users management page with per-user privileges

### DIFF
--- a/__mocks__/@mui/material.tsx
+++ b/__mocks__/@mui/material.tsx
@@ -65,8 +65,8 @@ export function FormGroup(props:any) {
 }
 
 export function FormControlLabel(props:any) {
-  const { children } = props;
-  return <div {...props}>{children}</div>;
+  const { children, control } = props;
+  return <div {...props}>{control}{children}</div>;
 }
 
 export function Select(props:any) {
@@ -96,4 +96,38 @@ export function Box(props:any) {
 export function Grid(props:any) {
   const { children } = props;
   return <div {...props}>{children}</div>;
+}
+
+export function Typography(props:any) {
+  const { children } = props;
+  return <div {...props}>{children}</div>;
+}
+
+export function Chip(props:any) {
+  return <span {...props} />;
+}
+
+export function Table(props:any) {
+  const { children } = props;
+  return <table {...props}>{children}</table>;
+}
+
+export function TableHead(props:any) {
+  const { children } = props;
+  return <thead {...props}>{children}</thead>;
+}
+
+export function TableBody(props:any) {
+  const { children } = props;
+  return <tbody {...props}>{children}</tbody>;
+}
+
+export function TableRow(props:any) {
+  const { children } = props;
+  return <tr {...props}>{children}</tr>;
+}
+
+export function TableCell(props:any) {
+  const { children } = props;
+  return <td {...props}>{children}</td>;
 }

--- a/src/App/AppTemplate/menuConfig.ts
+++ b/src/App/AppTemplate/menuConfig.ts
@@ -58,6 +58,9 @@ const wjNav = [
     nav: 'wj', className: '', type: 'link', iconClass: 'fas fa-sort', link: '/sort', name: 'Sort', auth: true,
   },
   {
+    nav: 'wj', className: '', type: 'link', iconClass: 'fas fa-users-cog', link: '/admin/users', name: 'Admin Users', auth: true,
+  },
+  {
     nav: 'wj', className: 'home', type: 'link', iconClass: 'fas fa-home', link: '/', name: 'Web Jam LLC',
   },
   {

--- a/src/App/index.tsx
+++ b/src/App/index.tsx
@@ -3,6 +3,7 @@ import {
   BrowserRouter, Navigate, Route, Routes,
 } from 'react-router-dom';
 import { Homepage } from 'src/containers/Homepage';
+import { AdminUsers } from '../containers/AdminUsers';
 import { SortContainer } from '../containers/SortContainer';
 import BuyMusic from '../containers/BuyMusic';
 import { Music } from '../containers/Music';
@@ -28,6 +29,7 @@ export function App(): JSX.Element {
               element={checkAppName()}
             />
             <Route path="/sort" element={<SortContainer />} />
+            <Route path="/admin/users" element={<AdminUsers />} />
             <Route path="/new-homepage" element={<Homepage />} />
             <Route path="/music" element={<Music />} />
             <Route path="/music/buymusic" element={<BuyMusic />} />

--- a/src/containers/AdminUsers/CreateUserForm.tsx
+++ b/src/containers/AdminUsers/CreateUserForm.tsx
@@ -1,0 +1,124 @@
+import { useState } from 'react';
+import {
+  TextField, Button, FormControl, InputLabel, Select, MenuItem, FormGroup, FormControlLabel, Checkbox, Box, Typography,
+} from '@mui/material';
+import { CAPABILITY_GROUPS, USER_STATUS_OPTIONS, type Capability } from './capabilities';
+import adminUtils from './admin-users.utils';
+
+interface IcreateUserFormProps {
+  token: string;
+  onCreated: () => void;
+}
+
+export function CreateUserForm({ token, onCreated }: IcreateUserFormProps): JSX.Element {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [userStatus, setUserStatus] = useState<string>('human');
+  const [privileges, setPrivileges] = useState<Capability[]>([]);
+  const [notes, setNotes] = useState('');
+  const [error, setError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const toggleCapability = (cap: Capability) => {
+    setPrivileges((prev) => (prev.includes(cap) ? prev.filter((c) => c !== cap) : [...prev, cap]));
+  };
+
+  const handleSubmit = async () => {
+    setError('');
+    if (!name.trim()) { setError('Name is required'); return; }
+    if (!email.trim()) { setError('Email is required'); return; }
+    setSubmitting(true);
+    try {
+      await adminUtils.createUser(token, {
+        name: name.trim(),
+        email: email.trim(),
+        userStatus,
+        privileges,
+        userDetails: notes,
+      });
+      setName(''); setEmail(''); setUserStatus('human'); setPrivileges([]); setNotes('');
+      onCreated();
+    } catch (e) {
+      const err = e as { response?: { body?: { message?: string } }; message?: string };
+      setError(err.response?.body?.message || err.message || 'Create failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Box className="create-user-form" sx={{ padding: 2, border: '1px solid #ddd', borderRadius: 1, marginBottom: 3 }}>
+      <Typography variant="h6" sx={{ marginBottom: 2 }}>Create User</Typography>
+      <TextField
+        label="Name"
+        fullWidth
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        sx={{ marginBottom: 2 }}
+        data-testid="create-user-name"
+      />
+      <TextField
+        label="Email"
+        fullWidth
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        sx={{ marginBottom: 2 }}
+        data-testid="create-user-email"
+      />
+      <FormControl fullWidth sx={{ marginBottom: 2 }}>
+        <InputLabel id="user-status-label">Type</InputLabel>
+        <Select
+          labelId="user-status-label"
+          value={userStatus}
+          label="Type"
+          onChange={(e) => setUserStatus(e.target.value)}
+          data-testid="create-user-status"
+        >
+          {USER_STATUS_OPTIONS.map((s) => <MenuItem key={s} value={s}>{s}</MenuItem>)}
+        </Select>
+      </FormControl>
+      <Box sx={{ marginBottom: 2 }}>
+        <Typography variant="subtitle2" sx={{ marginBottom: 1 }}>Privileges</Typography>
+        {CAPABILITY_GROUPS.map((group) => (
+          <Box key={group.label} sx={{ marginBottom: 1 }}>
+            <Typography variant="body2" sx={{ fontWeight: 'bold' }}>{group.label}</Typography>
+            <FormGroup row>
+              {group.items.map((cap) => (
+                <FormControlLabel
+                  key={cap}
+                  control={(
+                    <Checkbox
+                      checked={privileges.includes(cap)}
+                      onChange={() => toggleCapability(cap)}
+                      aria-label={cap}
+                      data-testid={`cap-${cap}`}
+                    />
+                  )}
+                  label={cap.split(':')[1]}
+                />
+              ))}
+            </FormGroup>
+          </Box>
+        ))}
+      </Box>
+      <TextField
+        label="Notes"
+        fullWidth
+        multiline
+        rows={2}
+        value={notes}
+        onChange={(e) => setNotes(e.target.value)}
+        sx={{ marginBottom: 2 }}
+      />
+      {error && <Typography color="error" sx={{ marginBottom: 2 }}>{error}</Typography>}
+      <Button
+        variant="contained"
+        onClick={handleSubmit}
+        disabled={submitting}
+        data-testid="create-user-submit"
+      >
+        {submitting ? 'Creating...' : 'Create User'}
+      </Button>
+    </Box>
+  );
+}

--- a/src/containers/AdminUsers/EditPrivilegesDialog.tsx
+++ b/src/containers/AdminUsers/EditPrivilegesDialog.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react';
+import {
+  Dialog, DialogTitle, DialogContent, DialogActions, Button, Box, Typography, FormGroup, FormControlLabel, Checkbox,
+} from '@mui/material';
+import { CAPABILITY_GROUPS, type Capability } from './capabilities';
+import adminUtils, { type IadminUser } from './admin-users.utils';
+
+interface IeditPrivilegesDialogProps {
+  open: boolean;
+  user: IadminUser | null;
+  token: string;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+export function EditPrivilegesDialog({
+  open, user, token, onClose, onSaved,
+}: IeditPrivilegesDialogProps): JSX.Element {
+  const [privileges, setPrivileges] = useState<Capability[]>([]);
+  const [error, setError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (user) setPrivileges((user.privileges || []) as Capability[]);
+    setError('');
+  }, [user]);
+
+  const toggleCapability = (cap: Capability) => {
+    setPrivileges((prev) => (prev.includes(cap) ? prev.filter((c) => c !== cap) : [...prev, cap]));
+  };
+
+  const handleSave = async () => {
+    if (!user) return;
+    setSubmitting(true);
+    setError('');
+    try {
+      await adminUtils.updatePrivileges(token, user._id, privileges);
+      onSaved();
+    } catch (e) {
+      const err = e as { response?: { body?: { message?: string } }; message?: string };
+      setError(err.response?.body?.message || err.message || 'Update failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
+      <DialogTitle>Edit Privileges{user ? ` — ${user.name}` : ''}</DialogTitle>
+      <DialogContent>
+        {CAPABILITY_GROUPS.map((group) => (
+          <Box key={group.label} sx={{ marginBottom: 1 }}>
+            <Typography variant="body2" sx={{ fontWeight: 'bold' }}>{group.label}</Typography>
+            <FormGroup row>
+              {group.items.map((cap) => (
+                <FormControlLabel
+                  key={cap}
+                  control={(
+                    <Checkbox
+                      checked={privileges.includes(cap)}
+                      onChange={() => toggleCapability(cap)}
+                      aria-label={cap}
+                      data-testid={`edit-cap-${cap}`}
+                    />
+                  )}
+                  label={cap.split(':')[1]}
+                />
+              ))}
+            </FormGroup>
+          </Box>
+        ))}
+        {error && <Typography color="error" sx={{ marginTop: 1 }}>{error}</Typography>}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} data-testid="edit-priv-cancel">Cancel</Button>
+        <Button onClick={handleSave} variant="contained" disabled={submitting} data-testid="edit-priv-save">
+          {submitting ? 'Saving...' : 'Save'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/containers/AdminUsers/ShowTokenDialog.tsx
+++ b/src/containers/AdminUsers/ShowTokenDialog.tsx
@@ -1,0 +1,40 @@
+import {
+  Dialog, DialogTitle, DialogContent, DialogActions, Button, Box, Typography, TextField,
+} from '@mui/material';
+
+interface IshowTokenDialogProps {
+  open: boolean;
+  token: string;
+  onClose: () => void;
+}
+
+export function ShowTokenDialog({ open, token, onClose }: IshowTokenDialogProps): JSX.Element {
+  const copyToClipboard = async () => {
+    try { await navigator.clipboard.writeText(token); } catch (_e) { /* ignore */ }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
+      <DialogTitle>Service Token</DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" sx={{ marginBottom: 2 }}>
+          Copy this token to your secrets manager (KeePass) now. Anyone with this token can authenticate as this user. The token has no expiration.
+        </Typography>
+        <Box>
+          <TextField
+            value={token}
+            fullWidth
+            multiline
+            rows={4}
+            InputProps={{ readOnly: true }}
+            data-testid="token-value"
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={copyToClipboard} data-testid="copy-token">Copy to clipboard</Button>
+        <Button onClick={onClose} data-testid="close-token">Done</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/containers/AdminUsers/UsersTable.tsx
+++ b/src/containers/AdminUsers/UsersTable.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+import {
+  Table, TableBody, TableCell, TableHead, TableRow, Button, Chip, Box,
+} from '@mui/material';
+import adminUtils, { type IadminUser } from './admin-users.utils';
+
+interface IusersTableProps {
+  users: IadminUser[];
+  token: string;
+  onShowToken: (token: string) => void;
+  onEditPrivileges: (user: IadminUser) => void;
+  onChange: () => void;
+}
+
+export function UsersTable({
+  users, token, onShowToken, onEditPrivileges, onChange,
+}: IusersTableProps): JSX.Element {
+  const [busy, setBusy] = useState<string>('');
+
+  const handleShowToken = async (userId: string) => {
+    setBusy(userId);
+    try {
+      const newToken = await adminUtils.mintToken(token, userId);
+      onShowToken(newToken);
+    } catch (_e) {
+      // surface as alert; keep simple for v1
+      // eslint-disable-next-line no-alert
+      alert('Failed to mint token');
+    } finally {
+      setBusy('');
+    }
+  };
+
+  const handleDelete = async (userId: string, userName: string) => {
+    // eslint-disable-next-line no-alert, no-restricted-globals
+    if (!confirm(`Delete user "${userName}"? This invalidates any token derived from it.`)) return;
+    setBusy(userId);
+    try {
+      await adminUtils.deleteUser(token, userId);
+      onChange();
+    } catch (_e) {
+      // eslint-disable-next-line no-alert
+      alert('Failed to delete user');
+    } finally {
+      setBusy('');
+    }
+  };
+
+  if (users.length === 0) {
+    return <Box sx={{ padding: 2, textAlign: 'center' }} data-testid="users-empty">No users yet.</Box>;
+  }
+
+  return (
+    <Table data-testid="users-table">
+      <TableHead>
+        <TableRow>
+          <TableCell>Name</TableCell>
+          <TableCell>Email</TableCell>
+          <TableCell>Type</TableCell>
+          <TableCell>Privileges</TableCell>
+          <TableCell>Actions</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {users.map((u) => (
+          <TableRow key={u._id} data-testid={`user-row-${u._id}`}>
+            <TableCell>{u.name}</TableCell>
+            <TableCell>{u.email}</TableCell>
+            <TableCell>
+              <Chip label={u.userStatus || 'human'} size="small" />
+            </TableCell>
+            <TableCell>
+              {(u.privileges || []).map((p) => <Chip key={p} label={p} size="small" sx={{ margin: '2px' }} />)}
+            </TableCell>
+            <TableCell>
+              <Button
+                size="small"
+                onClick={() => handleShowToken(u._id)}
+                disabled={busy === u._id}
+                data-testid={`show-token-${u._id}`}
+              >
+                Show token
+              </Button>
+              <Button
+                size="small"
+                onClick={() => onEditPrivileges(u)}
+                disabled={busy === u._id}
+                data-testid={`edit-priv-${u._id}`}
+              >
+                Edit privileges
+              </Button>
+              <Button
+                size="small"
+                color="error"
+                onClick={() => handleDelete(u._id, u.name)}
+                disabled={busy === u._id}
+                data-testid={`delete-${u._id}`}
+              >
+                Delete
+              </Button>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/src/containers/AdminUsers/admin-users.utils.ts
+++ b/src/containers/AdminUsers/admin-users.utils.ts
@@ -1,0 +1,53 @@
+import superagent from 'superagent';
+
+export interface IadminUser {
+  _id: string;
+  name: string;
+  email: string;
+  userType?: string;
+  userStatus?: string;
+  privileges?: string[];
+  userDetails?: string;
+}
+
+const baseUrl = `${process.env.BackendUrl}/admin/user`;
+
+async function listUsers(token: string): Promise<IadminUser[]> {
+  const res = await superagent.get(baseUrl).set('Accept', 'application/json').set('Authorization', `Bearer ${token}`);
+  return res.body as IadminUser[];
+}
+
+async function createUser(
+  token: string,
+  payload: { name: string; email: string; userType?: string; userStatus?: string; privileges?: string[]; userDetails?: string },
+): Promise<IadminUser> {
+  const res = await superagent.post(baseUrl).set('Accept', 'application/json')
+    .set('Authorization', `Bearer ${token}`).send(payload);
+  return res.body as IadminUser;
+}
+
+async function updatePrivileges(token: string, userId: string, privileges: string[]): Promise<IadminUser> {
+  const res = await superagent.put(`${baseUrl}/${userId}`).set('Accept', 'application/json')
+    .set('Authorization', `Bearer ${token}`).send({ privileges });
+  return res.body as IadminUser;
+}
+
+async function mintToken(token: string, userId: string): Promise<string> {
+  const res = await superagent.post(`${baseUrl}/${userId}/token`).set('Accept', 'application/json')
+    .set('Authorization', `Bearer ${token}`).send({});
+  return (res.body as { token: string }).token;
+}
+
+async function deleteUser(token: string, userId: string): Promise<void> {
+  await superagent.delete(`${baseUrl}/${userId}`).set('Accept', 'application/json').set('Authorization', `Bearer ${token}`);
+}
+
+export function getAllowedAdminRoles(): string[] {
+  return process.env.NODE_ENV === 'production'
+    ? ['JaM-admin']
+    : ['JaM-admin', 'Developer'];
+}
+
+export default {
+  listUsers, createUser, updatePrivileges, mintToken, deleteUser, getAllowedAdminRoles,
+};

--- a/src/containers/AdminUsers/capabilities.ts
+++ b/src/containers/AdminUsers/capabilities.ts
@@ -1,0 +1,24 @@
+export const CAPABILITIES = [
+  'tour:create',
+  'tour:edit',
+  'tour:delete',
+  'song:read',
+  'song:create',
+  'song:edit',
+  'song:delete',
+  'book:read',
+  'book:create',
+  'book:edit',
+  'book:delete',
+] as const;
+
+export type Capability = (typeof CAPABILITIES)[number];
+
+export const CAPABILITY_GROUPS: { label: string; items: Capability[] }[] = [
+  { label: 'Tours', items: ['tour:create', 'tour:edit', 'tour:delete'] },
+  { label: 'Songs', items: ['song:read', 'song:create', 'song:edit', 'song:delete'] },
+  { label: 'Books', items: ['book:read', 'book:create', 'book:edit', 'book:delete'] },
+];
+
+export const USER_STATUS_OPTIONS = ['human', 'ai-agent'] as const;
+export type UserStatus = (typeof USER_STATUS_OPTIONS)[number];

--- a/src/containers/AdminUsers/index.tsx
+++ b/src/containers/AdminUsers/index.tsx
@@ -1,0 +1,74 @@
+import { useCallback, useContext, useEffect, useState } from 'react';
+import { Box, Typography } from '@mui/material';
+import { AuthContext } from 'src/providers/Auth.provider';
+import { CreateUserForm } from './CreateUserForm';
+import { UsersTable } from './UsersTable';
+import { ShowTokenDialog } from './ShowTokenDialog';
+import { EditPrivilegesDialog } from './EditPrivilegesDialog';
+import adminUtils, { type IadminUser } from './admin-users.utils';
+
+export function AdminUsers(): JSX.Element {
+  const { auth } = useContext(AuthContext);
+  const allowed = adminUtils.getAllowedAdminRoles();
+  const isAuthorized = auth.isAuthenticated && allowed.indexOf(auth.user.userType) !== -1;
+
+  const [users, setUsers] = useState<IadminUser[]>([]);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [tokenShown, setTokenShown] = useState<string | null>(null);
+  const [editingUser, setEditingUser] = useState<IadminUser | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!isAuthorized) return;
+    setLoading(true);
+    setError('');
+    try {
+      const data = await adminUtils.listUsers(auth.token);
+      setUsers(data);
+    } catch (e) {
+      const err = e as { response?: { body?: { message?: string } }; message?: string };
+      setError(err.response?.body?.message || err.message || 'Failed to load users');
+    } finally {
+      setLoading(false);
+    }
+  }, [auth.token, isAuthorized]);
+
+  useEffect(() => { void refresh(); }, [refresh]);
+
+  if (!isAuthorized) {
+    return (
+      <Box sx={{ padding: 3 }} data-testid="admin-users-unauthorized">
+        <Typography variant="h6">Not authorized</Typography>
+        <Typography variant="body2">You must be signed in as an admin to view this page.</Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ padding: 3, maxWidth: 1200, margin: 'auto' }} data-testid="admin-users-page">
+      <Typography variant="h5" sx={{ marginBottom: 2 }}>Admin Users</Typography>
+      <CreateUserForm token={auth.token} onCreated={refresh} />
+      {loading && <Typography data-testid="admin-users-loading">Loading...</Typography>}
+      {error && <Typography color="error" data-testid="admin-users-error">{error}</Typography>}
+      <UsersTable
+        users={users}
+        token={auth.token}
+        onShowToken={(t) => setTokenShown(t)}
+        onEditPrivileges={(u) => setEditingUser(u)}
+        onChange={refresh}
+      />
+      <ShowTokenDialog
+        open={tokenShown !== null}
+        token={tokenShown || ''}
+        onClose={() => setTokenShown(null)}
+      />
+      <EditPrivilegesDialog
+        open={editingUser !== null}
+        user={editingUser}
+        token={auth.token}
+        onClose={() => setEditingUser(null)}
+        onSaved={() => { setEditingUser(null); void refresh(); }}
+      />
+    </Box>
+  );
+}

--- a/test/containers/AdminUsers/CreateUserForm.spec.tsx
+++ b/test/containers/AdminUsers/CreateUserForm.spec.tsx
@@ -1,0 +1,62 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import renderer, { act } from 'react-test-renderer';
+import { CreateUserForm } from 'src/containers/AdminUsers/CreateUserForm';
+import adminUtils from 'src/containers/AdminUsers/admin-users.utils';
+
+describe('CreateUserForm', () => {
+  beforeEach(() => {
+    adminUtils.createUser = vi.fn(() => Promise.resolve({ _id: 'newid', name: 'N', email: 'e@e.com' })) as any;
+  });
+
+  function render(onCreated = vi.fn()) {
+    return renderer.create(<CreateUserForm token="tk" onCreated={onCreated} />).root;
+  }
+
+  it('shows error when name is empty on submit', async () => {
+    const tree = render();
+    await act(async () => {
+      tree.findByProps({ 'data-testid': 'create-user-submit' }).props.onClick();
+    });
+    expect(adminUtils.createUser).not.toHaveBeenCalled();
+  });
+
+  it('submits valid input and calls onCreated', async () => {
+    const onCreated = vi.fn();
+    const tree = render(onCreated);
+    await act(async () => {
+      tree.findByProps({ 'data-testid': 'create-user-name' }).props.onChange({ target: { value: 'Test' } });
+    });
+    await act(async () => {
+      tree.findByProps({ 'data-testid': 'create-user-email' }).props.onChange({ target: { value: 't@t.com' } });
+    });
+    await act(async () => {
+      tree.findByProps({ 'data-testid': 'create-user-submit' }).props.onClick();
+    });
+    expect(adminUtils.createUser).toHaveBeenCalled();
+    expect(onCreated).toHaveBeenCalled();
+  });
+
+  it('toggles a privilege checkbox', async () => {
+    const tree = render();
+    const cap = tree.findByProps({ 'data-testid': 'cap-tour:create' });
+    await act(async () => { cap.props.onChange(); });
+    expect(tree.findByProps({ 'data-testid': 'cap-tour:create' }).props.checked).toBe(true);
+    await act(async () => { cap.props.onChange(); });
+    expect(tree.findByProps({ 'data-testid': 'cap-tour:create' }).props.checked).toBe(false);
+  });
+
+  it('surfaces server-side error message', async () => {
+    adminUtils.createUser = vi.fn(() => Promise.reject({ response: { body: { message: 'dup email' } } })) as any;
+    const tree = render();
+    await act(async () => {
+      tree.findByProps({ 'data-testid': 'create-user-name' }).props.onChange({ target: { value: 'A' } });
+    });
+    await act(async () => {
+      tree.findByProps({ 'data-testid': 'create-user-email' }).props.onChange({ target: { value: 'a@a.com' } });
+    });
+    await act(async () => {
+      tree.findByProps({ 'data-testid': 'create-user-submit' }).props.onClick();
+    });
+    expect(adminUtils.createUser).toHaveBeenCalled();
+  });
+});

--- a/test/containers/AdminUsers/EditPrivilegesDialog.spec.tsx
+++ b/test/containers/AdminUsers/EditPrivilegesDialog.spec.tsx
@@ -1,0 +1,70 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import renderer, { act } from 'react-test-renderer';
+import { EditPrivilegesDialog } from 'src/containers/AdminUsers/EditPrivilegesDialog';
+import adminUtils, { type IadminUser } from 'src/containers/AdminUsers/admin-users.utils';
+
+const user: IadminUser = {
+  _id: 'u1', name: 'Bot', email: 'b@x.com', privileges: ['tour:create'],
+};
+
+describe('EditPrivilegesDialog', () => {
+  beforeEach(() => {
+    adminUtils.updatePrivileges = vi.fn(() => Promise.resolve({} as IadminUser)) as any;
+  });
+
+  it('initializes with the user privileges', async () => {
+    let component: renderer.ReactTestRenderer | null = null;
+    await act(async () => {
+      component = renderer.create(
+        <EditPrivilegesDialog open user={user} token="tk" onClose={vi.fn()} onSaved={vi.fn()} />,
+      );
+    });
+    const tree = component!.root;
+    expect(tree.findByProps({ 'data-testid': 'edit-cap-tour:create' }).props.checked).toBe(true);
+    expect(tree.findByProps({ 'data-testid': 'edit-cap-song:read' }).props.checked).toBe(false);
+  });
+
+  it('saves and calls onSaved', async () => {
+    const onSaved = vi.fn();
+    let component: renderer.ReactTestRenderer | null = null;
+    await act(async () => {
+      component = renderer.create(
+        <EditPrivilegesDialog open user={user} token="tk" onClose={vi.fn()} onSaved={onSaved} />,
+      );
+    });
+    const tree = component!.root;
+    await act(async () => {
+      tree.findByProps({ 'data-testid': 'edit-priv-save' }).props.onClick();
+    });
+    expect(adminUtils.updatePrivileges).toHaveBeenCalledWith('tk', 'u1', ['tour:create']);
+    expect(onSaved).toHaveBeenCalled();
+  });
+
+  it('calls onClose when Cancel clicked', () => {
+    const onClose = vi.fn();
+    const tree = renderer.create(
+      <EditPrivilegesDialog open user={user} token="tk" onClose={onClose} onSaved={vi.fn()} />,
+    ).root;
+    tree.findByProps({ 'data-testid': 'edit-priv-cancel' }).props.onClick();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('toggles a capability checkbox', async () => {
+    const tree = renderer.create(
+      <EditPrivilegesDialog open user={user} token="tk" onClose={vi.fn()} onSaved={vi.fn()} />,
+    ).root;
+    const cap = tree.findByProps({ 'data-testid': 'edit-cap-song:read' });
+    await act(async () => { cap.props.onChange(); });
+    expect(tree.findByProps({ 'data-testid': 'edit-cap-song:read' }).props.checked).toBe(true);
+  });
+
+  it('handles null user gracefully on save', async () => {
+    const tree = renderer.create(
+      <EditPrivilegesDialog open user={null} token="tk" onClose={vi.fn()} onSaved={vi.fn()} />,
+    ).root;
+    await act(async () => {
+      tree.findByProps({ 'data-testid': 'edit-priv-save' }).props.onClick();
+    });
+    expect(adminUtils.updatePrivileges).not.toHaveBeenCalled();
+  });
+});

--- a/test/containers/AdminUsers/ShowTokenDialog.spec.tsx
+++ b/test/containers/AdminUsers/ShowTokenDialog.spec.tsx
@@ -1,0 +1,37 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import renderer, { act } from 'react-test-renderer';
+import { ShowTokenDialog } from 'src/containers/AdminUsers/ShowTokenDialog';
+
+describe('ShowTokenDialog', () => {
+  it('renders the token value', () => {
+    const tree = renderer.create(<ShowTokenDialog open token="my-jwt" onClose={vi.fn()} />).root;
+    expect(tree.findByProps({ 'data-testid': 'token-value' })).toBeDefined();
+  });
+
+  it('calls onClose when Done clicked', () => {
+    const onClose = vi.fn();
+    const tree = renderer.create(<ShowTokenDialog open token="x" onClose={onClose} />).root;
+    tree.findByProps({ 'data-testid': 'close-token' }).props.onClick();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('writes to clipboard when copy clicked', async () => {
+    const write = vi.fn(() => Promise.resolve());
+    Object.defineProperty(window.navigator, 'clipboard', { value: { writeText: write }, configurable: true });
+    const tree = renderer.create(<ShowTokenDialog open token="copy-me" onClose={vi.fn()} />).root;
+    await act(async () => {
+      tree.findByProps({ 'data-testid': 'copy-token' }).props.onClick();
+    });
+    expect(write).toHaveBeenCalledWith('copy-me');
+  });
+
+  it('tolerates clipboard write failure silently', async () => {
+    const write = vi.fn(() => Promise.reject(new Error('blocked')));
+    Object.defineProperty(window.navigator, 'clipboard', { value: { writeText: write }, configurable: true });
+    const tree = renderer.create(<ShowTokenDialog open token="x" onClose={vi.fn()} />).root;
+    await act(async () => {
+      tree.findByProps({ 'data-testid': 'copy-token' }).props.onClick();
+    });
+    expect(write).toHaveBeenCalled();
+  });
+});

--- a/test/containers/AdminUsers/UsersTable.spec.tsx
+++ b/test/containers/AdminUsers/UsersTable.spec.tsx
@@ -1,0 +1,76 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import renderer, { act } from 'react-test-renderer';
+import { UsersTable } from 'src/containers/AdminUsers/UsersTable';
+import adminUtils, { type IadminUser } from 'src/containers/AdminUsers/admin-users.utils';
+
+describe('UsersTable', () => {
+  const users: IadminUser[] = [
+    {
+      _id: 'u1', name: 'Bot One', email: 'b1@x.com', userStatus: 'ai-agent', privileges: ['tour:create'],
+    },
+  ];
+
+  beforeEach(() => {
+    adminUtils.mintToken = vi.fn(() => Promise.resolve('JWT')) as any;
+    adminUtils.deleteUser = vi.fn(() => Promise.resolve()) as any;
+  });
+
+  it('renders empty state when no users', () => {
+    const tree = renderer.create(
+      <UsersTable users={[]} token="tk" onShowToken={vi.fn()} onEditPrivileges={vi.fn()} onChange={vi.fn()} />,
+    ).root;
+    expect(tree.findByProps({ 'data-testid': 'users-empty' })).toBeDefined();
+  });
+
+  it('renders a row per user', () => {
+    const tree = renderer.create(
+      <UsersTable users={users} token="tk" onShowToken={vi.fn()} onEditPrivileges={vi.fn()} onChange={vi.fn()} />,
+    ).root;
+    expect(tree.findByProps({ 'data-testid': 'user-row-u1' })).toBeDefined();
+  });
+
+  it('calls onShowToken after minting succeeds', async () => {
+    const onShowToken = vi.fn();
+    const tree = renderer.create(
+      <UsersTable users={users} token="tk" onShowToken={onShowToken} onEditPrivileges={vi.fn()} onChange={vi.fn()} />,
+    ).root;
+    await act(async () => {
+      tree.findByProps({ 'data-testid': 'show-token-u1' }).props.onClick();
+    });
+    expect(adminUtils.mintToken).toHaveBeenCalledWith('tk', 'u1');
+    expect(onShowToken).toHaveBeenCalledWith('JWT');
+  });
+
+  it('calls onEditPrivileges with the user', () => {
+    const onEdit = vi.fn();
+    const tree = renderer.create(
+      <UsersTable users={users} token="tk" onShowToken={vi.fn()} onEditPrivileges={onEdit} onChange={vi.fn()} />,
+    ).root;
+    tree.findByProps({ 'data-testid': 'edit-priv-u1' }).props.onClick();
+    expect(onEdit).toHaveBeenCalledWith(users[0]);
+  });
+
+  it('confirms before delete and calls onChange', async () => {
+    window.confirm = vi.fn(() => true);
+    const onChange = vi.fn();
+    const tree = renderer.create(
+      <UsersTable users={users} token="tk" onShowToken={vi.fn()} onEditPrivileges={vi.fn()} onChange={onChange} />,
+    ).root;
+    await act(async () => {
+      tree.findByProps({ 'data-testid': 'delete-u1' }).props.onClick();
+    });
+    expect(adminUtils.deleteUser).toHaveBeenCalledWith('tk', 'u1');
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it('skips delete when confirm returns false', async () => {
+    window.confirm = vi.fn(() => false);
+    const tree = renderer.create(
+      <UsersTable users={users} token="tk" onShowToken={vi.fn()} onEditPrivileges={vi.fn()} onChange={vi.fn()} />,
+    ).root;
+    await act(async () => {
+      tree.findByProps({ 'data-testid': 'delete-u1' }).props.onClick();
+    });
+    expect(adminUtils.deleteUser).not.toHaveBeenCalled();
+  });
+});

--- a/test/containers/AdminUsers/admin-users.utils.spec.tsx
+++ b/test/containers/AdminUsers/admin-users.utils.spec.tsx
@@ -1,0 +1,29 @@
+import adminUtils from 'src/containers/AdminUsers/admin-users.utils';
+
+describe('AdminUsers utils', () => {
+  describe('getAllowedAdminRoles', () => {
+    const originalEnv = process.env.NODE_ENV;
+    afterEach(() => { process.env.NODE_ENV = originalEnv; });
+
+    it('returns only JaM-admin in production', () => {
+      process.env.NODE_ENV = 'production';
+      const roles = adminUtils.getAllowedAdminRoles();
+      expect(roles).toEqual(['JaM-admin']);
+    });
+
+    it('includes Developer in non-production', () => {
+      process.env.NODE_ENV = 'development';
+      const roles = adminUtils.getAllowedAdminRoles();
+      expect(roles).toContain('JaM-admin');
+      expect(roles).toContain('Developer');
+    });
+  });
+
+  it('exports all expected API functions', () => {
+    expect(typeof adminUtils.listUsers).toBe('function');
+    expect(typeof adminUtils.createUser).toBe('function');
+    expect(typeof adminUtils.updatePrivileges).toBe('function');
+    expect(typeof adminUtils.mintToken).toBe('function');
+    expect(typeof adminUtils.deleteUser).toBe('function');
+  });
+});

--- a/test/containers/AdminUsers/capabilities.spec.tsx
+++ b/test/containers/AdminUsers/capabilities.spec.tsx
@@ -1,0 +1,23 @@
+import { CAPABILITIES, CAPABILITY_GROUPS, USER_STATUS_OPTIONS } from 'src/containers/AdminUsers/capabilities';
+
+describe('AdminUsers capabilities registry', () => {
+  it('includes tour, song, and book capabilities', () => {
+    expect(CAPABILITIES).toContain('tour:create');
+    expect(CAPABILITIES).toContain('song:read');
+    expect(CAPABILITIES).toContain('book:delete');
+  });
+
+  it('does not include user:* capabilities', () => {
+    for (const c of CAPABILITIES) expect(c.startsWith('user:')).toBe(false);
+  });
+
+  it('CAPABILITY_GROUPS covers every capability exactly once', () => {
+    const inGroups = CAPABILITY_GROUPS.flatMap((g) => g.items);
+    expect(inGroups.sort()).toEqual([...CAPABILITIES].sort());
+  });
+
+  it('USER_STATUS_OPTIONS includes human and ai-agent', () => {
+    expect(USER_STATUS_OPTIONS).toContain('human');
+    expect(USER_STATUS_OPTIONS).toContain('ai-agent');
+  });
+});

--- a/test/containers/AdminUsers/index.spec.tsx
+++ b/test/containers/AdminUsers/index.spec.tsx
@@ -1,0 +1,60 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import renderer, { act } from 'react-test-renderer';
+import { AuthContext, defaultAuth, type Iauth } from 'src/providers/Auth.provider';
+import { AdminUsers } from 'src/containers/AdminUsers';
+import adminUtils from 'src/containers/AdminUsers/admin-users.utils';
+
+const adminAuth: Iauth = {
+  isAuthenticated: true,
+  error: '',
+  token: 'tk',
+  user: { userType: 'JaM-admin', email: 'a@b.com' },
+};
+
+const wrap = (auth: Iauth) => (
+  <AuthContext.Provider value={{ auth, setAuth: () => { /* noop */ } }}>
+    <AdminUsers />
+  </AuthContext.Provider>
+);
+
+describe('AdminUsers page', () => {
+  beforeEach(() => {
+    adminUtils.listUsers = vi.fn(() => Promise.resolve([])) as any;
+    adminUtils.getAllowedAdminRoles = vi.fn(() => ['JaM-admin', 'Developer']) as any;
+  });
+
+  it('renders not-authorized when user is not authenticated', () => {
+    const tree = renderer.create(wrap(defaultAuth)).root;
+    expect(tree.findByProps({ 'data-testid': 'admin-users-unauthorized' })).toBeDefined();
+  });
+
+  it('renders not-authorized when userType is not in allowed list', () => {
+    const otherAuth: Iauth = { ...adminAuth, user: { userType: 'clc-admin', email: 'x@y.com' } };
+    const tree = renderer.create(wrap(otherAuth)).root;
+    expect(tree.findByProps({ 'data-testid': 'admin-users-unauthorized' })).toBeDefined();
+  });
+
+  it('renders the page when user is JaM-admin', async () => {
+    let component: renderer.ReactTestRenderer | null = null;
+    await act(async () => { component = renderer.create(wrap(adminAuth)); });
+    const tree = component!.root;
+    expect(tree.findByProps({ 'data-testid': 'admin-users-page' })).toBeDefined();
+    expect(adminUtils.listUsers).toHaveBeenCalledWith('tk');
+  });
+
+  it('renders the page when user is Developer (non-prod)', async () => {
+    const devAuth: Iauth = { ...adminAuth, user: { userType: 'Developer', email: 'd@d.com' } };
+    let component: renderer.ReactTestRenderer | null = null;
+    await act(async () => { component = renderer.create(wrap(devAuth)); });
+    const tree = component!.root;
+    expect(tree.findByProps({ 'data-testid': 'admin-users-page' })).toBeDefined();
+  });
+
+  it('shows an error message when listUsers rejects', async () => {
+    adminUtils.listUsers = vi.fn(() => Promise.reject(new Error('boom'))) as any;
+    let component: renderer.ReactTestRenderer | null = null;
+    await act(async () => { component = renderer.create(wrap(adminAuth)); });
+    const tree = component!.root;
+    expect(tree.findByProps({ 'data-testid': 'admin-users-error' }).props.children).toBe('boom');
+  });
+});

--- a/test/containers/Music/__snapshots__/index.spec.tsx.snap
+++ b/test/containers/Music/__snapshots__/index.spec.tsx.snap
@@ -131,7 +131,12 @@ exports[`/music > renders the component 1`] = `
               />
             }
             label="Show Title In Caption"
-          />
+          >
+            <input
+              checked={false}
+              onClick={[Function]}
+            />
+          </div>
         </div>
       </div>
       <div>


### PR DESCRIPTION
## Summary

- New admin-only page at \`/admin/users\` for managing all users (humans and AI agents).
- Companion to web-jam-back #758 and WebJamSocketCluster #215 (both already merged to dev).
- Admin can create users, edit per-user privileges, mint long-lived service tokens, and delete users — all from one page.

## Behavior

- **Page placement:** new \`/admin/users\` route + admin menu entry in \`wjNav\` with \`auth: true\` (hidden from non-admin menus).
- **Page-level role gate:** allows \`JaM-admin\` always; allows \`Developer\` only when \`NODE_ENV !== 'production'\`. Anyone else navigating to the URL directly sees a "Not authorized" message.
- **Capability checkboxes:** grouped by resource (tour / song / book), matching the backend capability registry exactly. \`user:*\` capabilities are deliberately excluded — admin actions on users are gated by the admin role itself.
- **Token-show modal:** displays the long-lived JWT (no \`exp\`) with copy-to-clipboard. Token endpoint is idempotent, so re-clicking re-shows a fresh-but-equivalent token.
- **Edit privileges modal:** prefills the user's current capabilities, supports add/remove via checkbox.
- **Delete confirmation:** native \`window.confirm\` for v1.

## Non-breaking by design

- The page is new; no existing route or component changed beyond the menu config and the App router registration.
- The capability check on \`newTour\` (shipped in the SCS PR) falls back to the existing role-based auth when \`privileges\` is empty, so existing users authorize exactly as today.

## Test plan

- [x] Lint clean (\`npm run lint:fix\`)
- [x] Typecheck clean (\`npm run typecheck\`)
- [x] All 250 unit tests pass (\`npm run test:unit\`), including 31 new tests across the AdminUsers page, dialogs, capabilities registry, and API utils
- [ ] Josh manually adds \`AUTH_ROLES.admin\` Heroku env entry on webjamsalem before this is usable in deployed envs
- [ ] End-to-end smoke: log in as \`JaM-admin\`, create a \`web-jam-llm\` AI-agent user with \`tour:create\`, mint a token, transmit a \`newTour\` from a test script, verify gig appears in the gigs table

## Notes on the MUI mock changes

- Added stubs for \`Typography\`, \`Chip\`, \`Table\` family in \`__mocks__/@mui/material.tsx\` (previously missing — page wouldn't render in tests)
- Updated \`FormControlLabel\` mock to render its \`control\` prop, not just \`children\` — this makes Checkbox-wrapped-in-FormControlLabel findable in test trees. One snapshot in \`test/containers/Music/index.spec.tsx\` was updated as a result; the snapshot diff reflects the now-correctly-rendered Checkbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)