### PR TITLE
fix(music): Maria review items #3-6 (songlist, Amazon buttons, YouTube, X link)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@
 * Copy the `.env.example` file and paste it as `.env` file in the project root directory. Request variable definitions from the project owner or spin up your own resourses where applicable.
 * More information is available in our [Developer's Guide](https://docs.google.com/document/d/1_QDDbqmBrJuGqBoib59fmgYtls03dAXXuLqRR5roPO4/edit).
 
+## Static assets
+
+* **`public/Josh-Maria-Songlist.pdf`** — the "Current Songlist" PDF linked from the **Book Us** page (`/music/bookus`). It is served by the app itself (opens inline in a new tab at `/Josh-Maria-Songlist.pdf`) rather than from Dropbox, so it renders reliably and isn't subject to Dropbox's download/redirect behavior.
+  * It is **derived from** the source spreadsheet in Dropbox: `joshandmariamusic/docs/Josh & Maria Songlist with links.xlsx`. The PDF lists each song's Title and Artist; original songs link their title to a working recording (web-jam.com or YouTube). When that spreadsheet changes, regenerate the PDF and re-commit it here (deploy required to publish).
+
 ## Deployment
 
 JaMmusic is a static SPA with no server of its own. It is built **into** two Heroku apps at build time — each backend's `postinstallJaM.sh` clones JaMmusic and checks out `main` (or `dev` for non-prod builds):

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/public/Josh-Maria-Songlist.pdf
+++ b/public/Josh-Maria-Songlist.pdf
@@ -1,0 +1,222 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 25 0 R /MediaBox [ 0 0 612 792 ] /Parent 24 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://web-jam.com/music/songs?id=5f5e6b7d13772f0004a091ae)
+>> /Border [ 0 0 0 ] /Rect [ 72.8 510.55 118.37 524.55 ] /Subtype /Link /Type /Annot
+>>
+endobj
+6 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://web-jam.com/music/songs?id=5f5e6b7d13772f0004a091b2)
+>> /Border [ 0 0 0 ] /Rect [ 72.8 486.55 145.61 500.55 ] /Subtype /Link /Type /Annot
+>>
+endobj
+7 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://youtu.be/IgKUq4fUImw)
+>> /Border [ 0 0 0 ] /Rect [ 72.8 462.55 161.15 476.55 ] /Subtype /Link /Type /Annot
+>>
+endobj
+8 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://youtu.be/533dH_Lwk90)
+>> /Border [ 0 0 0 ] /Rect [ 72.8 438.55 115.6 452.55 ] /Subtype /Link /Type /Annot
+>>
+endobj
+9 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://web-jam.com/music/songs?id=5f5e6b7d13772f0004a091b1)
+>> /Border [ 0 0 0 ] /Rect [ 72.8 414.55 123.37 428.55 ] /Subtype /Link /Type /Annot
+>>
+endobj
+10 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://youtu.be/kxRA9Wm3zt0)
+>> /Border [ 0 0 0 ] /Rect [ 72.8 390.55 160.04 404.55 ] /Subtype /Link /Type /Annot
+>>
+endobj
+11 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://web-jam.com/music/songs?id=5f5e6b7d13772f0004a091ad)
+>> /Border [ 0 0 0 ] /Rect [ 72.8 366.55 163.37 380.55 ] /Subtype /Link /Type /Annot
+>>
+endobj
+12 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://youtu.be/WozbDmVPB3o)
+>> /Border [ 0 0 0 ] /Rect [ 72.8 318.55 129.48 332.55 ] /Subtype /Link /Type /Annot
+>>
+endobj
+13 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://youtu.be/HwjwUvjABPU)
+>> /Border [ 0 0 0 ] /Rect [ 72.8 294.55 123.94 308.55 ] /Subtype /Link /Type /Annot
+>>
+endobj
+14 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://youtu.be/bkb61qoW-mg)
+>> /Border [ 0 0 0 ] /Rect [ 72.8 270.55 117.27 284.55 ] /Subtype /Link /Type /Annot
+>>
+endobj
+15 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://web-jam.com/music/songs?id=5f5e6b7d13772f0004a091b0)
+>> /Border [ 0 0 0 ] /Rect [ 72.8 246.55 111.95 260.55 ] /Subtype /Link /Type /Annot
+>>
+endobj
+16 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://web-jam.com/music/songs?id=5f5e6b7d13772f0004a091b3)
+>> /Border [ 0 0 0 ] /Rect [ 72.8 198.55 159.51 212.55 ] /Subtype /Link /Type /Annot
+>>
+endobj
+17 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://youtu.be/-Fbfa4QAJkA)
+>> /Border [ 0 0 0 ] /Rect [ 72.8 174.55 127.83 188.55 ] /Subtype /Link /Type /Annot
+>>
+endobj
+18 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://youtu.be/pd3_77SxmJA)
+>> /Border [ 0 0 0 ] /Rect [ 72.8 150.55 125.04 164.55 ] /Subtype /Link /Type /Annot
+>>
+endobj
+19 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://youtu.be/J4CYKcQ5OZI)
+>> /Border [ 0 0 0 ] /Rect [ 72.8 126.55 116.71 140.55 ] /Subtype /Link /Type /Annot
+>>
+endobj
+20 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://web-jam.com/music/songs?id=5f5e6b7d13772f0004a091af)
+>> /Border [ 0 0 0 ] /Rect [ 72.8 102.55 134.51 116.55 ] /Subtype /Link /Type /Annot
+>>
+endobj
+21 0 obj
+<<
+/Annots [ 5 0 R 6 0 R 7 0 R 8 0 R 9 0 R 10 0 R 11 0 R 12 0 R 13 0 R 14 0 R 
+  15 0 R 16 0 R 17 0 R 18 0 R 19 0 R 20 0 R ] /Contents 26 0 R /MediaBox [ 0 0 612 792 ] /Parent 24 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 
+  /Trans <<
+
+>> /Type /Page
+>>
+endobj
+22 0 obj
+<<
+/PageMode /UseNone /Pages 24 0 R /Type /Catalog
+>>
+endobj
+23 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260604122556-04'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260604122556-04'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (Josh & Maria Songlist) /Trapped /False
+>>
+endobj
+24 0 obj
+<<
+/Count 2 /Kids [ 4 0 R 21 0 R ] /Type /Pages
+>>
+endobj
+25 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1512
+>>
+stream
+Gatm<hcJes(k).^pmtN1c42bs&'CZ?JrZuDFI'7[p*J,e);8UJ/UI3\pM5nOJu0l-XU8Na^O,k>hBXE*iBcbdZQ,X1_!*-G66Va!#s&)42fOm!rB):MB1@=tJhH^W0j]C&it\?j_96jAIaACJpfEU[V%pf1,mER6OC!A!"e8hu@L9fc/^o<fABAu>jR81XLZB+rIL1SU^Z)NE^l&U0Lu7ImiV%Tg9EA/D'KU^AFmrRsROG_f6r=$8<)3E=h<stWJC7mM,g2jrP6t]d_^lJ-'mn"]A4!F+-l"G_I&;!8jPlMpQZN`!"=U)#gs6IUVR?/u(Io+aO(\MZ9X-=EnJuY;ImTsrfU^rG#:FV>@2)4f[J0NF8_B$HQsiOf0koEpkoC+F_$o<jBs04Cn5)XpVLL#]25YRGU]o5.>C,@#eiiU&Q6,k?\jnSpkn/oVHUNLP*`6D&,LUAl&W*T97"U^G&Sg-s?;$3fef>+O)IsDaMfM]c3B[Z=(o&;1B$N#o?Ung,7;3LmgY=(I>]>j^1?5u[3s[V\H#Bj!]#<C[_gMj\/&:&l'#ru77EOkiP>Yp/N7]AAa!Fuj[7k#?A0kJ$kA[3G$<%p/ejd2EjUR"3pW&/@U[Q'oS?Qc^kEb9j8b'YkGDC!+(FNso,_RMm3)*P>*\!UCKnOKgTs)VI_:@&>V#Q-]"_Z1p=iRk2_Bd%bfupnH;Qd>89\#&DbhEJJn<OFL3R\jNZeRf/Ld,@^4lEA$>f!u/n2D7n@H?;'>B90gFOiV,H=J-@3EUNZGGPF"YK+rh"dF`[[=lWGY4lb'_<l&hjWle-n/\TWYLP\9(;lWj.ZRo3eo:0#2,$!eH=P0PH!E4L/VOW<A!7hji9A?EcT)2UDYA+'D9;PpPs:XF0#eWnK8'3g![ac?@H?2d>B7`Nb??kq%c6So*$]O$iH>;JV2LZ/De`C[:Xm8d^2Qq%9`bA$rsk;d@4]ikadIF]2"6gdLUse<3AYs3-Oua8ZXUmH(pK`g3,pb:7u5WcK0:sPO"k.!WiUBF,E^R)YAqO6T:S1`$<D29P.#E3B/mGk*'b_RfA9)*`W%mg^i,kt8REtpiN@E%>/&m)A0*^TGKL]2TUIJncck/H2q-Vp.1ES0Jm4h(RDA\V=fNj5$L2$WJ]b4u&r((RO]X0FH*uGWY[2dE-2bm--'O%/Ij0hkZfkfY.p3&>NL63+ggL0N6_AH@I%2UA2nZ69$[nTqgoMb.]5?-GFgLO*Rc4tM0:o%q%\o-$_8?R`ETE*8=O-s!Xl<`i=DE#%;p<tG9+4iR+3d]^K;j2\)"Y,kBAds4Kg'W8p/#>b*4MeWp7?o)Vb9mg2S8A/2)BTi.:L?uI/T.8*,1T[\h<ke>WsBHac?h>@7?#oBA9/TlXo?Kjg^j19@MB13]J%e896uLIgiWt"*WG6#e;]C,TNP.rM*rTFgL8!PRLW_1=]iGip:(!!W')R+W\&%R(o#MD]iEIchDXUl]6hrn#,<qIK'.0YBlhWU^$X@"@rIm\L4>a~>endstream
+endobj
+26 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1331
+>>
+stream
+Gau0E?$"^Z'Re<2\5/UMcE,T[-%A$DPH`;dh))X*l(^UFE.audR!.+h^Xj#a',Cn"lo9Ork3/=^FcW\:$3;2io/J<&L)Ko/7=d58^&[8J6ZrQug"EhjqJp2d8HNm^&(;0K-8_fRi9dk=SLHZcMAbo:+jTP8K9>Zb*?s$(Ero,I:*?NlOpJ>L4?$W`'CD/Qi/9&DaGq^fTb&"e4-]FW1H6*.^uWV2Zr`W"*"$[oL5m8D^cP%pilFt6H06Ra*B=J+GE,eba:X?CF2YR57uVcWLo-1PdE"C>PWNnRR<OZh7uI;d%\,?3&PS+=`m*_ec.IT6,nPoPlXRcnXmL>$O)]-[8q^S;K<6<J&AMgG[?/-hp(alW2;gtep7Mh,Ft;3rWJY9[#5;b\NL&M4(7(OG."+8BL[u-Bl]kW,oeb$K_=mU[o]pn('oYldmnn>j*=./OP>taXF2!<#ok:8[TR0SOdMf9Gft<K6fH_RPl;.CKk!hXk""`#(niQK8aG\]Cr,@coTAVn'Cch@qglqVhedmIfU!_EG5sIK.b20qkjb8$-5N'4U8kuER/%^[N$r7Uf8Q-B>TEMb[H=g(fZma[+nQj"6_EUZ0SZJm9Xs.O\^R<3ACNr(iT?I0-#dm%/.,bPd,-8.qYb&3dW9NSUAXb_CC/MDVCcgIO?+#,j2Psn]7PpbeN^1IK$(_3T"-Fju0og[(2qfmH,Sj3cCIkZT2_Pq#3@R>+H%MO>8*mf+MMI9tTKVd?OhoR60B_g4N,qqY0Yq4B9JRN0'T&1h1fg5>A7c:9L68QFYgDZ[4`B=GgNgdc*pu"@8_R#]P(\M*.h7'(F5A-/$25&:`a01&UA`"R&m\KAc3LO,>j(=_(YU#sC?Jp$b3-,Vq',;cL:RR7A4>a=!,lM+Vac2[AW98TnERh;!\Zu=W4Ks"]9RgCh)"FE&1m4k),p"'0ZImo2:Pp^)TLL0_I8HdY5Ksg/8ER49if6?Gg'%\[oHjq>hG;u6hII5G@bh>,*AMD@>h"S?iWRYB_M0GqjHBD1U!R,qGmAD?LPs]nK6K0DU5SS&C@ej5*-HG=6$b&>n1a(r9=:K)>4_o\1<aN;aUH:SdV[G.i<!4rj^RgO7G2h-GN1WP7"MEm5mEloR>&DZEDD&M+I!b_[j/HeJelW2ikIV/a)hXY[/=Z20S(pJcqcK+TBTWT@Yc:?,l4[p(Dqd.mF]k[s>U)T'a)Fr,M'f`4[(XkfV4r85d3#(t<mnC2-g'HF5Q[eO=:BI>qX1ocm]k]pdV+T^AWNM<Sr`@oaH5[85G$mF04]naGekqnAF:$9r^CG0?5A1\LcjG!9dR3;X5X_jBZ~>endstream
+endobj
+xref
+0 27
+0000000000 65535 f 
+0000000061 00000 n 
+0000000102 00000 n 
+0000000209 00000 n 
+0000000321 00000 n 
+0000000516 00000 n 
+0000000717 00000 n 
+0000000918 00000 n 
+0000001088 00000 n 
+0000001257 00000 n 
+0000001458 00000 n 
+0000001629 00000 n 
+0000001831 00000 n 
+0000002002 00000 n 
+0000002173 00000 n 
+0000002344 00000 n 
+0000002546 00000 n 
+0000002748 00000 n 
+0000002919 00000 n 
+0000003090 00000 n 
+0000003261 00000 n 
+0000003463 00000 n 
+0000003781 00000 n 
+0000003851 00000 n 
+0000004140 00000 n 
+0000004207 00000 n 
+0000005811 00000 n 
+trailer
+<<
+/ID 
+[<2416ea39627049caecdc67e33c53af3c><2416ea39627049caecdc67e33c53af3c>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 23 0 R
+/Root 22 0 R
+/Size 27
+>>
+startxref
+7234
+%%EOF

--- a/src/App/AppTemplate/Footer.tsx
+++ b/src/App/AppTemplate/Footer.tsx
@@ -5,7 +5,6 @@ const footerLinks = () => {
     { href: 'https://github.com/WebJamApps', name: 'github' },
     { href: 'https://www.linkedin.com/company/webjam/', name: 'linkedin' },
     { href: 'https://www.instagram.com/joshua.v.sherman/', name: 'instagram' },
-    { href: 'https://twitter.com/JoshuaVSherman', name: 'twitter' },
     { href: 'https://www.facebook.com/WebJamLLC/', name: 'facebook' },
     { href: 'https://joshuavsherman.tumblr.com/', name: 'tumblr' },
   ];

--- a/src/containers/BookUs/index.tsx
+++ b/src/containers/BookUs/index.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@mui/material';
 import { Inquiry } from '../Homepage/Inquiry';
 
-const songlistUrl = 'https://docs.google.com/spreadsheets/d/1uePCuHO6qxg2tHTqGist_O4iYXJjy9AgSmXvMgF9NPM/edit?usp=sharing';
+const songlistUrl = '/Josh-Maria-Songlist.pdf';
 export function BookUs() {
   return (
     <div className="bookus" style={{ margin: 'auto', padding: '6px', paddingRight: '12px' }}>
@@ -14,7 +14,7 @@ export function BookUs() {
             style={{ marginLeft: '8px' }}
             size="small"
             variant="contained"
-            onClick={() => window.open(songlistUrl)}
+            onClick={() => window.open(songlistUrl, '_blank', 'noopener,noreferrer')}
           >
             Current Songlist
           </Button>

--- a/src/containers/BuyMusic/BuyLinks/AlbumBuyCard.tsx
+++ b/src/containers/BuyMusic/BuyLinks/AlbumBuyCard.tsx
@@ -1,0 +1,52 @@
+interface IalbumBuyCardProps {
+  heading: string;
+  href: string;
+  img: string;
+  alt: string;
+  title: string;
+}
+
+export function AlbumBuyCard({
+  heading, href, img, alt, title,
+}: IalbumBuyCardProps) {
+  return (
+    <div className="col">
+      <div className="material-content elevation2" style={{ maxWidth: '3in', margin: 'auto', height: '3in' }}>
+        <h5 style={{ textAlign: 'center' }}>{heading}</h5>
+        <div style={{ textAlign: 'center' }}>
+          <a
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            title={title}
+            style={{ textDecoration: 'none' }}
+          >
+            <img
+              src={img}
+              alt={alt}
+              style={{
+                width: '150px', height: '150px', display: 'block', margin: '0 auto 12px',
+              }}
+            />
+            <span
+              style={{
+                display: 'inline-block',
+                background: '#ff9900',
+                color: '#131921',
+                fontWeight: 700,
+                padding: '6px 18px',
+                borderRadius: '4px',
+                fontSize: '13px',
+              }}
+            >
+              <i className="fas fa-shopping-cart" style={{ marginRight: '6px' }} aria-hidden="true" />
+              Buy on Amazon
+            </span>
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AlbumBuyCard;

--- a/src/containers/BuyMusic/BuyLinks/joshShermanBand.tsx
+++ b/src/containers/BuyMusic/BuyLinks/joshShermanBand.tsx
@@ -1,29 +1,14 @@
+import AlbumBuyCard from './AlbumBuyCard';
 
 function JoshShermanBand() {
   return (
-    <div className="col">
-      <div className="material-content elevation2" style={{ maxWidth: '3in', margin: 'auto', height: '3in' }}>
-        <h5 style={{ textAlign: 'center' }}>Josh Sherman Band</h5>
-        <div style={{ textAlign: 'center' }}>
-          <a
-            href="https://www.amazon.com/Live-Central-Florida-2001-Explicit/dp/B0015HGSEO/ref=ntt_mus_dp_dpt_1"
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{
-              display: 'inline-block',
-              background: 'url(https://m.media-amazon.com/images/I/81hDicJieTL._SS500_.jpg) 18px 2px no-repeat, '
-                + 'url(http://content.cdbaby.com/img/links/link-artwork-cart-dark-buy-now.png) 0px 0px no-repeat',
-              backgroundSize: '175px, 211px',
-              height: '233px',
-              width: '211px',
-            }}
-            title="Josh Sherman Band: live from central Florida, 2001 - 2005"
-          >
-            <span style={{ display: 'none' }}>Buy Josh Sherman Band</span>
-          </a>
-        </div>
-      </div>
-    </div>
+    <AlbumBuyCard
+      heading="Josh Sherman Band"
+      href="https://www.amazon.com/Live-Central-Florida-2001-Explicit/dp/B0015HGSEO/ref=ntt_mus_dp_dpt_1"
+      img="https://m.media-amazon.com/images/I/81hDicJieTL._SS500_.jpg"
+      alt="Josh Sherman Band: Live from Central Florida 2001-2005"
+      title="Josh Sherman Band: live from central Florida, 2001 - 2005"
+    />
   );
 }
 

--- a/src/containers/BuyMusic/BuyLinks/joshShermanSolo.tsx
+++ b/src/containers/BuyMusic/BuyLinks/joshShermanSolo.tsx
@@ -1,30 +1,14 @@
+import AlbumBuyCard from './AlbumBuyCard';
 
 function JoshShermanSolo() {
   return (
-    <div className="col">
-      <div className="material-content elevation2" style={{ margin: 'auto', maxWidth: '3in', height: '3in' }}>
-        <h5 style={{ textAlign: 'center' }}>Solo Acoustic</h5>
-        <div style={{ textAlign: 'center' }}>
-          <a
-            href="https://www.amazon.com/Solo-Acoustic-Explicit-Josh-Sherman/dp/B0013XP8MI/ref=ntt_mus_dp_dpt_2"
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{
-              textAlign: 'center',
-              display: 'inline-block',
-              background: 'url(https://m.media-amazon.com/images/I/81PLWgAmBEL._SS500_.jpg) 18px 2px no-repeat, '
-                + 'url(http://content.cdbaby.com/img/links/link-artwork-cart-light-buy-now.png) 0px 0px no-repeat',
-              backgroundSize: '175px, 211px',
-              height: '233px',
-              width: '211px',
-            }}
-            title="Josh Sherman: Solo Acoustic"
-          >
-            <span style={{ display: 'none' }}>Buy Solo Acoustic</span>
-          </a>
-        </div>
-      </div>
-    </div>
+    <AlbumBuyCard
+      heading="Solo Acoustic"
+      href="https://www.amazon.com/Solo-Acoustic-Explicit-Josh-Sherman/dp/B0013XP8MI/ref=ntt_mus_dp_dpt_2"
+      img="https://m.media-amazon.com/images/I/81PLWgAmBEL._SS500_.jpg"
+      alt="Josh Sherman: Solo Acoustic"
+      title="Josh Sherman: Solo Acoustic"
+    />
   );
 }
 

--- a/src/containers/BuyMusic/MediaLinks/joshShermanAppleOrYouTube.tsx
+++ b/src/containers/BuyMusic/MediaLinks/joshShermanAppleOrYouTube.tsx
@@ -12,7 +12,7 @@ export function JoshShermanAppleOrYouTube({ service }: { service: 'Apple Music' 
         <div className="elevation3 top-row-style" style={{ textAlign: 'center', marginBottom: '50px' }}>
           <a
             href={service === 'Apple Music' ? 'https://music.apple.com/nz/artist/josh-sherman-band/id80070957'
-              : '"https://youtube.com/playlist?list=OLAK5uy_mtLf1U_oKuSgkFRcXYpo5E0OJWnvRt1TI"'}
+              : 'https://youtube.com/playlist?list=OLAK5uy_mtLf1U_oKuSgkFRcXYpo5E0OJWnvRt1TI'}
             className={service === 'Apple Music' ? 'fab fa-apple fa-2x' : 'fab fa-youtube fa-2x'}
             style={{ color: '#333333', margin: '20px', marginLeft: '5%' }}
           >

--- a/src/containers/BuyMusic/index.tsx
+++ b/src/containers/BuyMusic/index.tsx
@@ -27,7 +27,7 @@ export default class BuyMusic extends Component {
           textAlign: 'center', margin: '20px', fontWeight: 'bold', marginBottom: '10px',
         }}
         >
-          Buy from CD Baby
+          Buy from Amazon Music
         </h2>
         <div className="row top-row-style">
           <Jsb />

--- a/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
+++ b/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
@@ -246,19 +246,6 @@ exports[`AppTemplate > renders the component 1`] = `
                 </span>
               </a>
               <a
-                aria-label="twitter"
-                href="https://twitter.com/JoshuaVSherman"
-                rel="noopener noreferrer"
-                style="color: var(--footer-link); padding-right: 5px;"
-                target="_blank"
-              >
-                <span>
-                  <i
-                    class="fab fa-twitter"
-                  />
-                </span>
-              </a>
-              <a
                 aria-label="facebook"
                 href="https://www.facebook.com/WebJamLLC/"
                 rel="noopener noreferrer"

--- a/test/containers/BuyMusic/__snapshots__/index.spec.tsx.snap
+++ b/test/containers/BuyMusic/__snapshots__/index.spec.tsx.snap
@@ -9,7 +9,7 @@ exports[`BuyMusic > renders correctly 1`] = `
     <h2
       style="text-align: center; font-weight: bold; margin: 20px 20px 10px;"
     >
-      Buy from CD Baby
+      Buy from Amazon Music
     </h2>
     <div
       class="row top-row-style"
@@ -32,14 +32,24 @@ exports[`BuyMusic > renders correctly 1`] = `
             <a
               href="https://www.amazon.com/Live-Central-Florida-2001-Explicit/dp/B0015HGSEO/ref=ntt_mus_dp_dpt_1"
               rel="noopener noreferrer"
-              style="display: inline-block; background: url("https://m.media-amazon.com/images/I/81hDicJieTL._SS500_.jpg") no-repeat, url("http://content.cdbaby.com/img/links/link-artwork-cart-dark-buy-now.png") no-repeat; height: 233px; width: 211px;"
+              style="text-decoration: none;"
               target="_blank"
               title="Josh Sherman Band: live from central Florida, 2001 - 2005"
             >
+              <img
+                alt="Josh Sherman Band: Live from Central Florida 2001-2005"
+                src="https://m.media-amazon.com/images/I/81hDicJieTL._SS500_.jpg"
+                style="width: 150px; height: 150px; display: block; margin: 0px auto 12px;"
+              />
               <span
-                style="display: none;"
+                style="display: inline-block; background: rgb(255, 153, 0); color: rgb(19, 25, 33); font-weight: 700; padding: 6px 18px; border-radius: 4px; font-size: 13px;"
               >
-                Buy Josh Sherman Band
+                <i
+                  aria-hidden="true"
+                  class="fas fa-shopping-cart"
+                  style="margin-right: 6px;"
+                />
+                Buy on Amazon
               </span>
             </a>
           </div>
@@ -50,7 +60,7 @@ exports[`BuyMusic > renders correctly 1`] = `
       >
         <div
           class="material-content elevation2"
-          style="margin: auto; max-width: 3in; height: 3in;"
+          style="max-width: 3in; margin: auto; height: 3in;"
         >
           <h5
             style="text-align: center;"
@@ -63,14 +73,24 @@ exports[`BuyMusic > renders correctly 1`] = `
             <a
               href="https://www.amazon.com/Solo-Acoustic-Explicit-Josh-Sherman/dp/B0013XP8MI/ref=ntt_mus_dp_dpt_2"
               rel="noopener noreferrer"
-              style="text-align: center; display: inline-block; background: url("https://m.media-amazon.com/images/I/81PLWgAmBEL._SS500_.jpg") no-repeat, url("http://content.cdbaby.com/img/links/link-artwork-cart-light-buy-now.png") no-repeat; height: 233px; width: 211px;"
+              style="text-decoration: none;"
               target="_blank"
               title="Josh Sherman: Solo Acoustic"
             >
+              <img
+                alt="Josh Sherman: Solo Acoustic"
+                src="https://m.media-amazon.com/images/I/81PLWgAmBEL._SS500_.jpg"
+                style="width: 150px; height: 150px; display: block; margin: 0px auto 12px;"
+              />
               <span
-                style="display: none;"
+                style="display: inline-block; background: rgb(255, 153, 0); color: rgb(19, 25, 33); font-weight: 700; padding: 6px 18px; border-radius: 4px; font-size: 13px;"
               >
-                Buy Solo Acoustic
+                <i
+                  aria-hidden="true"
+                  class="fas fa-shopping-cart"
+                  style="margin-right: 6px;"
+                />
+                Buy on Amazon
               </span>
             </a>
           </div>
@@ -182,7 +202,7 @@ exports[`BuyMusic > renders correctly 1`] = `
         >
           <a
             class="fab fa-youtube fa-2x"
-            href=""https://youtube.com/playlist?list=OLAK5uy_mtLf1U_oKuSgkFRcXYpo5E0OJWnvRt1TI""
+            href="https://youtube.com/playlist?list=OLAK5uy_mtLf1U_oKuSgkFRcXYpo5E0OJWnvRt1TI"
             style="color: rgb(51, 51, 51); margin: 20px 20px 20px 5%;"
           >
              


### PR DESCRIPTION
Addresses **/music page link fixes** from Maria's 2026-06-03 review (#1091).


## Changes
- **#3 — BookUs "Current Songlist"** pointed at a deleted Google Sheet. Now a site-hosted PDF at `/Josh-Maria-Songlist.pdf` (in `public/`), opened in a new tab — renders inline as `application/pdf`. Derived from the Dropbox spreadsheet `joshandmariamusic/docs/Josh & Maria Songlist with links.xlsx`; all 16 original-song recording links were verified live (web-jam.com ids checked against the prod `/song` API, YouTube via oEmbed).
- **#4 — BuyMusic "Buy from CD Baby"** → **"Buy from Amazon Music"**. The two buy buttons linked to Amazon but showed dead `content.cdbaby.com` cart graphics; replaced with a local **"Buy on Amazon"** badge via a new shared `AlbumBuyCard` component.
- **#5 — Josh Sherman Band YouTube link** had stray literal quotes baked into the URL string, so it resolved to web-jam.com. Fixed.
- **#6 — Empty X/Twitter link** removed from the footer.
- **README** — new "Static assets" section documenting the songlist PDF and its Dropbox source spreadsheet.

## How to Test Locally
```bash
git checkout fix-music-links-maria-review
npm install
npm run dev
# open http://localhost:7878/
```
1. **/music/bookus** → click **Current Songlist** → PDF opens/renders in a new tab (not a download).
2. **/music/buymusic** → heading reads "Buy from Amazon Music"; both albums show cover art + an orange "Buy on Amazon" badge; under "Also on YouTube", the Josh Sherman Band link goes to a real YouTube playlist.
3. **Footer** (any page) → no X/Twitter icon.

Checks: `npm run lint`, `npx tsc --noEmit`, `TZ=UTC npx vitest run`.

Refs #1091
🤖 Generated with [Claude Code](https://claude.com/claude-code)
