### PR TITLE
fix(facebook): force page picker on reconnect + surface backend error

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ with a self-signed cert:
      Authorized JavaScript origins **and** Authorized redirect URIs, or Google
      login returns a 400 (the token-exchange `redirect_uri` must match the
      scheme the auth code was issued under).
+   - **Meta app (Facebook)** — add `localhost` to **Allowed Domains for the
+     JavaScript SDK** (and **App Domains**) in the Web Jam LLC app, or `FB.login`
+     fails with *"JSSDK Unknown Host domain"*. The full domain list for every
+     environment (including the production `web-jam.com` host) is in
+     **web-jam-back's README**.
 
 ### Homepage Facebook feed
 

--- a/src/containers/Homepage/facebook.utils.tsx
+++ b/src/containers/Homepage/facebook.utils.tsx
@@ -22,7 +22,7 @@ export function isJamAdmin(auth: Iauth): boolean {
 interface FbLoginResponse { authResponse?: { accessToken?: string } }
 interface FbSdk {
   init: (opts: Record<string, unknown>) => void;
-  login: (cb: (res: FbLoginResponse) => void, opts: { scope: string }) => void;
+  login: (cb: (res: FbLoginResponse) => void, opts: { scope: string; auth_type?: string }) => void;
 }
 interface FbWindow extends Window { FB?: FbSdk; fbAsyncInit?: () => void }
 
@@ -59,7 +59,10 @@ async function sendPageToken(userToken: string, auth: Iauth, pageId: string): Pr
       },
       body: JSON.stringify({ userToken, pageId }),
     });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({})) as { message?: string };
+      throw new Error(body.message || `HTTP ${res.status}`);
+    }
     commonUtils.notify('Facebook', 'Reconnected — the feed will refresh shortly', 'success');
   } catch (e) {
     commonUtils.notify('Facebook', `Reconnect failed, ${(e as Error).message}`, 'warning');
@@ -67,9 +70,12 @@ async function sendPageToken(userToken: string, auth: Iauth, pageId: string): Pr
 }
 
 // "Reconnect Facebook": admin logs in as the page admin → short-lived user token
-// → sendPageToken to web-jam-back for the given pageId. NOTE: in the Facebook
-// consent dialog, keep BOTH the WebJamLLC and CollegeLutheran pages checked —
-// deselecting a page revokes the app's access to it (see README).
+// → sendPageToken to web-jam-back for the given pageId. `auth_type: 'rerequest'`
+// forces Facebook to re-show the page picker every time instead of silently
+// reusing the last grant ("continue with previous settings") — otherwise a prior
+// reconnect of the OTHER page leaves this page ungranted and the exchange 400s.
+// NOTE: in the consent dialog, keep BOTH the WebJamLLC and CollegeLutheran pages
+// checked — deselecting a page revokes the app's access to it (see README).
 async function reconnectFacebookAPI(auth: Iauth, pageId: string): Promise<void> {
   const w = window as unknown as FbWindow;
   if (!w.FB) {
@@ -85,7 +91,7 @@ async function reconnectFacebookAPI(auth: Iauth, pageId: string): Promise<void> 
         return;
       }
       void sendPageToken(userToken, auth, pageId).finally(resolve);
-    }, { scope: 'pages_show_list,pages_read_engagement' });
+    }, { scope: 'pages_show_list,pages_read_engagement', auth_type: 'rerequest' });
   });
 }
 

--- a/test/containers/Homepage/facebook.utils.spec.tsx
+++ b/test/containers/Homepage/facebook.utils.spec.tsx
@@ -63,15 +63,17 @@ describe('facebook.utils', () => {
       expect(commonUtils.notify).toHaveBeenCalledWith('Facebook', expect.stringMatching(/still loading/), 'warning');
     });
 
-    it('PUTs the user token + pageId and notifies success', async () => {
+    it('PUTs the user token + pageId (rerequesting the page picker) and notifies success', async () => {
       commonUtils.notify = vi.fn();
-      (window as any).FB = {
-        init: vi.fn(),
-        login: (cb: (r: any) => void) => cb({ authResponse: { accessToken: 'USER-TOKEN' } }),
-      };
+      const loginMock = vi.fn((cb: (r: any) => void) => cb({ authResponse: { accessToken: 'USER-TOKEN' } }));
+      (window as any).FB = { init: vi.fn(), login: loginMock };
       const fetchMock = vi.fn(() => Promise.resolve({ ok: true, status: 200 }));
       vi.stubGlobal('fetch', fetchMock);
       await facebookUtils.reconnectFacebookAPI(auth as any, WEBJAMLLC_PAGE_ID);
+      expect(loginMock).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({ auth_type: 'rerequest' }),
+      );
       expect(fetchMock).toHaveBeenCalledWith(
         `${process.env.BackendUrl}/facebook/token`,
         {
@@ -90,15 +92,19 @@ describe('facebook.utils', () => {
       expect(commonUtils.notify).toHaveBeenCalledWith('Facebook', expect.stringMatching(/cancelled/), 'warning');
     });
 
-    it('warns when the backend PUT fails', async () => {
+    it('surfaces the backend error message when the PUT fails', async () => {
       commonUtils.notify = vi.fn();
       (window as any).FB = {
         init: vi.fn(),
         login: (cb: (r: any) => void) => cb({ authResponse: { accessToken: 'USER-TOKEN' } }),
       };
-      vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: false, status: 400 })));
+      vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+        ok: false, status: 400, json: () => Promise.resolve({ message: 'WebJamLLC page not found in /me/accounts' }),
+      })));
       await facebookUtils.reconnectFacebookAPI(auth as any, WEBJAMLLC_PAGE_ID);
-      expect(commonUtils.notify).toHaveBeenCalledWith('Facebook', expect.stringMatching(/Reconnect failed/), 'warning');
+      expect(commonUtils.notify).toHaveBeenCalledWith(
+        'Facebook', expect.stringMatching(/Reconnect failed.*page not found/), 'warning',
+      );
     });
   });
 });


### PR DESCRIPTION
## Why

Seeding the WebJamLLC token failed in production with `Reconnect failed, HTTP 400`. The backend message was **`WebJamLLC page not found in /me/accounts`**: `FB.login` reused the *previous* grant ("continue with previous settings" dialog), which from a prior CollegeLutheran reconnect didn't include WebJamLLC — so the page wasn't in `/me/accounts` and the token exchange rejected it.

## Changes

- **`auth_type: 'rerequest'`** on `FB.login` — forces Facebook to re-show the page picker every reconnect instead of silently reusing the last grant. Kills the "previous settings" trap for both pages.
- **Surface the backend error** — `sendPageToken` now reads the 400 response body's `message`, so the toast says *why* ("…page not found in /me/accounts") instead of a bare `HTTP 400`.
- **README** — documents the **Allowed Domains for the JavaScript SDK** Meta-app setup (the "JSSDK Unknown Host domain" error), pointing to web-jam-back for the full per-environment domain list (incl. production `web-jam.com`).

## Verification
- eslint + prod `tsc` clean; `facebook.utils` specs pass (assert `rerequest` is sent and the backend message is surfaced).

Follow-up to #1108. The same fix for CollegeLutheran is in a parallel PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)