### PR TITLE
fix(mobile): responsive gigs DataGrid + admin users table

### DIFF
--- a/__mocks__/@mui/material.tsx
+++ b/__mocks__/@mui/material.tsx
@@ -131,3 +131,8 @@ export function TableCell(props:any) {
   const { children } = props;
   return <td {...props}>{children}</td>;
 }
+
+// Default to desktop (false) in tests; suites can override per-case.
+export function useMediaQuery() {
+  return false;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jammusic",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jammusic",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/AdminUsers/UsersTable.tsx
+++ b/src/containers/AdminUsers/UsersTable.tsx
@@ -51,61 +51,63 @@ export function UsersTable({
   }
 
   return (
-    <Table data-testid="users-table">
-      <TableHead>
-        <TableRow>
-          <TableCell>Name</TableCell>
-          <TableCell>Email</TableCell>
-          <TableCell>Role</TableCell>
-          <TableCell>Type</TableCell>
-          <TableCell>Privileges</TableCell>
-          <TableCell>Actions</TableCell>
-        </TableRow>
-      </TableHead>
-      <TableBody>
-        {users.map((u) => (
-          <TableRow key={u._id} data-testid={`user-row-${u._id}`}>
-            <TableCell>{u.name}</TableCell>
-            <TableCell>{u.email}</TableCell>
-            <TableCell>
-              <Chip label={u.userType || 'N/A'} color="primary" variant="outlined" size="small" />
-            </TableCell>
-            <TableCell>
-              <Chip label={u.userStatus || 'human'} size="small" />
-            </TableCell>
-            <TableCell>
-              {(u.privileges || []).map((p) => <Chip key={p} label={p} size="small" sx={{ margin: '2px' }} />)}
-            </TableCell>
-            <TableCell>
-              <Button
-                size="small"
-                onClick={() => handleShowToken(u._id)}
-                disabled={busy === u._id}
-                data-testid={`show-token-${u._id}`}
-              >
-                Show token
-              </Button>
-              <Button
-                size="small"
-                onClick={() => onEditPrivileges(u)}
-                disabled={busy === u._id}
-                data-testid={`edit-priv-${u._id}`}
-              >
-                Edit privileges
-              </Button>
-              <Button
-                size="small"
-                color="error"
-                onClick={() => handleDelete(u._id, u.name)}
-                disabled={busy === u._id}
-                data-testid={`delete-${u._id}`}
-              >
-                Delete
-              </Button>
-            </TableCell>
+    <Box sx={{ width: '100%', overflowX: 'auto' }}>
+      <Table data-testid="users-table" size="small" sx={{ minWidth: 720 }}>
+        <TableHead>
+          <TableRow>
+            <TableCell>Name</TableCell>
+            <TableCell>Email</TableCell>
+            <TableCell>Role</TableCell>
+            <TableCell>Type</TableCell>
+            <TableCell>Privileges</TableCell>
+            <TableCell>Actions</TableCell>
           </TableRow>
-        ))}
-      </TableBody>
-    </Table>
+        </TableHead>
+        <TableBody>
+          {users.map((u) => (
+            <TableRow key={u._id} data-testid={`user-row-${u._id}`}>
+              <TableCell>{u.name}</TableCell>
+              <TableCell>{u.email}</TableCell>
+              <TableCell>
+                <Chip label={u.userType || 'N/A'} color="primary" variant="outlined" size="small" />
+              </TableCell>
+              <TableCell>
+                <Chip label={u.userStatus || 'human'} size="small" />
+              </TableCell>
+              <TableCell>
+                {(u.privileges || []).map((p) => <Chip key={p} label={p} size="small" sx={{ margin: '2px' }} />)}
+              </TableCell>
+              <TableCell>
+                <Button
+                  size="small"
+                  onClick={() => handleShowToken(u._id)}
+                  disabled={busy === u._id}
+                  data-testid={`show-token-${u._id}`}
+                >
+                  Show token
+                </Button>
+                <Button
+                  size="small"
+                  onClick={() => onEditPrivileges(u)}
+                  disabled={busy === u._id}
+                  data-testid={`edit-priv-${u._id}`}
+                >
+                  Edit privileges
+                </Button>
+                <Button
+                  size="small"
+                  color="error"
+                  onClick={() => handleDelete(u._id, u.name)}
+                  disabled={busy === u._id}
+                  data-testid={`delete-${u._id}`}
+                >
+                  Delete
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Box>
   );
 }

--- a/src/containers/Music/Gigs/gigs.utils.tsx
+++ b/src/containers/Music/Gigs/gigs.utils.tsx
@@ -147,6 +147,9 @@ const makeDateValue = (datetime: string) => {
   return localString;
 };
 
+const makeShortDateValue = (datetime: string) => new Date(datetime)
+  .toLocaleString('en-US', { year: '2-digit', month: 'numeric', day: 'numeric' });
+
 const makeTimeValue = (datetime: string) => new Date(datetime)
   .toLocaleString('en-US', { hour: 'numeric', minute: '2-digit' });
 
@@ -156,11 +159,11 @@ const makeVenueValue = (value: string) => {
   return <div>{parsed}</div>;
 };
 
-const makeVenue = (): GridColDef => (
+const makeVenue = (isMobile = false): GridColDef => (
   {
     field: 'venue',
     headerName: 'Venue',
-    minWidth: 400,
+    minWidth: isMobile ? 110 : 400,
     flex: 2,
     editable: false,
     renderCell: (params: GridRenderCellParams) => makeVenueValue(params.value),
@@ -171,6 +174,7 @@ export default {
   makeVenue,
   makeVenueValue,
   makeDateValue,
+  makeShortDateValue,
   makeTimeValue,
   createGig,
   updateGig,

--- a/src/containers/Music/Gigs/index.tsx
+++ b/src/containers/Music/Gigs/index.tsx
@@ -4,7 +4,7 @@ import {
 import {
   DataGrid, type GridColDef, type GridRenderCellParams,
 } from '@mui/x-data-grid';
-import { Button, IconButton, Tooltip } from '@mui/material';
+import { Button, IconButton, Tooltip, useMediaQuery } from '@mui/material';
 import { Add as AddIcon } from '@mui/icons-material';
 import HtmlReactParser from 'html-react-parser';
 import { DataContext, Igig } from 'src/providers/Data.provider';
@@ -16,19 +16,19 @@ import { EditGigDialog } from './EditGigDialog';
 import { CreateGigDialog } from './CreateGigDialog';
 import './gigs.scss';
 
-export const columns: GridColDef[] = [
-  {
+export const makeColumns = (isMobile = false): GridColDef[] => {
+  const dateCol: GridColDef = {
     field: 'date',
     headerName: 'Date',
-    width: 220,
+    width: isMobile ? 92 : 220,
     editable: false,
     renderCell: (params: GridRenderCellParams) => {
       const { row: { datetime } } = params;
       if (!datetime) return '';
-      return utils.makeDateValue(datetime);
+      return isMobile ? utils.makeShortDateValue(datetime) : utils.makeDateValue(datetime);
     },
-  },
-  {
+  };
+  const timeCol: GridColDef = {
     field: 'time',
     headerName: 'Time',
     width: 90,
@@ -38,11 +38,11 @@ export const columns: GridColDef[] = [
       if (!datetime) return '';
       return utils.makeTimeValue(datetime);
     },
-  },
-  {
+  };
+  const locationCol: GridColDef = {
     field: 'location',
     headerName: 'Location',
-    minWidth: 160,
+    minWidth: isMobile ? 90 : 160,
     flex: 1,
     editable: false,
     renderCell: (params: GridRenderCellParams) => {
@@ -51,16 +51,21 @@ export const columns: GridColDef[] = [
       if (city) return `${city}, ${usState}`;
       return '';
     },
-  },
-  utils.makeVenue(),
-  {
+  };
+  const ticketsCol: GridColDef = {
     field: 'tickets',
     headerName: 'Tickets',
     width: 120,
     editable: false,
     renderCell: (params: GridRenderCellParams) => <span>{HtmlReactParser(params.value || 'Free')}</span>,
-  },
-];
+  };
+  // On phones the full table (~990px) overflows; show only Date/Location/Venue.
+  if (isMobile) return [dateCol, locationCol, utils.makeVenue(true)];
+  return [dateCol, timeCol, locationCol, utils.makeVenue(), ticketsCol];
+};
+
+// Backwards-compatible default (desktop) export.
+export const columns: GridColDef[] = makeColumns(false);
 
 export const ShowCreateGigButton = (
   { isAdmin, setShowDialog }: { isAdmin: boolean, setShowDialog: (arg0: boolean) => void },
@@ -90,6 +95,7 @@ export const GigsDiv = (props: IgigsDivProps) => {
     isAdmin, setShowDialog, setEditGig, editGig, gigsInOrder = [], pageSize, showDialog, editChanged, setEditChanged, getGigs, auth, setPageSize,
   } = props;
   const navigate = useNavigate();
+  const isMobile = useMediaQuery('(max-width:600px)');
   const handleClick = () => {
     if (process.env.APP_NAME === 'joshandmariamusic.com') window.open('https://web-jam.com/music/bookus');
     else navigate('/music/bookus');
@@ -109,11 +115,12 @@ export const GigsDiv = (props: IgigsDivProps) => {
       <div style={{ height: '500px', width: '100%' }}>
         <DataGrid
           className={isAdmin ? 'adminGrid' : ''}
+          getRowHeight={() => 'auto'}
           onRowClick={(rowParams) => {
             utils.clickToEdit(setEditGig, isAdmin, rowParams.row);
           }}
           rows={gigsInOrder || []}
-          columns={columns}
+          columns={makeColumns(isMobile)}
           paginationModel={{ page: 0, pageSize }}
           onPaginationModelChange={(model) => setPageSize(model.pageSize)}
           pageSizeOptions={[pageSize]}


### PR DESCRIPTION
## What
Two mobile layout bugs reported on web-jam.com / joshandmariamusic.com from a phone.

### Gigs table (public)
The DataGrid columns summed to ~990px (venue `minWidth: 400`, date `220` rendering the long "Saturday, January 25, 2026" form, etc.), overflowing phone screens and mangling the layout.
- `useMediaQuery('(max-width:600px)')`: on mobile, show **Date / Location / Venue** only (drop Time + Tickets), use a short numeric date, and reduce venue `minWidth` to 110.
- `getRowHeight={() => 'auto'}` so wrapped venue text grows the row instead of clipping.
- Desktop layout unchanged (`makeColumns(false)` === the old columns; `columns` export preserved).

### Admin users table
A plain MUI `<Table>` with 6 columns + 3 action buttons blew past the viewport.
- Wrapped in an `overflowX: auto` Box + `size="small"` + `minWidth`, so it scrolls within its own container instead of breaking the page.

### Test mock
Added `useMediaQuery` (returns `false` = desktop) to `__mocks__/@mui/material.tsx`.

Patch bump 2.7.2 → 2.7.3. Lint clean, typecheck passes, **246/246 tests pass** (TZ=UTC), prod build succeeds.

## How to Test Locally
```bash
git checkout fix-mobile-table-layout
npm install
npm test
npm run build
```
Then on a narrow viewport (DevTools device toolbar ≤600px or a real phone): `/music` gigs table shows Date/Location/Venue and fits without horizontal blowout; admin users table scrolls within its box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)