### PR TITLE
fix(admin): drop public-read capabilities (tour/song/book :read)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jammusic",
-  "version": "2.7.15",
+  "version": "2.7.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jammusic",
-      "version": "2.7.15",
+      "version": "2.7.16",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.7.15",
+  "version": "2.7.16",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/AdminUsers/capabilities.ts
+++ b/src/containers/AdminUsers/capabilities.ts
@@ -1,13 +1,10 @@
 export const CAPABILITIES = [
-  'tour:read',
   'tour:create',
   'tour:edit',
   'tour:delete',
-  'song:read',
   'song:create',
   'song:edit',
   'song:delete',
-  'book:read',
   'book:create',
   'book:edit',
   'book:delete',
@@ -16,9 +13,9 @@ export const CAPABILITIES = [
 export type Capability = (typeof CAPABILITIES)[number];
 
 export const CAPABILITY_GROUPS: { label: string; items: Capability[] }[] = [
-  { label: 'Tours', items: ['tour:read', 'tour:create', 'tour:edit', 'tour:delete'] },
-  { label: 'Songs', items: ['song:read', 'song:create', 'song:edit', 'song:delete'] },
-  { label: 'Books', items: ['book:read', 'book:create', 'book:edit', 'book:delete'] },
+  { label: 'Tours', items: ['tour:create', 'tour:edit', 'tour:delete'] },
+  { label: 'Songs', items: ['song:create', 'song:edit', 'song:delete'] },
+  { label: 'Books', items: ['book:create', 'book:edit', 'book:delete'] },
 ];
 
 export const USER_STATUS_OPTIONS = ['human', 'ai-agent'] as const;

--- a/test/containers/AdminUsers/EditPrivilegesDialog.spec.tsx
+++ b/test/containers/AdminUsers/EditPrivilegesDialog.spec.tsx
@@ -20,7 +20,7 @@ describe('EditPrivilegesDialog', () => {
       );
     });
     expect(screen.getByRole('checkbox', { name: /tour:create/i })).toBeChecked();
-    expect(screen.getByRole('checkbox', { name: /song:read/i })).not.toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /song:create/i })).not.toBeChecked();
   });
 
   it('saves and calls onSaved', async () => {
@@ -49,7 +49,7 @@ describe('EditPrivilegesDialog', () => {
 
   it('toggles a capability checkbox', async () => {
     render(<EditPrivilegesDialog open user={user} token="tk" onClose={vi.fn()} onSaved={vi.fn()} />);
-    const cap = screen.getByRole('checkbox', { name: /song:read/i });
+    const cap = screen.getByRole('checkbox', { name: /song:create/i });
     await act(async () => { fireEvent.click(cap); });
     expect(cap).toBeChecked();
   });

--- a/test/containers/AdminUsers/capabilities.spec.tsx
+++ b/test/containers/AdminUsers/capabilities.spec.tsx
@@ -3,12 +3,18 @@ import { CAPABILITIES, CAPABILITY_GROUPS, USER_STATUS_OPTIONS } from 'src/contai
 describe('AdminUsers capabilities registry', () => {
   it('includes tour, song, and book capabilities', () => {
     expect(CAPABILITIES).toContain('tour:create');
-    expect(CAPABILITIES).toContain('song:read');
+    expect(CAPABILITIES).toContain('song:create');
     expect(CAPABILITIES).toContain('book:delete');
   });
 
   it('does not include user:* capabilities', () => {
     for (const c of CAPABILITIES) expect(c.startsWith('user:')).toBe(false);
+  });
+
+  // tour/song/book reads are public & unauthenticated, so a read privilege
+  // gates nothing; the backend registry omits them too.
+  it('does not include any :read capabilities', () => {
+    for (const c of CAPABILITIES) expect(c.endsWith(':read')).toBe(false);
   });
 
   it('CAPABILITY_GROUPS covers every capability exactly once', () => {


### PR DESCRIPTION
## What

The Admin Users privilege picker offered `tour:read`, `song:read`, and `book:read`. But all three read paths are **public and unauthenticated**:

- Tours → SocketCluster `allTours` push (no token) — `sendTours` in WebJamSocketCluster
- Books → SocketCluster `allBooks` push (no token) — `sendBooks`
- Songs → REST `GET /song` list calls `controller.find` directly (no auth wrapper)

A read privilege can never gate those — there's no token in the request to check against. And selecting one **400'd** in production (`invalid capability` / the picker diverged from the backend registry, which correctly has no `:read` caps).

So this removes the three `:read` capabilities from the frontend registry + `CAPABILITY_GROUPS`. The write caps (`create`/`edit`/`delete`) stay — those operations are authenticated and legitimately gateable.

A companion **web-jam-back** PR removes `song:read` / `book:read` from the backend registry so the two stay in sync.

## How to Test Locally

```bash
npm ci
npm run typecheck
TZ=UTC npx vitest run test/containers/AdminUsers
npm run test:lint
```
All green. New test asserts no `:read` capability exists in the registry. Manually: open `/admin/users`, edit a user's privileges — the Tours/Songs/Books rows no longer show a "read" checkbox, and saving no longer 400s on a read cap.

Part of Task 5 (promote-gig) admin-UI hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)