### PR TITLE
feat(music): play SoundCloud songs via widget iframe (no deletion needed)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jammusic",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jammusic",
-      "version": "2.9.1",
+      "version": "2.9.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jammusic",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jammusic",
-      "version": "2.9.2",
+      "version": "2.9.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jammusic",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jammusic",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jammusic",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jammusic",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/Songs/MusicPlayer/index.tsx
+++ b/src/containers/Songs/MusicPlayer/index.tsx
@@ -98,7 +98,10 @@ export function MyReactPlayer(props: ImyReactPlayerProps): React.JSX.Element {
   if (!song) return <> </>;
   if (isSoundCloud(song.url)) {
     return (
-      <div id="mainPlayer" className="audio soundcloud">
+      // Distinct key from the Plyr branch so React cleanly unmounts the whole
+      // wrapper when crossing the SoundCloud<->Plyr boundary instead of trying to
+      // swap inner nodes that Plyr has restructured (which throws removeChild).
+      <div key="sc-player" id="mainPlayer" className="audio soundcloud">
         <iframe
           title={song.title || 'SoundCloud player'}
           width="100%"
@@ -123,7 +126,11 @@ export function MyReactPlayer(props: ImyReactPlayerProps): React.JSX.Element {
     justifyContent: 'flex-end',
   };
   return (
+    // Stable key across all Plyr songs so audio<->video updates in place
+    // (no remount); it differs from the SoundCloud branch's key so crossing that
+    // boundary forces a clean unmount instead of a removeChild crash.
     <div
+      key="plyr-player"
       id="mainPlayer"
       className={isVideo ? 'video' : 'audio'}
       style={isVideo ? undefined : audioBoxStyle}

--- a/src/containers/Songs/MusicPlayer/index.tsx
+++ b/src/containers/Songs/MusicPlayer/index.tsx
@@ -23,6 +23,17 @@ export function normalizeUrl(url: string): string {
   return direct;
 }
 
+// SoundCloud has no Plyr provider, so those songs render the SoundCloud widget
+// iframe (its own controls) instead of the Plyr player.
+export function isSoundCloud(url?: string): boolean {
+  return /soundcloud\.com/i.test(url || '');
+}
+
+export function buildSoundCloudEmbed(url: string): string {
+  const opts = 'auto_play=false&hide_related=true&show_comments=false&show_user=true&show_reposts=false&visual=false';
+  return `https://w.soundcloud.com/player/?url=${encodeURIComponent(url)}&${opts}`;
+}
+
 // Build a Plyr source from a song URL: YouTube, a self-hosted video file, or an audio file.
 export function buildSource(url: string): PlyrSource {
   const u = (url || '').toLowerCase();
@@ -85,6 +96,21 @@ export function MyReactPlayer(props: ImyReactPlayerProps): React.JSX.Element {
     };
   }, [index, songsState, setIndex, setPlaying, playerRef]);
   if (!song) return <> </>;
+  if (isSoundCloud(song.url)) {
+    return (
+      <div id="mainPlayer" className="audio soundcloud">
+        <iframe
+          title={song.title || 'SoundCloud player'}
+          width="100%"
+          height="166"
+          scrolling="no"
+          frameBorder="no"
+          allow="autoplay"
+          src={buildSoundCloudEmbed(song.url || '')}
+        />
+      </div>
+    );
+  }
   const source = buildSource(song.url || '');
   const isVideo = source.type === 'video';
   // Audio shows the album art behind a chrome-less bar (the buttons below drive it);
@@ -129,18 +155,25 @@ export function MyButtons(props: ImyButtonsProps): React.JSX.Element {
     if (player && typeof player.togglePlay === 'function') player.togglePlay();
     else utils.play(playing, setPlaying);
   };
+  // eslint-disable-next-line security/detect-object-injection
+  const currentSong = songsState[index];
+  // SoundCloud songs render their own widget (with built-in controls), so hide
+  // our Play/Pause for them; Next/Prev still navigate.
+  const hidePlayPause = isSoundCloud(currentSong?.url);
   return (
     <div style={{ paddingTop: 0, margin: 'auto' }}>
       <div id="play-buttons">
-        <Button
-          size="small"
-          variant="contained"
-          id="play-pause"
-          className={playing ? 'on' : 'off'}
-          onClick={togglePlay}
-        >
-          Play/Pause
-        </Button>
+        {hidePlayPause ? null : (
+          <Button
+            size="small"
+            variant="contained"
+            id="play-pause"
+            className={playing ? 'on' : 'off'}
+            onClick={togglePlay}
+          >
+            Play/Pause
+          </Button>
+        )}
         {!isSingle ? null : (
           <Button
             size="small"

--- a/src/containers/Songs/MusicPlayer/index.tsx
+++ b/src/containers/Songs/MusicPlayer/index.tsx
@@ -108,7 +108,7 @@ export function MyReactPlayer(props: ImyReactPlayerProps): React.JSX.Element {
           height="166"
           scrolling="no"
           frameBorder="no"
-          allow="autoplay"
+          allow="autoplay; encrypted-media"
           src={buildSoundCloudEmbed(song.url || '')}
         />
       </div>

--- a/src/containers/Songs/MusicPlayer/musicPlayer.scss
+++ b/src/containers/Songs/MusicPlayer/musicPlayer.scss
@@ -8,7 +8,9 @@
 }
 
 
-#mainPlayer iframe { pointer-events: none; }
+/* Disable direct interaction with the Plyr (YouTube) iframe only — the SoundCloud
+   widget iframe needs its own controls clickable. */
+#mainPlayer .plyr iframe { pointer-events: none; }
 
 /* Hide Plyr's own play controls in the normal embedded view so only the buttons
    beneath the player drive playback. They reappear in fullscreen (native via the

--- a/src/styles/_musicplayer.scss
+++ b/src/styles/_musicplayer.scss
@@ -50,7 +50,9 @@
     text-align: center;
 }
 
-#mainPlayer iFrame {
+/* Only the Plyr (YouTube) iframe is non-interactive — the SoundCloud widget
+   iframe must stay clickable so its own play button works. */
+#mainPlayer .plyr iFrame {
   pointer-events: none;
 }
 

--- a/test/containers/Songs/MusicPlayer/index.spec.tsx
+++ b/test/containers/Songs/MusicPlayer/index.spec.tsx
@@ -11,6 +11,8 @@ import {
   makeHandleEnded,
   buildSource,
   normalizeUrl,
+  isSoundCloud,
+  buildSoundCloudEmbed,
 } from 'src/containers/Songs/MusicPlayer';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
@@ -72,5 +74,31 @@ describe('MusicPlayer index', () => {
   });
   it('normalizeUrl leaves non-Dropbox urls untouched', () => {
     expect(normalizeUrl('https://example.com/clip.mp4?dl=0')).toBe('https://example.com/clip.mp4?dl=0');
+  });
+  it('isSoundCloud detects soundcloud urls', () => {
+    expect(isSoundCloud('https://soundcloud.com/user/track')).toBe(true);
+    expect(isSoundCloud('https://example.com/song.mp3')).toBe(false);
+    expect(isSoundCloud(undefined)).toBe(false);
+  });
+  it('buildSoundCloudEmbed wraps the track url for the widget', () => {
+    const embed = buildSoundCloudEmbed('https://soundcloud.com/user/track');
+    expect(embed).toContain('https://w.soundcloud.com/player/?url=');
+    expect(embed).toContain(encodeURIComponent('https://soundcloud.com/user/track'));
+  });
+  it('renders a SoundCloud iframe (not Plyr) for a soundcloud song', () => {
+    const song = {
+      category: 'originals', year: 2020, title: 'SC', url: 'https://soundcloud.com/u/t', _id: 'sc1', image: '', artist: '',
+    };
+    const editDialogState = { setShowEditDialog: vi.fn(), showEditDialog: false };
+    const { container } = render(
+      <BrowserRouter>
+        <MusicPlayer songs={[song]} filterBy="originals" editDialogState={editDialogState} />
+      </BrowserRouter>,
+    );
+    const iframe = container.querySelector('#mainPlayer iframe') as HTMLIFrameElement;
+    expect(iframe).not.toBeNull();
+    expect(iframe.getAttribute('src')).toContain('w.soundcloud.com/player');
+    // Play/Pause is hidden for SoundCloud songs.
+    expect(container.querySelector('#play-pause')).toBeNull();
   });
 });


### PR DESCRIPTION
Instead of deleting the 7 SoundCloud songs (Plyr has no SoundCloud provider), keep them playable by rendering the **SoundCloud widget iframe** for those songs.

## What changed
- `isSoundCloud(url)` / `buildSoundCloudEmbed(url)` helpers.
- `MyReactPlayer`: if the song URL is SoundCloud, render the `w.soundcloud.com/player` iframe (with its own controls) instead of Plyr.
- `MyButtons`: hide our **Play/Pause** for SoundCloud songs (the widget drives playback); **Next/Prev** still navigate.
- SCSS: scoped `#mainPlayer iframe { pointer-events: none }` to `#mainPlayer .plyr iframe` so the YouTube iframe stays non-interactive (Plyr controls it) but the **SoundCloud widget stays clickable**.

No CSP change needed — `frame-src` already allows `https://w.soundcloud.com`. The 7 SoundCloud songs no longer need to be deleted.

## How to Test Locally
```bash
git fetch origin && git checkout soundcloud-iframe-fallback
npm install
npm run typecheck
TZ=UTC npx vitest run        # 260 passing
npm start                    # open the Music page
```
In the browser:
1. Navigate to a **SoundCloud** song → the SoundCloud widget renders (no Plyr bar); play it with the widget's own button; our Play/Pause is hidden; Next/Prev still work.
2. Navigate to an **audio / YouTube / Dropbox** song → unchanged (Plyr, under-player Play/Pause).

🤖 Generated with [Claude Code](https://claude.com/claude-code)