### PR TITLE
fix(gigs): center cell text vertically + reduce row height

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jammusic",
-  "version": "2.7.4",
+  "version": "2.7.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jammusic",
-      "version": "2.7.4",
+      "version": "2.7.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.7.5",
+  "version": "2.7.6",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/Music/Gigs/gigs.scss
+++ b/src/containers/Music/Gigs/gigs.scss
@@ -87,10 +87,18 @@
   margin-left: 14px;
 }
 
+/* Rows use getRowHeight=auto so long venue/location text can wrap on phones.
+   Auto-height cells top-align their content, which left single-line cells
+   sitting at the top of tall rows (looked misaligned). Center vertically and
+   trim the vertical padding so rows are as short as their content allows. */
 .MuiDataGrid-root .MuiDataGrid-cell {
   white-space: normal !important;
   overflow-wrap: break-word !important;
   border-color: var(--table-border) !important;
+  display: flex;
+  align-items: center;
+  padding-top: 4px !important;
+  padding-bottom: 4px !important;
 }
 
 .bookUsButton{

--- a/src/containers/Music/Pictures/editPicTable.scss
+++ b/src/containers/Music/Pictures/editPicTable.scss
@@ -1,5 +1,10 @@
-.MuiDataGrid-cell, .MuiDataGrid-row {
+/* Scoped to the pictures grid only — CSS imports are global, so an unscoped
+   .MuiDataGrid-cell/.row rule here was forcing every DataGrid on the site
+   (including the gigs table) to a fixed 100px row height. */
+.editPicTable {
+  .MuiDataGrid-cell, .MuiDataGrid-row {
     min-height: 100px !important;
     max-height: 100px !important;
     cursor:pointer;
+  }
 }


### PR DESCRIPTION
## What
The gigs table cells were too tall and their text was top-aligned instead of centered.

Two fixes:
- **[gigs.scss](src/containers/Music/Gigs/gigs.scss)** — gig cells now `display: flex; align-items: center` with `4px` top/bottom padding, so text is vertically centered in the middle of each cell.
- **[editPicTable.scss](src/containers/Music/Pictures/editPicTable.scss)** — scoped the fixed `100px` min/max-height rule under `.editPicTable`. CSS imports are global, so the previously unscoped `.MuiDataGrid-cell/.row` rule was forcing **every** DataGrid on the site (including gigs) to a hard 100px row height. The pictures grid keeps its 100px rows; the gigs grid now sizes to content.

## Result
Gig rows shrink from a fixed 100px to ~29px on desktop (content-driven), text vertically centered. On mobile, rows are only as tall as needed for the Location to wrap, with single-line cells centered.

## How to Test Locally
1. Start the backend so gig data loads:
   ```
   cd ../WebJamSocketCluster && npm run dev
   ```
2. In another terminal, start the frontend:
   ```
   git checkout fix-mobile-table-layout
   npm run dev
   ```
3. Open http://localhost:7878/music and scroll to the Gigs table.
4. Confirm: rows are compact (not the old tall 100px), and each cell's text is vertically centered. Resize to a phone width (≤600px) and confirm the wrapped "City, State" cells still look centered.
5. Open the admin Pictures edit table (Edit Pictures) and confirm its rows are still the intended 100px with thumbnails.