### PR TITLE
fix(dark-mode): MUI dark palette + legible gigs/admin tables; responsive admin users; drop dead nav

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,9 @@ typings/
 
 .yarn
 yarn.lock
+
+# Playwright
+/test-results
+/playwright-report
+/blob-report
+/playwright/.cache

--- a/e2e/dark-mode.spec.ts
+++ b/e2e/dark-mode.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+
+// The site stores its theme in localStorage (applied as a data-theme attribute
+// on <html>), NOT via prefers-color-scheme — so seed localStorage before the
+// app boots to exercise the real dark mode.
+test.beforeEach(async ({ context }) => {
+  await context.addInitScript(() => {
+    try { localStorage.setItem('theme', 'dark'); } catch { /* ignore */ }
+  });
+});
+
+const isWhite = (c: string): boolean => /rgba?\(\s*255,\s*255,\s*255/.test(c);
+
+test('gigs table is legible in dark mode on a phone', async ({ page }) => {
+  await page.goto('/music', { waitUntil: 'networkidle' });
+
+  await expect
+    .poll(() => page.evaluate(() => document.documentElement.getAttribute('data-theme')))
+    .toBe('dark');
+
+  const grid = page.locator('.MuiDataGrid-root').first();
+  await grid.scrollIntoViewIfNeeded();
+  await expect(grid).toBeVisible();
+
+  // The regression: MUI X DataGrid renders its own light-palette WHITE surfaces
+  // (header / footer / even rows) while text uses the light --fg token, making
+  // rows invisible in dark mode. None of these surfaces may be white.
+  for (const sel of [
+    '.MuiDataGrid-columnHeaders',
+    '.MuiDataGrid-footerContainer',
+    '.MuiDataGrid-row',
+  ]) {
+    const bg = await page.locator(sel).first()
+      .evaluate((el) => getComputedStyle(el).backgroundColor);
+    expect(isWhite(bg), `${sel} must not be white in dark mode (got ${bg})`).toBe(false);
+  }
+});
+
+test('music page has no horizontal overflow on a phone', async ({ page }) => {
+  await page.goto('/music', { waitUntil: 'networkidle' });
+  const overflow = await page.evaluate(() => {
+    const el = document.scrollingElement || document.documentElement;
+    return el.scrollWidth - el.clientWidth;
+  });
+  expect(overflow, `unexpected horizontal overflow of ${overflow}px`).toBeLessThanOrEqual(2);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jammusic",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jammusic",
-      "version": "2.7.3",
+      "version": "2.7.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -57,6 +57,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "^1.60.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@vitest/coverage-v8": "^4.1.7",
@@ -1967,6 +1968,22 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@popperjs/core": {
@@ -8045,6 +8062,53 @@
       ],
       "dependencies": {
         "media-chrome": "~4.19.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.7.4",
+  "version": "2.7.5",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {
@@ -28,6 +28,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
+    "test:e2e": "playwright test",
+    "test:e2e:install": "playwright install chromium",
     "typecheck": "tsc --noEmit",
     "test:stylelint": "stylelint \"src/styles/**/*.scss\"",
     "lint:fix": "eslint . --fix",
@@ -90,6 +92,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.60.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@vitest/coverage-v8": "^4.1.7",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Runs against a deployed/served URL. Override with BASE_URL for staging or a
+// local `npm run preview`. Defaults to production so the dark-mode + mobile
+// regression guard is runnable out of the box.
+const baseURL = process.env.BASE_URL || 'https://www.web-jam.com';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  fullyParallel: true,
+  retries: process.env.CI ? 1 : 0,
+  reporter: 'list',
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+  },
+  projects: [
+    { name: 'mobile-dark', use: { ...devices['Pixel 5'] } },
+  ],
+});

--- a/src/App/AppTemplate/menuConfig.ts
+++ b/src/App/AppTemplate/menuConfig.ts
@@ -52,12 +52,6 @@ const wjNav = [
     nav: 'wj', className: 'tipjar', type: 'link', iconClass: 'fab fa-gratipay', link: '/music/tipjar', name: 'Tip Jar',
   },
   {
-    nav: 'wj', className: '', type: 'link', iconClass: 'fas fa-map-marker', link: '/map', name: 'Map', auth: true,
-  },
-  {
-    nav: 'wj', className: '', type: 'link', iconClass: 'fas fa-sort', link: '/sort', name: 'Sort', auth: true,
-  },
-  {
     nav: 'wj', className: '', type: 'link', iconClass: 'fas fa-users-cog', link: '/admin/users', name: 'Admin Users', auth: true,
   },
   {

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -9,6 +9,7 @@ import store from './redux/store/index';
 import { DataProvider } from './providers/Data.provider';
 import { AuthProvider } from './providers/Auth.provider';
 import { ThemeProvider } from './providers/Theme.provider';
+import { MuiThemeProvider } from './providers/MuiThemeProvider';
 import './styles/styles.scss';
 
 const root = createRoot(document.getElementById('root') as HTMLElement);
@@ -16,15 +17,17 @@ function Main() {
   return (
     <GoogleOAuthProvider clientId={process.env.GoogleClientId || ''}>
       <ThemeProvider>
-        <AuthProvider>
-          <DataProvider>
-            <Provider store={store.store}>
-              <PersistGate loading={null} persistor={store.persistor}>
-                <App />
-              </PersistGate>
-            </Provider>
-          </DataProvider>
-        </AuthProvider>
+        <MuiThemeProvider>
+          <AuthProvider>
+            <DataProvider>
+              <Provider store={store.store}>
+                <PersistGate loading={null} persistor={store.persistor}>
+                  <App />
+                </PersistGate>
+              </Provider>
+            </DataProvider>
+          </AuthProvider>
+        </MuiThemeProvider>
       </ThemeProvider>
     </GoogleOAuthProvider>
   );

--- a/src/containers/AdminUsers/index.tsx
+++ b/src/containers/AdminUsers/index.tsx
@@ -45,7 +45,9 @@ export function AdminUsers() {
   }
 
   return (
-    <Box sx={{ padding: 3, maxWidth: 1200, margin: 'auto' }} data-testid="admin-users-page">
+    <Box sx={{
+      padding: 3, maxWidth: 1200, margin: 'auto', width: '100%', minWidth: 0,
+    }} data-testid="admin-users-page">
       <Typography variant="h5" sx={{ marginBottom: 2 }}>Admin Users</Typography>
       <CreateUserForm token={auth.token} onCreated={refresh} />
       {loading && <Typography data-testid="admin-users-loading">Loading...</Typography>}

--- a/src/containers/Music/Gigs/gigs.scss
+++ b/src/containers/Music/Gigs/gigs.scss
@@ -19,8 +19,26 @@
   border-color: var(--table-border) !important;
 }
 
+/* MUI X DataGrid v9 paints its own (light-palette) white background on the
+   header, base rows, footer, scroller and filler elements — MUI's theme is
+   never switched to dark, so in our data-theme="dark" mode those surfaces
+   stayed white while the text used the light --fg → illegible. Force every
+   surface onto the table tokens so it's correct in both themes. */
+.MuiDataGrid-root .MuiDataGrid-columnHeaders,
+.MuiDataGrid-root .MuiDataGrid-columnHeader,
+.MuiDataGrid-root .MuiDataGrid-columnHeaderTitleContainer,
+.MuiDataGrid-root .MuiDataGrid-virtualScroller,
+.MuiDataGrid-root .MuiDataGrid-row,
+.MuiDataGrid-root .MuiDataGrid-filler,
+.MuiDataGrid-root .MuiDataGrid-scrollbarFiller,
+.MuiDataGrid-root .MuiDataGrid-footerContainer,
+.MuiDataGrid-root .MuiTablePagination-root,
+.MuiDataGrid-root .MuiTablePagination-toolbar {
+  background-color: var(--table-bg) !important;
+}
+
 .MuiDataGrid-root .MuiDataGrid-row:nth-of-type(odd) {
-  background-color: var(--table-row-alt-bg);
+  background-color: var(--table-row-alt-bg) !important;
 }
 
 /* MUI DataGrid v5 sets cell/header/pagination text via the MUI theme,

--- a/src/containers/Music/Pictures/PicSlider/caption.tsx
+++ b/src/containers/Music/Pictures/PicSlider/caption.tsx
@@ -9,7 +9,8 @@ function Caption(props: { caption?: string }) {
         fontWeight: 600,
         padding: '15px 0',
         boxShadow: '0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12), 0 2px 4px -1px rgba(0, 0, 0, 0.14)',
-        backgroundColor: '#fff',
+        backgroundColor: 'var(--bg)',
+        color: 'var(--fg)',
         marginBottom: '10px',
       }}
     >

--- a/src/providers/MuiThemeProvider.tsx
+++ b/src/providers/MuiThemeProvider.tsx
@@ -1,0 +1,25 @@
+import React, { useContext, useMemo } from 'react';
+import { ThemeProvider as MuiProvider, createTheme } from '@mui/material/styles';
+import { ThemeContext } from './Theme.provider';
+
+/**
+ * Bridges our custom CSS-variable theme (data-theme attribute) into MUI.
+ * Without this, MUI components always render with the default LIGHT palette —
+ * so in dark mode checkbox boxes, labels, chips and table text stay
+ * black-on-dark and are illegible. Syncing palette.mode to our theme makes
+ * every MUI component respect dark mode. Surfaces/text are pinned to the same
+ * hex values as our --bg/--table-bg/--fg tokens in _theme.scss for consistency.
+ */
+export function MuiThemeProvider({ children }: { children?: React.ReactNode }): React.JSX.Element {
+  const { theme } = useContext(ThemeContext);
+  const muiTheme = useMemo(() => createTheme({
+    palette: theme === 'dark'
+      ? {
+        mode: 'dark',
+        background: { default: '#121212', paper: '#1c1c1c' },
+        text: { primary: '#e8e8e8' },
+      }
+      : { mode: 'light' },
+  }), [theme]);
+  return <MuiProvider theme={muiTheme}>{children}</MuiProvider>;
+}

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -166,6 +166,27 @@ th, td {
   text-align: left;
 }
 
+/* MUI <Table> (e.g. Admin Users) — MUI's palette is never switched to dark, so
+   MuiTableCell text defaults to the light-palette near-black color and is
+   illegible on our dark surfaces. Pin the table surface + cell/header text and
+   borders onto the theme tokens so it's correct in both light and dark. */
+.MuiTable-root {
+  background-color: var(--table-bg);
+}
+
+.MuiTableCell-root {
+  color: var(--fg) !important;
+  border-color: var(--table-border) !important;
+}
+
+/* Default (no-color) MUI Chips use a translucent-black fill + dark text — both
+   vanish on dark surfaces (Admin Users "Type"/"Privileges" columns). Outlined
+   coloured chips (e.g. "Role") are fine, so only the default filled chip. */
+.MuiChip-filled.MuiChip-colorDefault {
+  background-color: var(--table-row-alt-bg);
+  color: var(--fg);
+}
+
 tbody.regformtbody td,
 tbody.regformtbody th {
   border: none;


### PR DESCRIPTION
**Draft** — opened for review; not deployed. Builds on the responsive mobile fixes already merged (#1060/#1061).

## Root cause: no MUI theme
The app themes via a `data-theme` attribute + CSS variables, but there was **no MUI `createTheme`/`ThemeProvider` at all** — the only ThemeProvider was the custom CSS-var one. So every MUI component rendered the default **light** palette (white/near-black surfaces) regardless of dark mode. CSS patches fixed one symptom at a time; the real fix is systemic.

## Fixes
- **`MuiThemeProvider.tsx` (new)** + `Main.tsx`: wrap the app in an MUI `ThemeProvider` whose `palette.mode` is synced to our `data-theme`. Fixes the gigs DataGrid, the Admin Users table, **checkbox boxes**, form labels, and chips in dark mode in one shot.
- **`gigs.scss` / `caption.tsx`**: DataGrid surfaces + PicSlider captions pinned to `--table-bg`/`--bg`/`--fg` tokens (carried from earlier; belt-and-suspenders with the MUI theme).
- **`AdminUsers/index.tsx`**: page Box `width:100%` + `minWidth:0` so it no longer shrink-wraps to the users table's `minWidth:720` — on phones the page fits the viewport and the table scrolls inside its own `overflowX:auto` wrapper (was running off-screen, unscrollable).
- **`menuConfig.ts`**: remove orphaned **Sort** and **Map** side-menu items (no `/sort` or `/map` routes exist; they redirected home).

## Playwright
`@playwright/test` + `playwright.config.ts` (Pixel 5) + `e2e/dark-mode.spec.ts` (seeds `localStorage.theme='dark'`, asserts no white DataGrid surfaces + no mobile horizontal overflow). Scripts `test:e2e` / `test:e2e:install`.

## Verification
Lint + stylelint + `tsc` clean; **246/246 unit tests pass** (TZ=UTC). Dark-mode + admin mobile layout verified via Playwright screenshots at 390/667/1334px.

## How to Test Locally
\`\`\`bash
git checkout fix-mobile-table-layout
npm install
npm test            # 246 unit tests
npm run build
npm run dev         # vite on http://localhost:7878
\`\`\`
Then, with the site toggled to **dark mode** (Dark Reader OFF):
- `/music` — gigs table + picture captions are legible.
- `/admin/users` (sign in as an admin) — Create-User form, **checkboxes**, chips, and users table are all readable; on a phone width (or DevTools device toolbar) the page fits the screen and the users table scrolls horizontally rather than running off-page.
- Side menu no longer shows **Sort** or **Map**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)