### PR TITLE
feat(music): migrate song player from react-player to Plyr

### DIFF
--- a/__mocks__/plyr-react.tsx
+++ b/__mocks__/plyr-react.tsx
@@ -1,0 +1,7 @@
+import { forwardRef } from 'react';
+
+// Plyr instantiates a real player (and loads an icon sprite via URL) which fails
+// under jsdom. Stub it as a ref-forwarding component that renders nothing.
+export const Plyr = forwardRef<unknown, Record<string, unknown>>(() => null);
+
+export default { Plyr };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jammusic",
-  "version": "2.7.19",
+  "version": "2.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jammusic",
-      "version": "2.7.19",
+      "version": "2.8.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -32,10 +32,11 @@
         "express-sslify": "^1.2.0",
         "html-react-parser": "^6.1.2",
         "jwt-simple": "^0.5.6",
+        "plyr": "^3.8.4",
+        "plyr-react": "^6.0.0",
         "process": "^0.11.10",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
-        "react-player": "^2.16.1",
         "react-redux": "^9.3.0",
         "react-router": "^7.15.1",
         "react-router-dom": "^7.15.1",
@@ -4155,6 +4156,17 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -4320,6 +4332,12 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/custom-event-polyfill": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/custom-event-polyfill/-/custom-event-polyfill-1.0.7.tgz",
+      "integrity": "sha512-TDDkd5DkaZxZFM8p+1I3yAlvM3rSr1wbrOliG4yJiwinMZN8z/iGL7BTlDkrJcYTmgUSb4ywVCc3ZaUtOtC76w==",
+      "license": "MIT"
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -4388,15 +4406,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "devOptional": true,
       "license": "MIT"
-    },
-    "node_modules/deepmerge": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -6915,10 +6924,10 @@
       "integrity": "sha512-0GK/ylO6e5cv1PCOIdTRHxOaCgQ+0jKwHt+cHzkiCAZlx0KM5Id1bBAPad6g2mkvBNp1pNdmG0cohFGfqjkv9A==",
       "license": "MIT"
     },
-    "node_modules/load-script": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-      "integrity": "sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA==",
+    "node_modules/loadjs": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/loadjs/-/loadjs-4.3.0.tgz",
+      "integrity": "sha512-vNX4ZZLJBeDEOBvdr2v/F+0aN5oMuPu7JTqrMwp+DtgK+AryOlpy6Xtm2/HpNr+azEa828oQjOtWsB6iDtSfSQ==",
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -7116,12 +7125,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/memoize-one": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
-      "license": "MIT"
     },
     "node_modules/meow": {
       "version": "14.1.0",
@@ -7667,6 +7670,35 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/plyr": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/plyr/-/plyr-3.8.4.tgz",
+      "integrity": "sha512-DrzLbK9Wol3zeiuZCleD9aUOl0KAaBHR9H6WVVVYPZ4Ya+LYxUFTgSF1jooHcMQCv96Ws96wCaZzIoP3bES8pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "core-js": "^3.45.1",
+        "custom-event-polyfill": "^1.0.7",
+        "loadjs": "^4.3.0",
+        "rangetouch": "^2.0.1",
+        "url-polyfill": "^1.1.13"
+      }
+    },
+    "node_modules/plyr-react": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/plyr-react/-/plyr-react-6.0.0.tgz",
+      "integrity": "sha512-P8M+BuQoGrCd7m6K4QwwQlcSS1E26OeXuJTAmgLx11B9UqJrdc3Ka4TFwPwF3jul4EsVxSK9Zn1ME3DV8m9gdw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-aptor": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "plyr": "^3.7.7",
+        "react": ">=16.8"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -8017,6 +8049,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/rangetouch": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rangetouch/-/rangetouch-2.0.1.tgz",
+      "integrity": "sha512-sln+pNSc8NGaHoLzwNBssFSf/rSYkqeBXzX1AtJlkJiUaVSJSbRAWJk+4omsXkN+EJalzkZhWQ3th1m0FpR5xA==",
+      "license": "MIT"
+    },
     "node_modules/raw-body": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
@@ -8041,6 +8079,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-aptor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-aptor/-/react-aptor-2.0.0.tgz",
+      "integrity": "sha512-YnCayokuhAwmBBP4Oc0bbT2l6ApfsjbY3DEEVUddIKZEBlGl1npzjHHzWnSqWuboSbMZvRqUM01Io9yiIp1wcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.2.6",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
@@ -8053,33 +8108,11 @@
         "react": "^19.2.6"
       }
     },
-    "node_modules/react-fast-compare": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
-      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
-      "license": "MIT"
-    },
     "node_modules/react-is": {
       "version": "19.2.6",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
       "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
       "license": "MIT"
-    },
-    "node_modules/react-player": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/react-player/-/react-player-2.16.1.tgz",
-      "integrity": "sha512-mxP6CqjSWjidtyDoMOSHVPdhX0pY16aSvw5fVr44EMaT7X5Xz46uQ4b/YBm1v2x+3hHkB9PmjEEkmbHb9PXQ4w==",
-      "license": "MIT",
-      "dependencies": {
-        "deepmerge": "^4.0.0",
-        "load-script": "^1.0.0",
-        "memoize-one": "^5.1.1",
-        "prop-types": "^15.7.2",
-        "react-fast-compare": "^3.0.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
     },
     "node_modules/react-property": {
       "version": "2.0.2",
@@ -9914,6 +9947,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/url-polyfill": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/url-polyfill/-/url-polyfill-1.1.14.tgz",
+      "integrity": "sha512-p4f3TTAG6ADVF3mwbXw7hGw+QJyw5CnNGvYh5fCuQQZIiuKUswqcznyV3pGDP9j0TSmC4UvRKm8kl1QsX1diiQ==",
+      "license": "MIT"
     },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.7.19",
+  "version": "2.8.0",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {
@@ -67,10 +67,11 @@
     "express-sslify": "^1.2.0",
     "html-react-parser": "^6.1.2",
     "jwt-simple": "^0.5.6",
+    "plyr": "^3.8.4",
+    "plyr-react": "^6.0.0",
     "process": "^0.11.10",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "react-player": "^2.16.1",
     "react-redux": "^9.3.0",
     "react-router": "^7.15.1",
     "react-router-dom": "^7.15.1",

--- a/src/containers/Songs/EditSongDialog.tsx
+++ b/src/containers/Songs/EditSongDialog.tsx
@@ -2,11 +2,12 @@ import {
   Button, Dialog, DialogActions, DialogContent,
   DialogContentText, DialogTitle, TextField,
 } from '@mui/material';
-import React, { useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { AuthContext } from 'src/providers/Auth.provider';
 import { DataContext, Isong } from 'src/providers/Data.provider';
 import { CategorySelect } from 'src/components/CategorySelect';
 import { YearField } from 'src/components/YearField';
+import { checkIsAdmin } from '../Music';
 import utils from './songs.utils';
 
 interface IsongFieldProps {
@@ -38,6 +39,8 @@ export function EditSongDialog({ editDialogState, editSongState, currentSong }: 
   const { getSongs } = useContext(DataContext);
   const { showEditDialog, setShowEditDialog } = editDialogState;
   const { editSong, setEditSong } = editSongState;
+  const [isAdmin, setIsAdmin] = useState(false);
+  useEffect(() => { checkIsAdmin(auth, setIsAdmin); }, [auth]);
   useEffect(() => {
     setEditSong(currentSong);
   }, [currentSong, setEditSong]);
@@ -136,6 +139,17 @@ export function EditSongDialog({ editDialogState, editSongState, currentSong }: 
         >
           Update
         </Button>
+        {isAdmin ? (
+          <Button
+            size="small"
+            variant="contained"
+            color="error"
+            className="deleteSongButton"
+            onClick={() => { utils.deleteSong(getSongs, setShowEditDialog, editSong, auth); }}
+          >
+            Delete
+          </Button>
+        ) : null}
         <Button
           size="small"
           className="cancelPicButton"

--- a/src/containers/Songs/MusicPlayer/index.tsx
+++ b/src/containers/Songs/MusicPlayer/index.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useState } from 'react';
-import ReactPlayer from 'react-player';
+import React, { useEffect, useRef, useState } from 'react';
+import { Plyr, type APITypes, type PlyrSource } from 'plyr-react';
+import 'plyr-react/plyr.css';
 import { Button } from '@mui/material';
 import { Share } from '@mui/icons-material';
 import { useSearchParams } from 'react-router-dom';
@@ -13,50 +14,121 @@ export function makeHandleEnded(index: number, songsState: Isong[], setIndex: (a
   return () => utils.next(index, songsState, setIndex);
 }
 
+// A Dropbox share link (?dl=0) serves an HTML preview page, not the file itself.
+// Rewrite it to the raw file so an <audio>/<video> element can actually stream it.
+export function normalizeUrl(url: string): string {
+  if (!/dropbox\.com/i.test(url)) return url;
+  let direct = url.replace(/([?&])dl=\d/i, '$1raw=1');
+  if (!/[?&]raw=1/i.test(direct)) direct += `${direct.includes('?') ? '&' : '?'}raw=1`;
+  return direct;
+}
+
+// Build a Plyr source from a song URL: YouTube, a self-hosted video file, or an audio file.
+export function buildSource(url: string): PlyrSource {
+  const u = (url || '').toLowerCase();
+  if (u.includes('youtube') || u.includes('youtu.be')) {
+    return { type: 'video', sources: [{ src: url, provider: 'youtube' }] };
+  }
+  const direct = normalizeUrl(url);
+  if (/\.(mp4|webm|mov|m4v|ogv)(\?|#|$)/.test(u)) {
+    return { type: 'video', sources: [{ src: direct }] };
+  }
+  return { type: 'audio', sources: [{ src: direct }] };
+}
+
+// Audio: no play button — the under-player Play/Pause drives it (no fullscreen for audio).
+const AUDIO_CONTROLS = ['progress', 'current-time', 'mute', 'volume'];
+// Video/YouTube: keep play + play-large + fullscreen so the video stays controllable in
+// fullscreen, where the under-player buttons aren't visible.
+const VIDEO_CONTROLS = ['play-large', 'play', 'progress', 'current-time', 'mute', 'volume', 'fullscreen'];
+
+const tryPlay = (player: any) => {
+  try {
+    const r = player.play();
+    if (r && typeof r.catch === 'function') r.catch(() => { /* autoplay blocked */ });
+  } catch { /* noop */ }
+};
+
 interface ImyReactPlayerProps {
-  playing: boolean,
-  index: number, songsState: Isong[], setIndex: (arg0: number) => void
+  playing: boolean, setPlaying: (arg0: boolean) => void,
+  index: number, songsState: Isong[], setIndex: (arg0: number) => void,
+  playerRef: React.RefObject<APITypes | null>
 }
 export function MyReactPlayer(props: ImyReactPlayerProps): React.JSX.Element {
   const {
-    playing, index, songsState, setIndex,
+    playing, setPlaying, index, songsState, setIndex, playerRef,
   } = props;
+  const playingRef = useRef(playing);
+  playingRef.current = playing;
   // eslint-disable-next-line security/detect-object-injection
   const song = songsState[index];
+  // Keep the under-player buttons' state in sync, auto-advance when a song ends,
+  // and resume playback when the source changes (Next/Prev) while we are playing.
+  useEffect(() => {
+    const player = playerRef.current?.plyr as any;
+    if (!player || typeof player.on !== 'function') return () => { /* noop */ };
+    const onPlay = () => setPlaying(true);
+    const onPause = () => setPlaying(false);
+    const onEnded = () => utils.next(index, songsState, setIndex);
+    const onLoaded = () => { if (playingRef.current) tryPlay(player); };
+    player.on('play', onPlay);
+    player.on('pause', onPause);
+    player.on('ended', onEnded);
+    player.on('ready', onLoaded);
+    player.on('loadeddata', onLoaded);
+    return () => {
+      try {
+        player.off('play', onPlay); player.off('pause', onPause);
+        player.off('ended', onEnded); player.off('ready', onLoaded);
+        player.off('loadeddata', onLoaded);
+      } catch { /* noop */ }
+    };
+  }, [index, songsState, setIndex, setPlaying, playerRef]);
   if (!song) return <> </>;
-  const handleEnded = makeHandleEnded(index, songsState, setIndex);
-  const Player = ReactPlayer as any;
+  const source = buildSource(song.url || '');
+  const isVideo = source.type === 'video';
+  // Audio shows the album art behind a chrome-less bar (the buttons below drive it);
+  // video renders at its natural size so there is no empty box above the picture.
+  const audioBoxStyle: React.CSSProperties = {
+    ...(utils.setPlayerStyle(song) as React.CSSProperties),
+    minHeight: '40vh',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'flex-end',
+  };
   return (
-    <Player
-      onError={utils.handlePlayerError}
-      onReady={utils.handlePlayerReady}
-      style={utils.setPlayerStyle(song) as React.CSSProperties}
-      url={song.url}
-      playing={playing}
-      controls
-      onEnded={handleEnded}
-      width="100%"
-      height="40vh"
+    <div
       id="mainPlayer"
-      className="audio"
-      config={{
-        youtube: {
-          playerVars: { controls: 0 },
-        },
-        file: { attributes: { controlsList: 'nodownload' } },
-      }}
-    />
+      className={isVideo ? 'video' : 'audio'}
+      style={isVideo ? undefined : audioBoxStyle}
+    >
+      <Plyr
+        ref={playerRef}
+        source={source}
+        options={{ controls: isVideo ? VIDEO_CONTROLS : AUDIO_CONTROLS }}
+      />
+    </div>
   );
 }
 
 interface ImyButtonsProps {
   playing: boolean, setPlaying: (arg0: boolean) => void, index: number,
-  songsState: Isong[], setIndex: (arg0: number) => void, isSingle: boolean
+  songsState: Isong[], setIndex: (arg0: number) => void, isSingle: boolean,
+  playerRef: React.RefObject<APITypes | null>
 }
 export function MyButtons(props: ImyButtonsProps): React.JSX.Element {
   const {
-    playing, setPlaying, index, songsState, setIndex, isSingle,
+    playing, setPlaying, index, songsState, setIndex, isSingle, playerRef,
   } = props;
+  // Toggle the player straight from the click so play() runs inside the user
+  // gesture (browsers block play() deferred to an effect). The play/pause events
+  // keep `playing` (and so the button label) in sync; fall back to state if the
+  // player isn't ready yet.
+  const togglePlay = () => {
+    const player = playerRef.current?.plyr as any;
+    if (player && typeof player.togglePlay === 'function') player.togglePlay();
+    else utils.play(playing, setPlaying);
+  };
   return (
     <div style={{ paddingTop: 0, margin: 'auto' }}>
       <div id="play-buttons">
@@ -65,7 +137,7 @@ export function MyButtons(props: ImyButtonsProps): React.JSX.Element {
           variant="contained"
           id="play-pause"
           className={playing ? 'on' : 'off'}
-          onClick={() => utils.play(playing, setPlaying)}
+          onClick={togglePlay}
         >
           Play/Pause
         </Button>
@@ -252,6 +324,8 @@ export function MusicPlayer({ songs, filterBy, editDialogState }: ImusicPlayerPr
   const [playing, setPlaying] = useState(false);
   const [isSingle, setIsSingle] = useState(false);
   const [editSong, setEditSong] = useState({ ...defaultSong, _id: '' } as Isong);
+  // Shared Plyr ref so the under-player buttons drive the (chrome-less) player.
+  const playerRef = useRef<APITypes>(null);
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [searchParams, setSearchParams] = useSearchParams();
   useEffect(() => {
@@ -271,8 +345,10 @@ export function MusicPlayer({ songs, filterBy, editDialogState }: ImusicPlayerPr
           <MyReactPlayer
             setIndex={setIndex}
             playing={playing}
+            setPlaying={setPlaying}
             index={index}
             songsState={songsState}
+            playerRef={playerRef}
           />
         </section>
         <MyButtons
@@ -282,6 +358,7 @@ export function MusicPlayer({ songs, filterBy, editDialogState }: ImusicPlayerPr
           index={index}
           songsState={songsState}
           isSingle={isSingle}
+          playerRef={playerRef}
         />
         <TextUnderPlayer songsState={songsState} index={index} />
         <CategoryButtons category={category} setCategory={setCategory} isSingle={isSingle} setIndex={setIndex} />

--- a/src/containers/Songs/MusicPlayer/musicPlayer.scss
+++ b/src/containers/Songs/MusicPlayer/musicPlayer.scss
@@ -10,6 +10,17 @@
 
 #mainPlayer iframe { pointer-events: none; }
 
+/* Hide Plyr's own play controls in the normal embedded view so only the buttons
+   beneath the player drive playback. They reappear in fullscreen (native via the
+   :fullscreen pseudo, or the JS fallback class), where those under-player buttons
+   aren't visible. */
+#mainPlayer .plyr:not(:fullscreen):not(.plyr--fullscreen-fallback) {
+    .plyr__control--overlaid,
+    .plyr__control[data-plyr="play"] {
+        display: none;
+    }
+}
+
 #play-pause.on { background-color: red; color: black; }
 
 #play-buttons { margin-bottom:10px;}

--- a/src/containers/Songs/songs.utils.tsx
+++ b/src/containers/Songs/songs.utils.tsx
@@ -62,6 +62,26 @@ const updateSong = async (
   } catch (err) { commonUtils.notify('Error creating song', (err as Error).message, 'danger'); }
 };
 
+const deleteSong = async (
+  getSongs: () => Promise<Isong[]>,
+  setShowDialog: (arg0: boolean) => void,
+  song: Isong,
+  auth: Iauth,
+) => {
+  // eslint-disable-next-line no-restricted-globals, no-alert
+  if (!confirm(`Delete "${song.title}"? This cannot be undone.`)) return;
+  try {
+    const { token } = auth;
+    const res = await fetch(`${process.env.BackendUrl}/song/${song._id}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    setShowDialog(false);
+    await getSongs();
+  } catch (err) { commonUtils.notify('Error deleting song', (err as Error).message, 'danger'); }
+};
+
 const checkDisabled = (song: Isong) => {
   if (song.url && song.title && song.artist && song.year) return false;
   return true;
@@ -79,5 +99,5 @@ function handleInputChange(
 }
 
 export default {
-  createSong, checkDisabled, handleInputChange, updateSong,
+  createSong, checkDisabled, handleInputChange, updateSong, deleteSong,
 };

--- a/test/containers/Songs/MusicPlayer/index.spec.tsx
+++ b/test/containers/Songs/MusicPlayer/index.spec.tsx
@@ -9,6 +9,8 @@ import {
   // TextUnderPlayer,
   // MyButtons,
   makeHandleEnded,
+  buildSource,
+  normalizeUrl,
 } from 'src/containers/Songs/MusicPlayer';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
@@ -45,5 +47,30 @@ describe('MusicPlayer index', () => {
     const he = makeHandleEnded(0, [{ title: 'title', artist: 'me', album: 'test' } as Isong], vi.fn());
     he();
     expect(utils.next).toHaveBeenCalled();
+  });
+  it('buildSource detects YouTube', () => {
+    expect(buildSource('https://youtube.com/watch?v=abc')).toEqual({
+      type: 'video', sources: [{ src: 'https://youtube.com/watch?v=abc', provider: 'youtube' }],
+    });
+  });
+  it('buildSource detects a self-hosted video file', () => {
+    const src = buildSource('https://example.com/clip.mp4');
+    expect(src.type).toBe('video');
+    expect(src.sources[0].provider).toBeUndefined();
+  });
+  it('buildSource defaults to audio', () => {
+    expect(buildSource('https://example.com/song.mp3').type).toBe('audio');
+  });
+  it('buildSource rewrites a Dropbox video link to raw and treats it as video', () => {
+    const src = buildSource('https://www.dropbox.com/scl/fi/x/clip.mp4?rlkey=abc&dl=0');
+    expect(src.type).toBe('video');
+    expect(src.sources[0].src).toContain('raw=1');
+    expect(src.sources[0].src).not.toContain('dl=0');
+  });
+  it('normalizeUrl appends raw=1 when no dl param', () => {
+    expect(normalizeUrl('https://www.dropbox.com/s/x/clip.mp4')).toContain('?raw=1');
+  });
+  it('normalizeUrl leaves non-Dropbox urls untouched', () => {
+    expect(normalizeUrl('https://example.com/clip.mp4?dl=0')).toBe('https://example.com/clip.mp4?dl=0');
   });
 });

--- a/test/containers/Songs/songs.utils.spec.tsx
+++ b/test/containers/Songs/songs.utils.spec.tsx
@@ -51,4 +51,35 @@ describe('songs utils', () => {
     const result = utils.checkDisabled(song);
     expect(result).toBe(false);
   });
+  const delSong = {
+    _id: 'abc', artist: '', category: '1', title: 'a', year: 12, url: 'https://test1.com',
+  };
+  const delAuth = {
+    isAuthenticated: true, user: { userType: 'admin', email: 'test@example.com' }, error: '', token: 'mock-token',
+  };
+  it('deleteSong when confirmed', async () => {
+    vi.stubGlobal('confirm', vi.fn(() => true));
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+    const getSongs = vi.fn();
+    const setShowDialog = vi.fn();
+    await utils.deleteSong(getSongs, setShowDialog, delSong, delAuth);
+    expect(setShowDialog).toHaveBeenCalledWith(false);
+    expect(getSongs).toHaveBeenCalled();
+  });
+  it('deleteSong does nothing when cancelled', async () => {
+    vi.stubGlobal('confirm', vi.fn(() => false));
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const getSongs = vi.fn();
+    await utils.deleteSong(getSongs, vi.fn(), delSong, delAuth);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(getSongs).not.toHaveBeenCalled();
+  });
+  it('deleteSong notifies on error', async () => {
+    vi.stubGlobal('confirm', vi.fn(() => true));
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500, statusText: 'fail' }));
+    commonUtils.notify = vi.fn();
+    await utils.deleteSong(vi.fn(), vi.fn(), delSong, delAuth);
+    expect(commonUtils.notify).toHaveBeenCalled();
+  });
 });

--- a/test/vitest.setup.ts
+++ b/test/vitest.setup.ts
@@ -14,6 +14,7 @@ vi.mock('@mui/x-date-pickers');
 vi.mock('@react-oauth/google');
 vi.mock('@tinymce/tinymce-react');
 vi.mock('socketcluster-client');
+vi.mock('plyr-react');
 
 global.ResizeObserver = class {
   observe(): void { /* no-op */ }


### PR DESCRIPTION
Replaces `react-player` with `plyr-react` (React 19 compatible) and reworks the Songs player so the buttons beneath the player drive playback.

## What changed
- **Player engine:** `react-player` → `plyr-react` / `plyr`. A shared Plyr `ref` is lifted to `MusicPlayer` so the under-player **Play/Pause/Next/Prev** buttons control the player. Play/Pause calls Plyr's `togglePlay()` **inside the click handler** so `play()` runs in the user-gesture context (fixes the "play button does nothing" autoplay block).
- **Hidden native controls:** Plyr's own play controls are hidden in the embedded view via CSS and **reappear only in fullscreen** (native `:fullscreen` / JS `plyr--fullscreen-fallback`), where the under-player buttons aren't visible.
- **Layout:** audio renders the album-art box (40vh); video/YouTube render at natural size (no empty box above the picture).
- **Dropbox video:** share links (`?dl=0`, an HTML preview page) are rewritten to `?raw=1` so `<video>` can stream the raw file. Verified against a real link: `206 Partial Content`, `content-type: video/mp4`, `accept-ranges: bytes`.
- **Delete song:** admin-only red **Delete** button in the Edit Song dialog → `DELETE /song/:id` (Bearer auth), with a confirm + list refresh. Lets the SoundCloud songs (which Plyr can't play) be removed manually in prod.
- **Tests:** `plyr-react` is mocked (jsdom can't instantiate Plyr); added coverage for `buildSource`, `normalizeUrl`, and `deleteSong`.

> Note: SoundCloud playback is dropped (Plyr has no SoundCloud provider). Those songs are deleted manually via the new Delete button.

## How to Test Locally
```bash
git fetch origin
git checkout migrate-music-player-to-plyr
npm install
npm run typecheck
TZ=UTC npx vitest run        # 257 passing
npm run test:lint            # 0 errors
npm start                    # then open the Music page
```
In the browser:
1. **Audio song** — album art shows; Play/Pause/Next/Prev (under the player) work; the player itself shows no play button.
2. **YouTube + Dropbox/self-hosted video** — embedded view has no play button (use the buttons below); click **fullscreen** and the play button is present.
3. **Dropbox** — paste a `?dl=0` share link as a song URL; it streams (rewritten to `raw=1`).
4. **Delete (admin)** — log in as admin, open a song's Edit dialog → red **Delete** removes it after confirm. Non-admins don't see the button.

Closes #1082

🤖 Generated with [Claude Code](https://claude.com/claude-code)