### PR TITLE
ci: dispatch backend redeploys when JaMmusic merges to main (Task 195b dispatcher)

### DIFF
--- a/.github/workflows/notify-backends.yml
+++ b/.github/workflows/notify-backends.yml
@@ -1,0 +1,23 @@
+name: Notify backends on main update
+
+# When JaMmusic merges to main, fan out a repository_dispatch to each Heroku
+# backend so they rebuild and re-embed the latest JaMmusic main (via their
+# postinstallJaM step). Each backend's own workflow does the Heroku redeploy.
+on:
+  push:
+    branches: [main]
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo: [web-jam-back, WebJamSocketCluster]
+    steps:
+      - name: repository_dispatch -> ${{ matrix.repo }}
+        run: |
+          curl -fsS -X POST \
+            https://api.github.com/repos/WebJamApps/${{ matrix.repo }}/dispatches \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.DISPATCH_TOKEN }}" \
+            -d '{"event_type":"jammusic-main-deploy","client_payload":{"sha":"${{ github.sha }}"}}'

--- a/README.md
+++ b/README.md
@@ -11,3 +11,27 @@
 * This is a React frontend project that requires both `web-jam-back` and `WebJamSocketCluster` to fully display applicable data and have interations to backend resourses.
 * Copy the `.env.example` file and paste it as `.env` file in the project root directory. Request variable definitions from the project owner or spin up your own resourses where applicable.
 * More information is available in our [Developer's Guide](https://docs.google.com/document/d/1_QDDbqmBrJuGqBoib59fmgYtls03dAXXuLqRR5roPO4/edit).
+
+## Deployment
+
+JaMmusic is a static SPA with no server of its own. It is built **into** two Heroku apps at build time — each backend's `postinstallJaM.sh` clones JaMmusic and checks out `main` (or `dev` for non-prod builds):
+
+* **`webjamsalem`** (repo `web-jam-back`) → serves <https://web-jam.com>
+* **`webjamsocket`** (repo `WebJamSocketCluster`) → serves <https://joshandmariamusic.com>
+
+Because Heroku only watches each backend's own repo, a JaMmusic merge would **not** redeploy them on its own. A GitHub Actions fan-out closes that gap:
+
+1. **JaMmusic** — `.github/workflows/notify-backends.yml` fires on push to `main` and sends a `repository_dispatch` (`jammusic-main-deploy`) to both backend repos.
+2. **Each backend** — `.github/workflows/redeploy-on-jammusic.yml` receives that event and calls the Heroku Platform API to rebuild its app from the current `main` tarball, which re-runs `postinstallJaM` and re-embeds the latest JaMmusic.
+
+### Required secrets
+
+These power the chain above and must be set as repo secrets (none are committed):
+
+| Repo | Secret | Purpose |
+| --- | --- | --- |
+| JaMmusic | `DISPATCH_TOKEN` | GitHub fine-grained PAT with **Contents: Read & write** on `web-jam-back` + `WebJamSocketCluster`; lets the dispatcher send `repository_dispatch` to them (GitHub → GitHub). |
+| web-jam-back | `HEROKU_API_KEY` | Heroku API token authorized for `webjamsalem`; triggers its rebuild (GitHub → Heroku). |
+| WebJamSocketCluster | `HEROKU_API_KEY` | Heroku API token authorized for `webjamsocket`; triggers its rebuild (GitHub → Heroku). |
+
+Either backend's receiver can also be run by hand from its **Actions** tab (`workflow_dispatch`) to force a redeploy.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jammusic",
-  "version": "2.7.14",
+  "version": "2.7.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jammusic",
-      "version": "2.7.14",
+      "version": "2.7.15",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.7.14",
+  "version": "2.7.15",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {


### PR DESCRIPTION
## What

Adds `.github/workflows/notify-backends.yml`. On every push to `main`, it fans out a `repository_dispatch` (`jammusic-main-deploy`) to **web-jam-back** and **WebJamSocketCluster**, whose receiver workflows then rebuild their Heroku apps so the embedded JaMmusic frontend stays current.

This is the **dispatcher** half of the Task 195(b) fan-out. Receivers: web-jam-back#775, WebJamSocketCluster#223.

Coexists with CircleCI (this only fires post-merge to `main`; CI is unchanged).

## Required secret (add before this does anything)

- `DISPATCH_TOKEN` — a PAT with permission to send repository_dispatch to the two backend repos (fine-grained: **Contents: Read & write** on web-jam-back + WebJamSocketCluster; or classic PAT with `repo` scope).

## How to Test Locally

Runs on GitHub's runners; validate + dry-run:

```bash
# 1. Validate the workflow YAML
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/notify-backends.yml')); print('valid')"

# 2. After this + both receivers merge and all secrets are set, do a real
#    end-to-end test by merging any trivial change to JaMmusic main, then watch:
gh run list -R WebJamApps/JaMmusic --workflow "Notify backends on main update"
gh run list -R WebJamApps/web-jam-back --workflow "Redeploy on JaMmusic main update"
gh run list -R WebJamApps/WebJamSocketCluster --workflow "Redeploy on JaMmusic main update"

# 3. Confirm new Heroku builds (requires Heroku auth — your call):
#    heroku builds -a webjamsalem   |   heroku builds -a webjamsocket
```

Closes #1071.

🤖 Generated with [Claude Code](https://claude.com/claude-code)