### PR TITLE
feat(admin-users): EditUserDialog + Notes column + sortable table (Maria #14, follow-up to #1096)

### DIFF
--- a/__mocks__/@mui/material.tsx
+++ b/__mocks__/@mui/material.tsx
@@ -132,6 +132,11 @@ export function TableCell(props:any) {
   return <td {...props}>{children}</td>;
 }
 
+export function TableSortLabel(props:any) {
+  const { children, active, direction, ...rest } = props;
+  return <span role="button" {...rest}>{children}</span>;
+}
+
 // Default to desktop (false) in tests; suites can override per-case.
 export function useMediaQuery() {
   return false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.9.7",
+  "version": "2.9.8",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.9.6",
+  "version": "2.9.7",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/AdminUsers/EditUserDialog.tsx
+++ b/src/containers/AdminUsers/EditUserDialog.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react';
 import {
   Dialog, DialogTitle, DialogContent, DialogActions,
-  Button, Box, Typography, FormGroup, FormControlLabel, Checkbox, FormControl, InputLabel, Select, MenuItem,
+  Button, Box, Typography, FormGroup, FormControlLabel, Checkbox, FormControl, InputLabel, Select, MenuItem, TextField,
 } from '@mui/material';
 import { CAPABILITY_GROUPS, USER_ROLES, USER_STATUS_OPTIONS, type Capability } from './capabilities';
 import adminUtils, { type IadminUser } from './admin-users.utils';
 
-interface IeditPrivilegesDialogProps {
+interface IeditUserDialogProps {
   open: boolean;
   user: IadminUser | null;
   token: string;
@@ -14,12 +14,15 @@ interface IeditPrivilegesDialogProps {
   onSaved: () => void;
 }
 
-export function EditPrivilegesDialog({
+export function EditUserDialog({
   open, user, token, onClose, onSaved,
-}: IeditPrivilegesDialogProps) {
+}: IeditUserDialogProps) {
   const [privileges, setPrivileges] = useState<Capability[]>([]);
   const [userType, setUserType] = useState<string>('');
   const [userStatus, setUserStatus] = useState<string>('');
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [notes, setNotes] = useState('');
   const [error, setError] = useState('');
   const [submitting, setSubmitting] = useState(false);
 
@@ -28,6 +31,9 @@ export function EditPrivilegesDialog({
       setPrivileges((user.privileges || []) as Capability[]);
       setUserType(user.userType || '');
       setUserStatus(user.userStatus || '');
+      setName(user.name || '');
+      setEmail(user.email || '');
+      setNotes(user.userDetails || '');
     }
     setError('');
   }, [user]);
@@ -38,6 +44,8 @@ export function EditPrivilegesDialog({
 
   const handleSave = async () => {
     if (!user) return;
+    if (!name.trim()) { setError('Name is required'); return; }
+    if (!email.trim()) { setError('Email is required'); return; }
     setSubmitting(true);
     setError('');
     try {
@@ -45,6 +53,9 @@ export function EditPrivilegesDialog({
         privileges,
         userType: userType || undefined,
         userStatus: userStatus || undefined,
+        name: name.trim(),
+        email: email.trim(),
+        userDetails: notes,
       });
       onSaved();
     } catch (e) {
@@ -59,7 +70,23 @@ export function EditPrivilegesDialog({
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
       <DialogTitle>Edit User{user ? ` — ${user.name}` : ''}</DialogTitle>
       <DialogContent>
-        <FormControl fullWidth sx={{ marginTop: 1, marginBottom: 3 }}>
+        <TextField
+          label="Name"
+          fullWidth
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          sx={{ marginTop: 1, marginBottom: 2 }}
+          data-testid="edit-user-name"
+        />
+        <TextField
+          label="Email"
+          fullWidth
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          sx={{ marginBottom: 2 }}
+          data-testid="edit-user-email"
+        />
+        <FormControl fullWidth sx={{ marginBottom: 3 }}>
           <InputLabel id="edit-user-status-label">Type</InputLabel>
           <Select
             labelId="edit-user-status-label"
@@ -121,6 +148,16 @@ export function EditPrivilegesDialog({
             </Box>
           </Box>
         ))}
+        <TextField
+          label="Notes"
+          fullWidth
+          multiline
+          rows={2}
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          sx={{ marginTop: 3 }}
+          data-testid="edit-user-notes"
+        />
         {error && <Typography color="error" sx={{ marginTop: 1 }}>{error}</Typography>}
       </DialogContent>
       <DialogActions>

--- a/src/containers/AdminUsers/JaPrivilegesDialog.tsx
+++ b/src/containers/AdminUsers/JaPrivilegesDialog.tsx
@@ -6,7 +6,7 @@ import {
 import { CAPABILITY_GROUPS, USER_ROLES, type Capability } from './capabilities';
 import adminUtils, { type IadminUser } from './admin-users.utils';
 
-interface IeditPrivilegesDialogProps {
+interface IeditUserDialogProps {
     open: boolean;
     user: IadminUser | null;
     token: string;
@@ -14,9 +14,9 @@ interface IeditPrivilegesDialogProps {
     onSaved: () => void;
 }
 
-export function EditPrivilegesDialog({
+export function EditUserDialog({
     open, user, token, onClose, onSaved,
-}: IeditPrivilegesDialogProps) {
+}: IeditUserDialogProps) {
     const [privileges, setPrivileges] = useState<Capability[]>([]);
     const [userType, setUserType] = useState<string>('');
     const [error, setError] = useState('');

--- a/src/containers/AdminUsers/UsersTable.tsx
+++ b/src/containers/AdminUsers/UsersTable.tsx
@@ -1,8 +1,32 @@
 import { useState } from 'react';
 import {
-  Table, TableBody, TableCell, TableHead, TableRow, Button, Chip, Box,
+  Table, TableBody, TableCell, TableHead, TableRow, TableSortLabel, Button, Chip, Box,
 } from '@mui/material';
 import adminUtils, { type IadminUser } from './admin-users.utils';
+
+type Order = 'asc' | 'desc';
+
+const COLUMNS: { key: string; label: string }[] = [
+  { key: 'name', label: 'Name' },
+  { key: 'email', label: 'Email' },
+  { key: 'role', label: 'Role' },
+  { key: 'type', label: 'Type' },
+  { key: 'privileges', label: 'Privileges' },
+  { key: 'notes', label: 'Notes' },
+];
+
+// The value each column sorts by (also what the row cells display).
+export function sortValue(u: IadminUser, key: string): string {
+  switch (key) {
+    case 'name': return u.name || '';
+    case 'email': return u.email || '';
+    case 'role': return u.userType || '';
+    case 'type': return u.userStatus || '';
+    case 'privileges': return (u.privileges || []).join(', ');
+    case 'notes': return u.userDetails || '';
+    default: return '';
+  }
+}
 
 interface IusersTableProps {
   users: IadminUser[];
@@ -16,6 +40,20 @@ export function UsersTable({
   users, token, onShowToken, onEditPrivileges, onChange,
 }: IusersTableProps) {
   const [busy, setBusy] = useState<string>('');
+  const [orderBy, setOrderBy] = useState<string>('name');
+  const [order, setOrder] = useState<Order>('asc');
+
+  const handleSort = (key: string) => {
+    if (orderBy === key) { setOrder(order === 'asc' ? 'desc' : 'asc'); } else { setOrderBy(key); setOrder('asc'); }
+  };
+
+  const sortedUsers = [...users].sort((a, b) => {
+    const av = sortValue(a, orderBy).toLowerCase();
+    const bv = sortValue(b, orderBy).toLowerCase();
+    if (av < bv) return order === 'asc' ? -1 : 1;
+    if (av > bv) return order === 'asc' ? 1 : -1;
+    return 0;
+  });
 
   const handleShowToken = async (userId: string) => {
     setBusy(userId);
@@ -52,19 +90,26 @@ export function UsersTable({
 
   return (
     <Box sx={{ width: '100%', overflowX: 'auto' }}>
-      <Table data-testid="users-table" size="small" sx={{ minWidth: 720 }}>
+      <Table data-testid="users-table" size="small" sx={{ minWidth: 900 }}>
         <TableHead>
           <TableRow>
-            <TableCell>Name</TableCell>
-            <TableCell>Email</TableCell>
-            <TableCell>Role</TableCell>
-            <TableCell>Type</TableCell>
-            <TableCell>Privileges</TableCell>
+            {COLUMNS.map((col) => (
+              <TableCell key={col.key} sortDirection={orderBy === col.key ? order : false}>
+                <TableSortLabel
+                  active={orderBy === col.key}
+                  direction={orderBy === col.key ? order : 'asc'}
+                  onClick={() => handleSort(col.key)}
+                  data-testid={`sort-${col.key}`}
+                >
+                  {col.label}
+                </TableSortLabel>
+              </TableCell>
+            ))}
             <TableCell>Actions</TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
-          {users.map((u) => (
+          {sortedUsers.map((u) => (
             <TableRow key={u._id} data-testid={`user-row-${u._id}`}>
               <TableCell>{u.name}</TableCell>
               <TableCell>{u.email}</TableCell>
@@ -77,6 +122,7 @@ export function UsersTable({
               <TableCell>
                 {(u.privileges || []).map((p) => <Chip key={p} label={p} size="small" sx={{ margin: '2px' }} />)}
               </TableCell>
+              <TableCell sx={{ whiteSpace: 'pre-wrap', maxWidth: 240 }}>{u.userDetails}</TableCell>
               <TableCell>
                 <Button
                   size="small"
@@ -92,7 +138,7 @@ export function UsersTable({
                   disabled={busy === u._id}
                   data-testid={`edit-priv-${u._id}`}
                 >
-                  Edit privileges
+                  Edit User
                 </Button>
                 <Button
                   size="small"

--- a/src/containers/AdminUsers/admin-users.utils.ts
+++ b/src/containers/AdminUsers/admin-users.utils.ts
@@ -41,7 +41,10 @@ async function createUser(
 async function updateUser(
   token: string,
   userId: string,
-  payload: { privileges?: string[]; userType?: string; userStatus?: string },
+  payload: {
+    privileges?: string[]; userType?: string; userStatus?: string;
+    name?: string; email?: string; userDetails?: string;
+  },
 ): Promise<IadminUser> {
   const res = await fetch(`${baseUrl}/${userId}`, {
     method: 'PUT',

--- a/src/containers/AdminUsers/index.tsx
+++ b/src/containers/AdminUsers/index.tsx
@@ -4,7 +4,7 @@ import { AuthContext } from 'src/providers/Auth.provider';
 import { CreateUserForm } from './CreateUserForm';
 import { UsersTable } from './UsersTable';
 import { ShowTokenDialog } from './ShowTokenDialog';
-import { EditPrivilegesDialog } from './EditPrivilegesDialog';
+import { EditUserDialog } from './EditUserDialog';
 import adminUtils, { type IadminUser } from './admin-users.utils';
 
 export function AdminUsers() {
@@ -64,7 +64,7 @@ export function AdminUsers() {
         token={tokenShown || ''}
         onClose={() => setTokenShown(null)}
       />
-      <EditPrivilegesDialog
+      <EditUserDialog
         open={editingUser !== null}
         user={editingUser}
         token={auth.token}

--- a/test/containers/AdminUsers/EditUserDialog.spec.tsx
+++ b/test/containers/AdminUsers/EditUserDialog.spec.tsx
@@ -3,14 +3,14 @@ import {
   render, screen, fireEvent, act, within,
 } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { EditPrivilegesDialog } from 'src/containers/AdminUsers/EditPrivilegesDialog';
+import { EditUserDialog } from 'src/containers/AdminUsers/EditUserDialog';
 import adminUtils, { type IadminUser } from 'src/containers/AdminUsers/admin-users.utils';
 
 const user: IadminUser = {
   _id: 'u1', name: 'Bot', email: 'b@x.com', privileges: ['gig:create'],
 };
 
-describe('EditPrivilegesDialog', () => {
+describe('EditUserDialog', () => {
   beforeEach(() => {
     adminUtils.updateUser = vi.fn(() => Promise.resolve({} as IadminUser)) as any;
   });
@@ -18,7 +18,7 @@ describe('EditPrivilegesDialog', () => {
   it('initializes with the user privileges', async () => {
     await act(async () => {
       render(
-        <EditPrivilegesDialog open user={user} token="tk" onClose={vi.fn()} onSaved={vi.fn()} />,
+        <EditUserDialog open user={user} token="tk" onClose={vi.fn()} onSaved={vi.fn()} />,
       );
     });
     expect(screen.getByRole('checkbox', { name: /gig:create/i })).toBeChecked();
@@ -29,35 +29,36 @@ describe('EditPrivilegesDialog', () => {
     const onSaved = vi.fn();
     await act(async () => {
       render(
-        <EditPrivilegesDialog open user={user} token="tk" onClose={vi.fn()} onSaved={onSaved} />,
+        <EditUserDialog open user={user} token="tk" onClose={vi.fn()} onSaved={onSaved} />,
       );
     });
     await act(async () => {
       fireEvent.click(screen.getByTestId('edit-priv-save'));
     });
-    expect(adminUtils.updateUser).toHaveBeenCalledWith('tk', 'u1', {
+    expect(adminUtils.updateUser).toHaveBeenCalledWith('tk', 'u1', expect.objectContaining({
       privileges: ['gig:create'],
-      userType: undefined,
-    });
+      name: 'Bot',
+      email: 'b@x.com',
+    }));
     expect(onSaved).toHaveBeenCalled();
   });
 
   it('calls onClose when Cancel clicked', () => {
     const onClose = vi.fn();
-    render(<EditPrivilegesDialog open user={user} token="tk" onClose={onClose} onSaved={vi.fn()} />);
+    render(<EditUserDialog open user={user} token="tk" onClose={onClose} onSaved={vi.fn()} />);
     fireEvent.click(screen.getByTestId('edit-priv-cancel'));
     expect(onClose).toHaveBeenCalled();
   });
 
   it('toggles a capability checkbox', async () => {
-    render(<EditPrivilegesDialog open user={user} token="tk" onClose={vi.fn()} onSaved={vi.fn()} />);
+    render(<EditUserDialog open user={user} token="tk" onClose={vi.fn()} onSaved={vi.fn()} />);
     const cap = screen.getByRole('checkbox', { name: /song:create/i });
     await act(async () => { fireEvent.click(cap); });
     expect(cap).toBeChecked();
   });
 
   it('handles null user gracefully on save', async () => {
-    render(<EditPrivilegesDialog open user={null} token="tk" onClose={vi.fn()} onSaved={vi.fn()} />);
+    render(<EditUserDialog open user={null} token="tk" onClose={vi.fn()} onSaved={vi.fn()} />);
     await act(async () => {
       fireEvent.click(screen.getByTestId('edit-priv-save'));
     });
@@ -69,7 +70,7 @@ describe('EditPrivilegesDialog', () => {
       _id: 'u2', name: 'Maria', email: 'm@x.com', userStatus: 'enabled', userType: 'JaM-admin', privileges: [],
     };
     await act(async () => {
-      render(<EditPrivilegesDialog open user={legacyUser} token="tk" onClose={vi.fn()} onSaved={vi.fn()} />);
+      render(<EditUserDialog open user={legacyUser} token="tk" onClose={vi.fn()} onSaved={vi.fn()} />);
     });
     await act(async () => {
       fireEvent.change(screen.getByTestId('edit-user-status'), { target: { value: 'human' } });
@@ -83,7 +84,7 @@ describe('EditPrivilegesDialog', () => {
       _id: 'u3', name: 'Josh', email: 'j@x.com', userStatus: 'human', userType: 'JaM-admin', privileges: [],
     };
     await act(async () => {
-      render(<EditPrivilegesDialog open user={humanUser} token="tk" onClose={vi.fn()} onSaved={vi.fn()} />);
+      render(<EditUserDialog open user={humanUser} token="tk" onClose={vi.fn()} onSaved={vi.fn()} />);
     });
     const typeSelect = screen.getByTestId('edit-user-status');
     expect(within(typeSelect).getByRole('option', { name: 'ai-agent' })).toBeDisabled();
@@ -94,9 +95,32 @@ describe('EditPrivilegesDialog', () => {
       _id: 'u4', name: 'Bot', email: 'bot@x.com', userStatus: 'ai-agent', userType: 'web-jam-llm', privileges: [],
     };
     await act(async () => {
-      render(<EditPrivilegesDialog open user={botUser} token="tk" onClose={vi.fn()} onSaved={vi.fn()} />);
+      render(<EditUserDialog open user={botUser} token="tk" onClose={vi.fn()} onSaved={vi.fn()} />);
     });
     const typeSelect = screen.getByTestId('edit-user-status');
     expect(within(typeSelect).getByRole('option', { name: 'ai-agent' })).not.toBeDisabled();
+  });
+
+  it('blocks save when the name is cleared', async () => {
+    await act(async () => {
+      render(<EditUserDialog open user={user} token="tk" onClose={vi.fn()} onSaved={vi.fn()} />);
+    });
+    await act(async () => { fireEvent.change(screen.getByTestId('edit-user-name'), { target: { value: '' } }); });
+    await act(async () => { fireEvent.click(screen.getByTestId('edit-priv-save')); });
+    expect(adminUtils.updateUser).not.toHaveBeenCalled();
+    expect(screen.getByText('Name is required')).toBeDefined();
+  });
+
+  it('saves edited name, email and notes', async () => {
+    await act(async () => {
+      render(<EditUserDialog open user={user} token="tk" onClose={vi.fn()} onSaved={vi.fn()} />);
+    });
+    await act(async () => { fireEvent.change(screen.getByTestId('edit-user-name'), { target: { value: 'Bot Two' } }); });
+    await act(async () => { fireEvent.change(screen.getByTestId('edit-user-email'), { target: { value: 'b2@x.com' } }); });
+    await act(async () => { fireEvent.change(screen.getByTestId('edit-user-notes'), { target: { value: 'updated note' } }); });
+    await act(async () => { fireEvent.click(screen.getByTestId('edit-priv-save')); });
+    expect(adminUtils.updateUser).toHaveBeenCalledWith('tk', 'u1', expect.objectContaining({
+      name: 'Bot Two', email: 'b2@x.com', userDetails: 'updated note',
+    }));
   });
 });

--- a/test/containers/AdminUsers/UsersTable.spec.tsx
+++ b/test/containers/AdminUsers/UsersTable.spec.tsx
@@ -61,4 +61,25 @@ describe('UsersTable', () => {
     });
     expect(adminUtils.deleteUser).not.toHaveBeenCalled();
   });
+
+  it('renders a Notes column from userDetails', () => {
+    const withNotes: IadminUser[] = [{
+      _id: 'u9', name: 'N', email: 'n@x.com', userDetails: 'the bot account', privileges: [],
+    }];
+    render(<UsersTable users={withNotes} token="tk" onShowToken={vi.fn()} onEditPrivileges={vi.fn()} onChange={vi.fn()} />);
+    expect(screen.getByText('the bot account')).toBeDefined();
+  });
+
+  it('sorts rows when a column header is clicked', () => {
+    const two: IadminUser[] = [
+      { _id: 'a', name: 'Alice', email: 'a@x.com', privileges: [] },
+      { _id: 'b', name: 'Bob', email: 'b@x.com', privileges: [] },
+    ];
+    render(<UsersTable users={two} token="tk" onShowToken={vi.fn()} onEditPrivileges={vi.fn()} onChange={vi.fn()} />);
+    // default sort is name asc -> Alice first
+    expect(document.querySelectorAll('tbody tr')[0].getAttribute('data-testid')).toBe('user-row-a');
+    // clicking the active Name header flips to desc -> Bob first
+    fireEvent.click(screen.getByTestId('sort-name'));
+    expect(document.querySelectorAll('tbody tr')[0].getAttribute('data-testid')).toBe('user-row-b');
+  });
 });


### PR DESCRIPTION
**Follow-up to #1096** (which only carried the first commit). This adds the rest of the admin/users work for Maria's review — it was committed after #1096 was already merged, so it needs its own PR.

## Changes
- **Edit the whole user (was privileges-only):** renamed `EditPrivilegesDialog` → **`EditUserDialog`**; now edits **Name, Email, Notes (`userDetails`), Type, Role, and Privileges**. Name + Email required. Table button now reads **"Edit User"**.
- **#14 — Notes column** added to the users table (renders `userDetails`).
- **Sortable table:** every data column sorts on header click (asc/desc toggle); Actions stays static.
- **Responsive:** table keeps horizontal scroll on narrow screens; min-width bumped for the added column.
- Added `TableSortLabel` to the `@mui/material` test mock.

No backend change needed — name/email/userDetails pass through `PUT /admin/user/:id`.

## How to Test Locally
```bash
git checkout fix-admin-user-type-edit
npm install
npm run dev   # run web-jam-back (#789 branch) on :7000 for live data
# http://localhost:7878/admin/users  (admin auth)
```
1. "Edit User" on a row → edit Name/Email/Notes/Type/Role/privileges → Save.
2. Notes column shows; click headers to sort; narrow the window for horizontal scroll.

Checks: `npm run lint`, `npx tsc --noEmit`, `npx vitest run test/containers/AdminUsers` (39 pass).

Refs #1091
🤖 Generated with [Claude Code](https://claude.com/claude-code)
