### PR TITLE
feat(gig): frontend tour->gig rename + duration & promo thumbnail (Phase 3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jammusic",
-  "version": "2.7.16",
+  "version": "2.7.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jammusic",
-      "version": "2.7.16",
+      "version": "2.7.17",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.7.16",
+  "version": "2.7.17",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/AdminUsers/capabilities.ts
+++ b/src/containers/AdminUsers/capabilities.ts
@@ -1,7 +1,7 @@
 export const CAPABILITIES = [
-  'tour:create',
-  'tour:edit',
-  'tour:delete',
+  'gig:create',
+  'gig:edit',
+  'gig:delete',
   'song:create',
   'song:edit',
   'song:delete',
@@ -13,7 +13,7 @@ export const CAPABILITIES = [
 export type Capability = (typeof CAPABILITIES)[number];
 
 export const CAPABILITY_GROUPS: { label: string; items: Capability[] }[] = [
-  { label: 'Tours', items: ['tour:create', 'tour:edit', 'tour:delete'] },
+  { label: 'Gigs', items: ['gig:create', 'gig:edit', 'gig:delete'] },
   { label: 'Songs', items: ['song:create', 'song:edit', 'song:delete'] },
   { label: 'Books', items: ['book:create', 'book:edit', 'book:delete'] },
 ];

--- a/src/containers/Music/Gigs/CreateGigDialog.tsx
+++ b/src/containers/Music/Gigs/CreateGigDialog.tsx
@@ -24,6 +24,8 @@ export function CreateGigDialog({
   const [city, setCity] = useState('');
   const [usState, setUSstate] = useState('Virginia');
   const [tickets, setTickets] = useState('');
+  const [duration, setDuration] = useState(0);
+  const [promoImageUrl, setPromoImageUrl] = useState('');
   return (
     <Dialog
       disableEnforceFocus
@@ -95,6 +97,22 @@ export function CreateGigDialog({
           value={tickets}
           onChange={(evt) => { setTickets(evt.target.value); return evt.target.value; }}
         />
+        <TextField
+          sx={{ marginTop: '20px' }}
+          label="Duration (hours)"
+          type="number"
+          fullWidth
+          value={duration}
+          onChange={(evt) => { setDuration(Number(evt.target.value)); return evt.target.value; }}
+        />
+        <TextField
+          sx={{ marginTop: '20px' }}
+          label="Promo image URL"
+          type="text"
+          fullWidth
+          value={promoImageUrl}
+          onChange={(evt) => { setPromoImageUrl(evt.target.value); return evt.target.value; }}
+        />
       </DialogContent>
       <DialogActions>
         <Button
@@ -102,7 +120,7 @@ export function CreateGigDialog({
           size="small"
           variant="contained"
           className="createGigButton"
-          onClick={() => { utils.createGig(getGigs, setShowDialog, dateTime, venue, city, usState, tickets, auth); }}
+          onClick={() => { utils.createGig(getGigs, setShowDialog, dateTime, venue, city, usState, tickets, auth, duration, promoImageUrl); }}
         >
           Create
         </Button>

--- a/src/containers/Music/Gigs/EditGigDialog.tsx
+++ b/src/containers/Music/Gigs/EditGigDialog.tsx
@@ -156,6 +156,22 @@ export function EditGigDialog(props: IeditGigDialogProps) {
         <EditText objKey="city" editGig={editGig} setEditChanged={setEditChanged} setEditGig={setEditGig} required />
         <UsStateDropDown editGig={editGig} setEditChanged={setEditChanged} setEditGig={setEditGig} />
         <EditText objKey="tickets" editGig={editGig} setEditChanged={setEditChanged} setEditGig={setEditGig} required={false} />
+        <TextField
+          label="Duration (hours)"
+          type="number"
+          fullWidth
+          sx={{ marginTop: '20px' }}
+          value={editGig.duration ?? 0}
+          onChange={(evt) => { setEditChanged(true); setEditGig({ ...editGig, duration: Number(evt.target.value) }); }}
+        />
+        <TextField
+          label="Promo image URL"
+          type="text"
+          fullWidth
+          sx={{ marginTop: '20px' }}
+          value={editGig.promoImageUrl ?? ''}
+          onChange={(evt) => { setEditChanged(true); setEditGig({ ...editGig, promoImageUrl: evt.target.value }); }}
+        />
       </DialogContent>
       <ButtonsSection
         editGig={editGig}

--- a/src/containers/Music/Gigs/gigs.utils.tsx
+++ b/src/containers/Music/Gigs/gigs.utils.tsx
@@ -18,11 +18,13 @@ const createGig = async (
   usState: string,
   tickets: string,
   auth: Iauth,
+  duration: number,
+  promoImageUrl: string,
 ) => {
   try {
     const { token } = auth;
-    const tour = {
-      datetime, venue, tickets, city, usState,
+    const gig = {
+      datetime, venue, tickets, city, usState, duration, promoImageUrl,
     };
     const socket = scc.create({
       hostname: process.env.SCS_HOST,
@@ -30,7 +32,7 @@ const createGig = async (
       autoConnect: true,
       secure: process.env.SOCKETCLUSTER_SECURE !== 'false',
     });
-    socket.transmit('newTour', { tour, token });
+    socket.transmit('newGig', { gig, token });
     setShowDialog(false);
     await commonUtils.delay(2);
     getGigs();
@@ -45,18 +47,18 @@ const updateGig = async (
   token: string,
 ) => {
   try {
-    const tour: Igig = { ...editGig };
-    delete tour.date;
-    delete tour.time;
-    delete tour.location;
-    delete tour._id;
+    const gig: Igig = { ...editGig };
+    delete gig.date;
+    delete gig.time;
+    delete gig.location;
+    delete gig._id;
     const socket = scc.create({
       hostname: process.env.SCS_HOST,
       port: Number(process.env.SCS_PORT),
       autoConnect: true,
       secure: process.env.SOCKETCLUSTER_SECURE !== 'false',
     });
-    socket.transmit('editTour', { tourId: editGig._id, tour, token });
+    socket.transmit('editGig', { gigId: editGig._id, gig, token });
     setEditGig(defaultGig);
     setEditChanged(false);
     await commonUtils.delay(2);
@@ -85,7 +87,7 @@ const checkUpdateDisabled = (editGig: GridRowParams['row'], editChanged: boolean
 };
 
 async function deleteGig(
-  tourId: string,
+  gigId: string,
   getGigs: () => void,
   setEditGig: (arg0: typeof defaultGig) => void,
   setEditChanged: (arg0: boolean) => void,
@@ -100,8 +102,8 @@ async function deleteGig(
         autoConnect: true,
         secure: process.env.SOCKETCLUSTER_SECURE !== 'false',
       });
-      const tour = { tourId };
-      socket.transmit('deleteTour', { tour, token });
+      const gig = { gigId };
+      socket.transmit('deleteGig', { gig, token });
       await commonUtils.delay(2);
       setEditGig(defaultGig);
       setEditChanged(false);
@@ -153,6 +155,15 @@ const makeShortDateValue = (datetime: string) => new Date(datetime)
 const makeTimeValue = (datetime: string) => new Date(datetime)
   .toLocaleString('en-US', { hour: 'numeric', minute: '2-digit' });
 
+// With a duration (hours) the Time column becomes a range "8:00 AM to 5:00 PM";
+// with no duration it stays the start time alone.
+const makeTimeRange = (datetime: string, duration?: number) => {
+  const start = makeTimeValue(datetime);
+  if (!duration || duration <= 0) return start;
+  const end = new Date(new Date(datetime).getTime() + duration * 60 * 60 * 1000);
+  return `${start} to ${makeTimeValue(end.toISOString())}`;
+};
+
 const makeVenueValue = (value: string) => {
   const parsed = HtmlReactParser(value);
   if (value === 'Our Past Performances') return <span className="ourPastPerformances">{parsed}</span>;
@@ -177,6 +188,7 @@ export default {
   makeDateValue,
   makeShortDateValue,
   makeTimeValue,
+  makeTimeRange,
   createGig,
   updateGig,
   clickToEdit,

--- a/src/containers/Music/Gigs/index.tsx
+++ b/src/containers/Music/Gigs/index.tsx
@@ -31,12 +31,12 @@ export const makeColumns = (isMobile = false): GridColDef[] => {
   const timeCol: GridColDef = {
     field: 'time',
     headerName: 'Time',
-    width: 90,
+    width: isMobile ? 140 : 170,
     editable: false,
     renderCell: (params: GridRenderCellParams) => {
-      const { row: { datetime } } = params;
+      const { row: { datetime, duration } } = params;
       if (!datetime) return '';
-      return utils.makeTimeValue(datetime);
+      return utils.makeTimeRange(datetime, duration);
     },
   };
   const locationCol: GridColDef = {
@@ -60,8 +60,30 @@ export const makeColumns = (isMobile = false): GridColDef[] => {
     editable: false,
     renderCell: (params: GridRenderCellParams) => <span>{HtmlReactParser(params.value || 'Free')}</span>,
   };
-  // Apply the requested column order for both mobile and desktop.
-  return [dateCol, timeCol, utils.makeVenue(isMobile), locationCol, ticketsCol];
+  const photoCol: GridColDef = {
+    field: 'promoImageUrl',
+    headerName: 'Photo',
+    width: 90,
+    sortable: false,
+    editable: false,
+    renderCell: (params: GridRenderCellParams) => {
+      const { row: { promoImageUrl } } = params;
+      if (!promoImageUrl) return '';
+      // Static thumbnail; the onClick only stops the click bubbling so it never
+      // opens the row's edit dialog (the thumbnail itself does nothing).
+      return (
+        // eslint-disable-next-line jsx-a11y-x/click-events-have-key-events, jsx-a11y-x/no-noninteractive-element-interactions
+        <img
+          src={promoImageUrl}
+          alt="gig promo"
+          style={{ height: '40px', width: 'auto', objectFit: 'contain' }}
+          onClick={(e) => e.stopPropagation()}
+        />
+      );
+    },
+  };
+  // Apply the requested column order for both mobile and desktop (photo far right).
+  return [dateCol, timeCol, utils.makeVenue(isMobile), locationCol, ticketsCol, photoCol];
 };
 
 // Backwards-compatible default (desktop) export.

--- a/src/providers/Data.provider.tsx
+++ b/src/providers/Data.provider.tsx
@@ -17,6 +17,8 @@ export interface Igig {
   id?: number;
   city?: string;
   usState?: string;
+  duration?: number;
+  promoImageUrl?: string;
 }
 
 export interface Isong {

--- a/src/providers/fetchGigs.tsx
+++ b/src/providers/fetchGigs.tsx
@@ -12,10 +12,12 @@ export const defaultGig: Igig = {
   city: '',
   usState: 'Virginia',
   id: 0,
+  duration: 0,
+  promoImageUrl: '',
 };
 
 const getGigs = (
   setGigs: (_arg0: Igig[] | null) => void,
-): boolean => socketClusterMessages.initialMessage(setGigs, 'allTours');
+): boolean => socketClusterMessages.initialMessage(setGigs, 'allGigs');
 
 export default { getGigs };

--- a/src/redux/store/index.ts
+++ b/src/redux/store/index.ts
@@ -8,7 +8,7 @@ import allReducers from '../allReducers';
 const persistConfig = {
   key: 'root',
   storage: storageSession,
-  blacklist: ['sc', 'tour', 'image'],
+  blacklist: ['sc', 'gig', 'image'],
 };
 let mWares = applyMiddleware(thunk);
 /* istanbul ignore if */

--- a/src/styles/_music.scss
+++ b/src/styles/_music.scss
@@ -22,7 +22,7 @@ td p a {
   font-size: inherit
 }
 
-.tourTable {
+.gigTable {
   -webkit-overflow-scrolling: touch;
 }
 

--- a/test/containers/AdminUsers/CreateUserForm.spec.tsx
+++ b/test/containers/AdminUsers/CreateUserForm.spec.tsx
@@ -35,7 +35,7 @@ describe('CreateUserForm', () => {
 
   it('toggles a privilege checkbox', async () => {
     render(<CreateUserForm token="tk" onCreated={vi.fn()} />);
-    const cap = screen.getByRole('checkbox', { name: /tour:create/i });
+    const cap = screen.getByRole('checkbox', { name: /gig:create/i });
     await act(async () => { fireEvent.click(cap); });
     expect(cap).toBeChecked();
     await act(async () => { fireEvent.click(cap); });

--- a/test/containers/AdminUsers/EditPrivilegesDialog.spec.tsx
+++ b/test/containers/AdminUsers/EditPrivilegesDialog.spec.tsx
@@ -5,7 +5,7 @@ import { EditPrivilegesDialog } from 'src/containers/AdminUsers/EditPrivilegesDi
 import adminUtils, { type IadminUser } from 'src/containers/AdminUsers/admin-users.utils';
 
 const user: IadminUser = {
-  _id: 'u1', name: 'Bot', email: 'b@x.com', privileges: ['tour:create'],
+  _id: 'u1', name: 'Bot', email: 'b@x.com', privileges: ['gig:create'],
 };
 
 describe('EditPrivilegesDialog', () => {
@@ -19,7 +19,7 @@ describe('EditPrivilegesDialog', () => {
         <EditPrivilegesDialog open user={user} token="tk" onClose={vi.fn()} onSaved={vi.fn()} />,
       );
     });
-    expect(screen.getByRole('checkbox', { name: /tour:create/i })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /gig:create/i })).toBeChecked();
     expect(screen.getByRole('checkbox', { name: /song:create/i })).not.toBeChecked();
   });
 
@@ -34,7 +34,7 @@ describe('EditPrivilegesDialog', () => {
       fireEvent.click(screen.getByTestId('edit-priv-save'));
     });
     expect(adminUtils.updateUser).toHaveBeenCalledWith('tk', 'u1', {
-      privileges: ['tour:create'],
+      privileges: ['gig:create'],
       userType: undefined,
     });
     expect(onSaved).toHaveBeenCalled();

--- a/test/containers/AdminUsers/UsersTable.spec.tsx
+++ b/test/containers/AdminUsers/UsersTable.spec.tsx
@@ -6,7 +6,7 @@ import adminUtils, { type IadminUser } from 'src/containers/AdminUsers/admin-use
 describe('UsersTable', () => {
   const users: IadminUser[] = [
     {
-      _id: 'u1', name: 'Bot One', email: 'b1@x.com', userStatus: 'ai-agent', privileges: ['tour:create'],
+      _id: 'u1', name: 'Bot One', email: 'b1@x.com', userStatus: 'ai-agent', privileges: ['gig:create'],
     },
   ];
 

--- a/test/containers/AdminUsers/capabilities.spec.tsx
+++ b/test/containers/AdminUsers/capabilities.spec.tsx
@@ -2,7 +2,7 @@ import { CAPABILITIES, CAPABILITY_GROUPS, USER_STATUS_OPTIONS } from 'src/contai
 
 describe('AdminUsers capabilities registry', () => {
   it('includes tour, song, and book capabilities', () => {
-    expect(CAPABILITIES).toContain('tour:create');
+    expect(CAPABILITIES).toContain('gig:create');
     expect(CAPABILITIES).toContain('song:create');
     expect(CAPABILITIES).toContain('book:delete');
   });

--- a/test/containers/Music/Gigs/gigs.utils.spec.tsx
+++ b/test/containers/Music/Gigs/gigs.utils.spec.tsx
@@ -88,13 +88,13 @@ describe('gigs.utils', () => {
   it('createGig successful', async () => {
     commonUtils.delay = vi.fn();
     const getGigs = vi.fn();
-    await utils.createGig(getGigs, vi.fn(), new Date(), 'item', 'item', 'item', 'item', { token: 'token' } as Iauth);
+    await utils.createGig(getGigs, vi.fn(), new Date(), 'item', 'item', 'item', 'item', { token: 'token' } as Iauth, 0, '');
     expect(getGigs).toHaveBeenCalled();
   });
   it('createGig catches error', async () => {
     commonUtils.delay = vi.fn(() => Promise.reject(new Error('failed')));
     const getGigs = vi.fn();
-    await utils.createGig(getGigs, vi.fn(), new Date(), 'item', 'item', 'item', 'item', { token: 'token' } as Iauth);
+    await utils.createGig(getGigs, vi.fn(), new Date(), 'item', 'item', 'item', 'item', { token: 'token' } as Iauth, 0, '');
     expect(getGigs).not.toHaveBeenCalled();
   });
   it('checkUpdateDisabled', () => {

--- a/test/containers/Music/__snapshots__/index.spec.tsx.snap
+++ b/test/containers/Music/__snapshots__/index.spec.tsx.snap
@@ -537,6 +537,18 @@ exports[`/music > renders the component 1`] = `
               type="text"
               value=""
             />
+            <input
+              label="Duration (hours)"
+              sx="[object Object]"
+              type="number"
+              value="0"
+            />
+            <input
+              label="Promo image URL"
+              sx="[object Object]"
+              type="text"
+              value=""
+            />
           </div>
           <div>
             <button
@@ -897,6 +909,18 @@ exports[`/music > renders the component 1`] = `
             </div>
             <input
               label="Tickets"
+              sx="[object Object]"
+              type="text"
+              value=""
+            />
+            <input
+              label="Duration (hours)"
+              sx="[object Object]"
+              type="number"
+              value="0"
+            />
+            <input
+              label="Promo image URL"
               sx="[object Object]"
               type="text"
               value=""


### PR DESCRIPTION
Phase 3 of the cross-repo `tour → gig` rename + gig-model expansion. **Deploy AFTER WebJamSocketCluster #226** (the new SCS dual-transmits `allGigs`+`allTours` and dual-listens, so the old frontend keeps working until this ships).

## Rename (#1077)
- AdminUsers capability registry `tour:*` → `gig:*` (+ "Gigs" group label).
- Socket client (`gigs.utils.tsx`): transmits `newGig` / `editGig` / `deleteGig` with `{ gig }` / `{ gigId }`; `fetchGigs` reads `allGigs`.
- Redux persist blacklist `tour` → `gig`; `.tourTable` → `.gigTable`; identifiers.

## duration (#1006)
- `duration` on `Igig` + `defaultGig` + a "Duration (hours)" input in the create/edit dialogs.
- The gigs-table **Time column becomes a range** `8:00 AM to 5:00 PM` when `duration > 0` (`makeTimeRange`), otherwise just the start time.

## promoImageUrl (#1078)
- `promoImageUrl` on `Igig` + `defaultGig` + a "Promo image URL" input in the create/edit dialogs (you paste a direct Dropbox image link).
- New **far-right "Photo" column** with a small **static thumbnail** when a URL is set; empty otherwise. Shown on mobile too. No click (stops propagation so the thumbnail never opens the edit dialog).

## How to Test Locally
```bash
npm ci
npm run typecheck
TZ=UTC npx vitest run        # 248 tests pass
npm run test:lint            # 0 errors
```
Manual (with the new SCS running, e.g. dev): gigs load via `allGigs`; create a gig with a duration → Time column shows the range; add a promo URL → thumbnail appears in the far-right column; edit/delete work via `editGig`/`deleteGig`.

Closes #1077. Closes #1006. Closes #1078.

🤖 Generated with [Claude Code](https://claude.com/claude-code)