### PR TITLE
fix(music): migrate MusicPlayer to react-player v3 so songs play again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jammusic",
-  "version": "2.7.17",
+  "version": "2.7.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jammusic",
-      "version": "2.7.17",
+      "version": "2.7.18",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.7.17",
+  "version": "2.7.18",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/Songs/MusicPlayer/index.tsx
+++ b/src/containers/Songs/MusicPlayer/index.tsx
@@ -32,20 +32,15 @@ export function MyReactPlayer(props: ImyReactPlayerProps): React.JSX.Element {
       onReady={utils.handlePlayerReady}
       muted={!playing}
       style={utils.setPlayerStyle(song) as React.CSSProperties}
-      url={song.url}
+      src={song.url}
       playing={playing}
       controls
+      controlsList="nodownload"
       onEnded={handleEnded}
       width="100%"
       height="40vh"
       id="mainPlayer"
       className="audio"
-      config={{
-        youtube: {
-          playerVars: { controls: 0 },
-        },
-        file: { attributes: { controlsList: 'nodownload' } },
-      }}
     />
   );
 }

--- a/src/containers/Songs/MusicPlayer/index.tsx
+++ b/src/containers/Songs/MusicPlayer/index.tsx
@@ -9,6 +9,11 @@ import './musicPlayer.scss';
 import { EditSongDialog } from '../EditSongDialog';
 import { defaultSong } from '../songs.utils';
 
+// react-player v3 lazy-loads its non-file players (YouTube, etc.) via dynamic
+// import, which adds a load delay on first play. Warm that chunk at page load so
+// it's ready by the time a YouTube song is selected. Best-effort (swallow errors).
+void import('youtube-video-element/react').catch(() => { /* preload best-effort */ });
+
 export function makeHandleEnded(index: number, songsState: Isong[], setIndex: (arg0: number) => void) {
   return () => utils.next(index, songsState, setIndex);
 }
@@ -36,6 +41,7 @@ export function MyReactPlayer(props: ImyReactPlayerProps): React.JSX.Element {
       playing={playing}
       controls
       controlsList="nodownload"
+      preload="auto"
       onEnded={handleEnded}
       width="100%"
       height="40vh"


### PR DESCRIPTION
## Bug
Songs display but the player won't play them. Root cause: `react-player` was upgraded across two majors (v1 → **v3.4.0**), a full rewrite, but `MusicPlayer` still used the v2 API. v3 renamed the source prop `url` → **`src`** and overhauled `config`, so the player got **no source** and nothing played. (Songs still *list* because that's a separate `/song` REST fetch — exactly the reported symptom, and why it predates the gig work.)

## Fix (migrate to v3)
- `url={song.url}` → **`src={song.url}`**
- Removed the v2 `config` (v3 `Config` has no `file` key; the youtube `playerVars` shape changed)
- `controlsList="nodownload"` passed directly (standard media attribute, replaces the old `config.file.attributes`)

The `playing`/`muted`/`controls`/`onEnded`/`onReady`/`onError` props are all valid v3 props (standard media attributes + `onReady: () => void`), and the existing callbacks are signature-compatible.

## How to Test Locally
```bash
npm ci
npm run typecheck
TZ=UTC npx vitest run      # 248 pass
npm run test:lint          # 0 errors
```
**⚠️ The definitive test is in-browser:** run the app, open the Songs page, and confirm a song actually plays (file + YouTube). Tests can't exercise real audio playback, so please verify before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)