### PR TITLE
fix(homepage): remove underline on FAQs heading

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.9.6",
+  "version": "2.9.7",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/Homepage/FAQs.tsx
+++ b/src/containers/Homepage/FAQs.tsx
@@ -65,7 +65,7 @@ const AccA3 = () => (
 function Faqs() {
   return (
     <div className="faqs">
-      <h3 style={{ textDecoration: 'underline', textAlign: 'center' }}>FAQs</h3>
+      <h3 style={{ textAlign: 'center' }}>FAQs</h3>
       <div className="qAnda">
         <Accordion>
           <AccQ1 />

--- a/test/containers/Homepage/__snapshots__/index.spec.tsx.snap
+++ b/test/containers/Homepage/__snapshots__/index.spec.tsx.snap
@@ -47,7 +47,7 @@ exports[`Homepage > renders correctly 1`] = `
                         class="faqs"
                       >
                         <h3
-                          style="text-decoration: underline; text-align: center;"
+                          style="text-align: center;"
                         >
                           FAQs
                         </h3>


### PR DESCRIPTION
Small cosmetic fix spotted during testing: the **FAQs** heading on the homepage had a `textDecoration: underline` that looked off. Removed it (alignment unchanged).

## How to Test Locally
```bash
git checkout fix-faqs-underline
npm install
npm run dev
# http://localhost:7878/  -> the "FAQs" heading is no longer underlined
```
Checks: `npx vitest run test/containers/Homepage` (29 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
