### PR TITLE
fix(gigs): make the gigs-table paginator work (past gigs reachable)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jammusic",
-  "version": "2.7.18",
+  "version": "2.7.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jammusic",
-      "version": "2.7.18",
+      "version": "2.7.19",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.7.18",
+  "version": "2.7.19",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/Music/Gigs/gigs.utils.tsx
+++ b/src/containers/Music/Gigs/gigs.utils.tsx
@@ -136,7 +136,10 @@ export const orderGigs = (
     ...defaultGig, venue: 'Our Past Performances', id: 999, tickets: ' ',
   });
   setGigsInOrder(sortedFuture.concat(pastGigs));
-  setPageSize(futureGigs.length - 1 > 5 ? futureGigs.length - 1 : 5);
+  // Default page size — the grid paginates; the "Our Past Performances" separator
+  // and the (often many) past gigs are reachable via the now-working paginator,
+  // and the user can bump the page size via the grid's options.
+  setPageSize(10);
 };
 
 const makeDateValue = (datetime: string) => {

--- a/src/containers/Music/Gigs/index.tsx
+++ b/src/containers/Music/Gigs/index.tsx
@@ -118,6 +118,7 @@ export const GigsDiv = (props: IgigsDivProps) => {
   } = props;
   const navigate = useNavigate();
   const isMobile = useMediaQuery('(max-width:600px)');
+  const [page, setPage] = useState(0);
   const handleClick = () => {
     if (process.env.APP_NAME === 'joshandmariamusic.com') window.open('https://web-jam.com/music/bookus');
     else navigate('/music/bookus');
@@ -143,9 +144,9 @@ export const GigsDiv = (props: IgigsDivProps) => {
           }}
           rows={gigsInOrder || []}
           columns={makeColumns(isMobile)}
-          paginationModel={{ page: 0, pageSize }}
-          onPaginationModelChange={(model) => setPageSize(model.pageSize)}
-          pageSizeOptions={[pageSize]}
+          paginationModel={{ page, pageSize }}
+          onPaginationModelChange={(model) => { setPage(model.page); setPageSize(model.pageSize); }}
+          pageSizeOptions={[5, 10, 25, 50]}
           disableRowSelectionOnClick
         />
       </div>

--- a/test/containers/Music/Gigs/gigs.utils.spec.tsx
+++ b/test/containers/Music/Gigs/gigs.utils.spec.tsx
@@ -47,7 +47,9 @@ describe('gigs.utils', () => {
       { datetime: yesterday }, { datetime: future }, { datetime: today }, { datetime: tomorrow },
     ] as Igig[];
     utils.orderGigs(gigs, setGigsInOrder, setPageSize);
-    expect(setPageSize).toHaveBeenCalledWith(12);
+    // Fixed default page size; the grid paginates (separator + past gigs are
+    // reachable via the paginator).
+    expect(setPageSize).toHaveBeenCalledWith(10);
   });
   it('makeVenue', () => {
     const venue: any = utils.makeVenue();


### PR DESCRIPTION
## Bug
On the Gigs table you could only see the future gigs — the "Our Past Performances" separator and all past gigs were unreachable (in prod there are a lot of past gigs). Pre-existing, unrelated to the tour→gig rename.

## Cause
The `DataGrid` pagination was broken:
```jsx
paginationModel={{ page: 0, pageSize }}                       // page hardcoded to 0
onPaginationModelChange={(model) => setPageSize(model.pageSize)}  // never updates page
pageSizeOptions={[pageSize]}
```
Clicking a later page snapped right back to page 0, and `orderGigs` set `pageSize` to roughly the future-gig count — so past gigs were stranded on a page you couldn't get to.

## Fix
- Track `page` in state; `onPaginationModelChange` updates **both** `page` and `pageSize`.
- Fixed default page size **10** with options **[5, 10, 25, 50]**.
- `orderGigs` sets the default page size (10) instead of the future-count formula.

Now the paginator works and past gigs are reachable page by page.

## How to Test Locally
```bash
npm ci
npm run typecheck
TZ=UTC npx vitest run test/containers/Music
npm run test:lint
```
All green. Manually: open the Gigs page → page through to reach the "Our Past Performances" separator and past gigs; change the page size via the grid's options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)