### PR TITLE
Local HTTPS dev + scheme-aware OAuth redirect (JaMmusic)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,9 @@ typings/
 .env.bak
 .env.dev
 
+# self-signed certs for local HTTPS dev (DEV_HTTPS=true)
+.certs/
+
 # next.js build output
 .next
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,34 @@
 * Copy the `.env.example` file and paste it as `.env` file in the project root directory. Request variable definitions from the project owner or spin up your own resourses where applicable.
 * More information is available in our [Developer's Guide](https://docs.google.com/document/d/1_QDDbqmBrJuGqBoib59fmgYtls03dAXXuLqRR5roPO4/edit).
 
+### Local HTTPS (for Facebook `FB.login`)
+
+Most local work runs over plain http (`npm run dev` → `http://localhost:7878`).
+Facebook's JS SDK `FB.login` (used by the page-admin Reconnect flow) refuses to
+run on `http://` pages, so to exercise it locally serve the dev server over https
+with a self-signed cert:
+
+1. **Generate a self-signed cert into `.certs/`** (gitignored) — one time:
+
+   ```sh
+   mkdir -p .certs && openssl req -x509 -newkey rsa:2048 -nodes \
+     -keyout .certs/localhost.key -out .certs/localhost.crt \
+     -days 825 -subj "/CN=localhost" \
+     -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
+   ```
+
+2. **`npm run dev`** now serves `https://localhost:7878` (the `dev` script sets
+   `DEV_HTTPS=true`). With no certs present it silently falls back to http, so
+   this is safe for anyone who skips the setup. Accept the browser's
+   self-signed-cert warning the first time.
+
+3. **One-time external setup for the https origin:**
+   - **web-jam-back** `AllowUrl` must include `https://localhost:7878` (CORS).
+   - **Google OAuth client** — add `https://localhost:7878` to **both**
+     Authorized JavaScript origins **and** Authorized redirect URIs, or Google
+     login returns a 400 (the token-exchange `redirect_uri` must match the
+     scheme the auth code was issued under).
+
 ## Static assets
 
 * **`public/Josh-Maria-Songlist.pdf`** — the "Current Songlist" PDF linked from the **Book Us** page (`/music/bookus`). It is served by the app itself (opens inline in a new tab at `/Josh-Maria-Songlist.pdf`) rather than from Dropbox, so it renders reliably and isn't subject to Dropbox's download/redirect behavior.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jammusic",
-  "version": "2.9.8",
+  "version": "2.9.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jammusic",
-      "version": "2.9.8",
+      "version": "2.9.9",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.9.8",
+  "version": "2.9.9",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {
@@ -25,7 +25,7 @@
   "license": "MIT",
   "scripts": {
     "install:prod": "npm run cleanup && npm install --only=prod",
-    "dev": "vite",
+    "dev": "DEV_HTTPS=true vite",
     "build": "vite build",
     "preview": "vite preview",
     "test:e2e": "playwright test",

--- a/src/App/AppTemplate/GoogleButtons/utils.tsx
+++ b/src/App/AppTemplate/GoogleButtons/utils.tsx
@@ -44,11 +44,15 @@ const responseGoogleLogin = async (
   try {
     const uri = window.location.href;
     const baseUri = uri.split('/')[2];
+    // Match the page's actual scheme. Production is https; local dev is usually
+    // http but can be https (DEV_HTTPS=true). The token-exchange redirect_uri
+    // must match the scheme the auth code was issued under or Google 400s.
+    const { protocol } = window.location;
     const body = {
       clientId: process.env.GoogleClientId,
       redirectUri: !baseUri.includes('localhost')
         && process.env.NODE_ENV === 'production' ? `https://${baseUri}`
-        : `http://${baseUri}`,
+        : `${protocol}//${baseUri}`,
       code: `${response.code}`,
       state: makeState(),
     };

--- a/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
+++ b/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
@@ -139,7 +139,7 @@ exports[`AppTemplate > renders the component 1`] = `
             <strong>
               Version
                
-              2.9.8
+              2.9.9
             </strong>
           </div>
           <p

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,26 @@
 /// <reference types="vitest" />
 import { defineConfig, loadEnv, type Plugin } from 'vite';
 import { fileURLToPath } from 'node:url';
+import fs from 'node:fs';
 import react from '@vitejs/plugin-react';
 import checker from 'vite-plugin-checker';
 import pkg from './package.json';
 
 const srcDir = fileURLToPath(new URL('./src', import.meta.url));
 const testDir = fileURLToPath(new URL('./test', import.meta.url));
+const certDir = fileURLToPath(new URL('./.certs', import.meta.url));
+
+// Opt-in local HTTPS for the dev server: `DEV_HTTPS=true npm run dev`. Needed to
+// exercise Facebook FB.login (page-admin Reconnect flow) locally, since FB.login
+// refuses to run on http:// pages. Off unless the flag is set AND the self-signed
+// certs exist (.certs is gitignored), so CI and production builds are unaffected.
+function devHttps(env: Record<string, string>) {
+  const enabled = (process.env.DEV_HTTPS ?? env.DEV_HTTPS) === 'true';
+  const key = `${certDir}/localhost.key`;
+  const cert = `${certDir}/localhost.crt`;
+  if (!enabled || !fs.existsSync(key) || !fs.existsSync(cert)) return undefined;
+  return { key: fs.readFileSync(key), cert: fs.readFileSync(cert) };
+}
 
 const APP_ENV_KEYS = [
   'BackendUrl',
@@ -55,6 +69,7 @@ export default defineConfig(async ({ mode }) => {
     ],
     server: {
       port: Number(env.PORT) || 7878,
+      ...(devHttps(env) ? { https: devHttps(env) } : {}),
     },
     resolve: {
       alias: {


### PR DESCRIPTION
Prep so JaMmusic can later host the CLC-style server-side Facebook feed + page-admin **Reconnect** button (`FB.login`), which requires the dev page to be https locally.

## Changes
- **vite.config.ts** — opt-in `DEV_HTTPS=true` https dev server; active only when `.certs/localhost.{key,crt}` exist (`.certs/` gitignored). CI/prod builds unaffected.
- **package.json** — `dev` script sets `DEV_HTTPS=true` (gracefully falls back to http when no certs present); version 2.9.8 → 2.9.9 + lockfile.
- **GoogleButtons/utils.tsx** — `redirectUri` follows `window.location.protocol` instead of forcing `http://` on localhost, so Google login works over local https. Production (`https://joshandmariamusic.com`) and normal http local dev unchanged.

## Local use
1. Generate self-signed certs into `.certs/` (see below).
2. `npm run dev` → https://localhost:7878.
3. Register `https://localhost:7878` in the Google OAuth client (both JS origins + redirect URIs).

Draft — no Facebook feed feature here yet; this only unblocks local https testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)