### PR TITLE
feat(auth): auto-logout when the JWT expires (#1121)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jammusic",
-  "version": "2.9.11",
+  "version": "2.9.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jammusic",
-      "version": "2.9.11",
+      "version": "2.9.12",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.9.11",
+  "version": "2.9.12",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/src/App/AppTemplate/index.tsx
+++ b/src/App/AppTemplate/index.tsx
@@ -45,14 +45,7 @@ export function handleEscapePress(e: { key: string; }, setMenuOpen: (arg0: boole
 export const makeHandleKeyPress = (
   setMenuOpen: (value: SetStateAction<boolean>) => void,
 ) => (evt: { key: string; }) => handleEscapePress(evt, setMenuOpen);
-// TODO logout user if token has expired
-// export async function checkIfTokenExpired(auth:Iauth) {
-//   console.log(auth);
-//   try {
-//     const user = await jwtVerify(auth.token);
-//     console.log(user);
-//   } catch (err) { console.log(err); }
-// }
+// Token-expiry auto-logout is handled app-wide in AuthProvider (JaMmusic#1121).
 
 interface IpageHostProps {
   userCount?: number, heartBeat?: string,

--- a/src/lib/tokenExpiry.ts
+++ b/src/lib/tokenExpiry.ts
@@ -1,0 +1,26 @@
+// Client-side JWT expiry check (JaMmusic#1121). Reads the `exp` claim from the
+// token payload WITHOUT the signing secret — the browser only needs to know
+// whether to log out; the backend does the real signature verification. Decoding
+// without the secret also avoids shipping HashString to the client for this.
+
+export function getTokenExp(token: string): number | null {
+  try {
+    const part = (token || '').split('.')[1];
+    if (!part) return null;
+    let b64 = part.replace(/-/g, '+').replace(/_/g, '/');
+    while (b64.length % 4) b64 += '=';
+    const payload = JSON.parse(atob(b64)) as { exp?: number };
+    return typeof payload.exp === 'number' ? payload.exp : null;
+  } catch {
+    return null;
+  }
+}
+
+// True when the token carries an `exp` that is at/before `nowMs`. A token with
+// no readable `exp` returns false (we can't prove it's expired, so don't force a
+// logout on it — the on-mount /user re-validation still gates those).
+export function isTokenExpired(token: string, nowMs: number = Date.now()): boolean {
+  const exp = getTokenExp(token);
+  if (exp === null) return false;
+  return exp * 1000 <= nowMs;
+}

--- a/src/providers/Auth.provider.tsx
+++ b/src/providers/Auth.provider.tsx
@@ -3,6 +3,7 @@ import React, {
 } from 'react';
 import jwt from 'jwt-simple';
 import { usePersistedState } from 'src/lib/usePersistedState';
+import { isTokenExpired } from 'src/lib/tokenExpiry';
 
 export interface Iauth {
   isAuthenticated: boolean,
@@ -69,6 +70,16 @@ export const setUserAuth = async (
   }
 };
 
+// Given the persisted auth string, return the reset auth-string to store when
+// the token has expired, or null when no logout is needed (JaMmusic#1121).
+export function expiredAuthReset(authString: string): string | null {
+  try {
+    const { token } = JSON.parse(authString);
+    if (token && isTokenExpired(token)) return JSON.stringify(defaultAuth);
+  } catch { /* no / unparseable auth — nothing to expire */ }
+  return null;
+}
+
 export function AuthProvider({ children }: { children: React.ReactNode }): React.JSX.Element {
   const { Provider } = AuthContext;
   const [authString, setAuthString] = usePersistedState('auth', JSON.stringify(defaultAuth));
@@ -85,6 +96,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }): React
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+  // Proactively log out the moment the token's exp passes — not only on reload
+  // (JaMmusic#1121). Runs immediately and every minute while the app is open.
+  useEffect(() => {
+    const checkExpiry = () => {
+      const reset = expiredAuthReset(authString as string);
+      if (reset) (setAuthString as React.Dispatch<React.SetStateAction<string>>)(reset);
+    };
+    checkExpiry();
+    const id = window.setInterval(checkExpiry, 60000);
+    return () => window.clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [authString]);
   const { auth, setAuth } = configAuth(
     authString as string,
     setAuthString as React.Dispatch<React.SetStateAction<string>>,

--- a/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
+++ b/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
@@ -139,7 +139,7 @@ exports[`AppTemplate > renders the component 1`] = `
             <strong>
               Version
                
-              2.9.11
+              2.9.12
             </strong>
           </div>
           <p

--- a/test/lib/tokenExpiry.spec.ts
+++ b/test/lib/tokenExpiry.spec.ts
@@ -1,0 +1,44 @@
+import jwt from 'jwt-simple';
+import { getTokenExp, isTokenExpired } from 'src/lib/tokenExpiry';
+
+const SECRET = 'test-secret';
+const nowSec = () => Math.floor(Date.now() / 1000);
+
+describe('tokenExpiry', () => {
+  describe('getTokenExp', () => {
+    it('reads the exp claim from a token', () => {
+      const exp = nowSec() + 100;
+      const token = jwt.encode({ sub: 'u', iat: nowSec(), exp }, SECRET);
+      expect(getTokenExp(token)).toBe(exp);
+    });
+    it('returns null for a token with no exp', () => {
+      const token = jwt.encode({ sub: 'u', iat: nowSec() }, SECRET);
+      expect(getTokenExp(token)).toBeNull();
+    });
+    it('returns null for empty / garbage input', () => {
+      expect(getTokenExp('')).toBeNull();
+      expect(getTokenExp('not-a-jwt')).toBeNull();
+    });
+  });
+
+  describe('isTokenExpired', () => {
+    it('is true for a token whose exp is in the past', () => {
+      const token = jwt.encode({ sub: 'u', iat: nowSec() - 200, exp: nowSec() - 100 }, SECRET);
+      expect(isTokenExpired(token)).toBe(true);
+    });
+    it('is false for a token whose exp is in the future', () => {
+      const token = jwt.encode({ sub: 'u', iat: nowSec(), exp: nowSec() + 24 * 60 * 60 }, SECRET);
+      expect(isTokenExpired(token)).toBe(false);
+    });
+    it('is exactly at the boundary (exp === now) => expired', () => {
+      const exp = nowSec();
+      const token = jwt.encode({ sub: 'u', iat: exp, exp }, SECRET);
+      expect(isTokenExpired(token, exp * 1000)).toBe(true);
+    });
+    it('is false when exp cannot be determined (no logout on unknowns)', () => {
+      const noExp = jwt.encode({ sub: 'u', iat: nowSec() }, SECRET);
+      expect(isTokenExpired(noExp)).toBe(false);
+      expect(isTokenExpired('')).toBe(false);
+    });
+  });
+});

--- a/test/providers/Auth.provider.spec.tsx
+++ b/test/providers/Auth.provider.spec.tsx
@@ -1,8 +1,9 @@
 import { render } from '@testing-library/react';
+import jwt from 'jwt-simple';
 
 import {
   Iauth, defaultSetAuth, AuthProvider,
-  configAuth,
+  configAuth, expiredAuthReset,
 } from 'src/providers/Auth.provider';
 import {
   setInitValue, handleValueChange, handleNameChange,
@@ -92,5 +93,22 @@ describe('AuthProvider', () => {
     const result = configAuth(JSON.stringify({}), setAuthString);
     result.setAuth({} as any);
     expect(setAuthString).toHaveBeenCalled();
+  });
+  describe('expiredAuthReset (auto-logout decision)', () => {
+    const now = () => Math.floor(Date.now() / 1000);
+    it('resets to logged-out when the token is expired', () => {
+      const token = jwt.encode({ sub: 'u', iat: now() - 200, exp: now() - 100 }, 'secret');
+      const reset = expiredAuthReset(JSON.stringify({ token, isAuthenticated: true }));
+      expect(reset).not.toBeNull();
+      expect(JSON.parse(reset as string).isAuthenticated).toBe(false);
+    });
+    it('returns null for a still-valid token', () => {
+      const token = jwt.encode({ sub: 'u', iat: now(), exp: now() + 24 * 60 * 60 }, 'secret');
+      expect(expiredAuthReset(JSON.stringify({ token, isAuthenticated: true }))).toBeNull();
+    });
+    it('returns null when there is no token or the value is garbage', () => {
+      expect(expiredAuthReset(JSON.stringify({ token: '' }))).toBeNull();
+      expect(expiredAuthReset('not-json')).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
Fixes the "stays logged in too long" problem: the UI now **proactively logs you out when the JWT expires**, instead of only re-checking on a full page reload.

Frontend half of the goal; pairs with **web-jam-back#829** (24h token expiry).

## Problem
`AuthProvider` validated the token only **once on mount**. An expired token sat in localStorage and the UI kept looking logged-in until a reload or an incidental 401. (There was even a long-standing `// TODO logout user if token has expired`.)

## Change
- **`src/lib/tokenExpiry.ts`** — `getTokenExp` / `isTokenExpired`: read the `exp` claim **client-side without the signing secret** (the backend still does real verification). Also sidesteps needing `HashString` on the client for this check.
- **`AuthProvider`** — `expiredAuthReset()` (pure, exported) + an effect that runs **on mount and every 60s** while the app is open; on expiry it clears the persisted auth → `isAuthenticated` flips false → logged-out UI.
- Removed the dead `checkIfTokenExpired` TODO stub in `AppTemplate`.

## How you'll verify it
A 24h token can't be "waited out" to demo live, so correctness is proven by tests:
- `tokenExpiry.spec.ts` — expired → true, valid → false, no-exp/garbage → false, boundary.
- `Auth.provider.spec.tsx` — `expiredAuthReset`: expired token → resets to logged-out; valid → no-op; garbage → no-op.

After this + #829 deploy, a single log-out/in gives a session that self-expires (~24h).

## Not in this PR (noted as follow-ups)
- Global **401 → logout** wrapper across the per-call fetch utils (defense-in-depth; the mount re-validation + this expiry check cover the main cases).
- The **`HashString`-on-frontend** smell flagged in #1121's body — separate issue if confirmed.

## Tests
Full suite green (295 passing), `tsc` + `eslint` clean (0 errors).

Closes #1121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
