### PR TITLE
security(auth): keep JWT signing secret (HashString) out of the client bundle (#1124)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,6 @@ BackendUrl=http://localhost:7000
 GoogleClientId=
 userRoles={"roles": ["role1", "role2", "role3"]}
 SOCKETCLUSTER_SECURE=false
-HashString=
 SCS_PORT=8888
 SCS_HOST=localhost
 TINY_KEY=

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.9.12",
+  "version": "2.9.13",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/src/App/AppTemplate/GoogleButtons/utils.tsx
+++ b/src/App/AppTemplate/GoogleButtons/utils.tsx
@@ -1,7 +1,7 @@
 import { CodeResponse, googleLogout } from '@react-oauth/google';
 import { defaultAuth, Iauth, setUserAuth } from 'src/providers/Auth.provider';
 import 'react-toastify/dist/ReactToastify.css';
-import jwt from 'jwt-simple';
+import { getTokenSub } from 'src/lib/tokenExpiry';
 import commonUtils from 'src/lib/utils';
 
 export interface GoogleBody {
@@ -12,7 +12,7 @@ export interface GoogleBody {
 }
 
 const setUser = async (auth: Iauth, setAuth: (args0: Iauth) => void, token: string): Promise<void> => {
-  const { sub } = jwt.decode(token, process.env.HashString as string);
+  const sub = getTokenSub(token) ?? undefined;
   await setUserAuth(token, sub, setAuth as (arg0: any) => void, 'setAuth');
 };
 

--- a/src/lib/tokenExpiry.ts
+++ b/src/lib/tokenExpiry.ts
@@ -1,19 +1,31 @@
-// Client-side JWT expiry check (JaMmusic#1121). Reads the `exp` claim from the
-// token payload WITHOUT the signing secret — the browser only needs to know
-// whether to log out; the backend does the real signature verification. Decoding
-// without the secret also avoids shipping HashString to the client for this.
+// Client-side JWT claim reads (JaMmusic#1121, #1124). Decode the token payload
+// WITHOUT the signing secret — the browser only needs claims like `exp`/`sub` to
+// drive the UI and the auto-logout; the backend does the real signature
+// verification on every request. Decoding without the secret is what keeps
+// HashString OUT of the client bundle (it must never ship to the browser).
 
-export function getTokenExp(token: string): number | null {
+export function getTokenPayload(token: string): Record<string, unknown> | null {
   try {
     const part = (token || '').split('.')[1];
     if (!part) return null;
     let b64 = part.replace(/-/g, '+').replace(/_/g, '/');
     while (b64.length % 4) b64 += '=';
-    const payload = JSON.parse(atob(b64)) as { exp?: number };
-    return typeof payload.exp === 'number' ? payload.exp : null;
+    return JSON.parse(atob(b64)) as Record<string, unknown>;
   } catch {
     return null;
   }
+}
+
+export function getTokenExp(token: string): number | null {
+  const exp = getTokenPayload(token)?.exp;
+  return typeof exp === 'number' ? exp : null;
+}
+
+// The token subject (the user id). Returns null when the token has no readable
+// `sub` — callers treat that as an unusable token.
+export function getTokenSub(token: string): string | null {
+  const sub = getTokenPayload(token)?.sub;
+  return typeof sub === 'string' ? sub : null;
 }
 
 // True when the token carries an `exp` that is at/before `nowMs`. A token with

--- a/src/providers/Auth.provider.tsx
+++ b/src/providers/Auth.provider.tsx
@@ -1,9 +1,8 @@
 import React, {
   createContext, useEffect,
 } from 'react';
-import jwt from 'jwt-simple';
 import { usePersistedState } from 'src/lib/usePersistedState';
-import { isTokenExpired } from 'src/lib/tokenExpiry';
+import { isTokenExpired, getTokenSub } from 'src/lib/tokenExpiry';
 
 export interface Iauth {
   isAuthenticated: boolean,
@@ -89,7 +88,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }): React
         try {
           const auth = JSON.parse(authString);
           const { token } = auth;
-          const { sub } = jwt.decode(token, process.env.HashString as string);
+          const sub = getTokenSub(token);
+          if (!sub) throw new Error('token has no subject');
           await setUserAuth(token, sub, setAuthString as (arg0: string | Iauth) => void, 'setAuthString');
         } catch (err) { (setAuthString as React.Dispatch<React.SetStateAction<string>>)(JSON.stringify(defaultAuth)); }
       }

--- a/test/App/AppTemplate/GoogleButtons/utils.spec.tsx
+++ b/test/App/AppTemplate/GoogleButtons/utils.spec.tsx
@@ -30,9 +30,7 @@ describe('GoogleButtons/utils', () => {
       isAuthenticated: false, token: 's', error: 'err', user: { userType: 'e', email: 'goo@hotmail.com' },
     };
     const setAuth = vi.fn();
-    const token = 'nickel';
-    const sub: any = 'some';
-    vi.spyOn(jwt, 'decode').mockReturnValue({ sub });
+    const token = jwt.encode({ sub: 'some' }, 'secret');
 
     await utils.setUser(auth, setAuth, token);
     expect(setAuth).toHaveBeenCalled();
@@ -40,7 +38,6 @@ describe('GoogleButtons/utils', () => {
   it('responseGoogleLogin', async () => {
     const setAuth = vi.fn();
     vi.spyOn(commonUtils, 'notify').mockImplementation(() => { });
-    vi.spyOn(jwt, 'decode').mockReturnValue({ sub: '1' });
     Object.defineProperty(window, 'location', {
       value: { href: 'https://localhost:8888', assign: vi.fn(), reload: vi.fn() }, writable: true, configurable: true,
     });
@@ -56,7 +53,6 @@ describe('GoogleButtons/utils', () => {
   it('responseGoogleLogin succeeds when production', async () => {
     const setAuth = vi.fn();
     vi.spyOn(commonUtils, 'notify').mockImplementation(() => { });
-    vi.spyOn(jwt, 'decode').mockReturnValue({ sub: '1' });
     Object.defineProperty(window, 'location', {
       value: { href: 'https://web-jam.com', assign: vi.fn(), reload: vi.fn() }, writable: true, configurable: true,
     });

--- a/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
+++ b/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
@@ -139,7 +139,7 @@ exports[`AppTemplate > renders the component 1`] = `
             <strong>
               Version
                
-              2.9.12
+              2.9.13
             </strong>
           </div>
           <p

--- a/test/lib/tokenExpiry.spec.ts
+++ b/test/lib/tokenExpiry.spec.ts
@@ -1,5 +1,5 @@
 import jwt from 'jwt-simple';
-import { getTokenExp, isTokenExpired } from 'src/lib/tokenExpiry';
+import { getTokenExp, getTokenSub, isTokenExpired } from 'src/lib/tokenExpiry';
 
 const SECRET = 'test-secret';
 const nowSec = () => Math.floor(Date.now() / 1000);
@@ -18,6 +18,21 @@ describe('tokenExpiry', () => {
     it('returns null for empty / garbage input', () => {
       expect(getTokenExp('')).toBeNull();
       expect(getTokenExp('not-a-jwt')).toBeNull();
+    });
+  });
+
+  describe('getTokenSub', () => {
+    it('reads the sub claim from a token', () => {
+      const token = jwt.encode({ sub: 'user-123', iat: nowSec() }, SECRET);
+      expect(getTokenSub(token)).toBe('user-123');
+    });
+    it('returns null when there is no string sub', () => {
+      const token = jwt.encode({ iat: nowSec() }, SECRET);
+      expect(getTokenSub(token)).toBeNull();
+    });
+    it('returns null for empty / garbage input', () => {
+      expect(getTokenSub('')).toBeNull();
+      expect(getTokenSub('not-a-jwt')).toBeNull();
     });
   });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,7 +25,6 @@ function devHttps(env: Record<string, string>) {
 const APP_ENV_KEYS = [
   'BackendUrl',
   'GoogleClientId',
-  'HashString',
   'APP_NAME',
   'SCS_HOST',
   'SCS_PORT',


### PR DESCRIPTION
Closes #1124.

## Problem
The vite build inlined `process.env.HashString` (the JWT **signing secret**) into the public client bundle, because `HashString` was in `vite.config.ts`'s `APP_ENV_KEYS` and every `jwt.decode(token, process.env.HashString)` call referenced it. Anyone could read the secret from browser sources and **forge valid login tokens**.

## Fix
The browser only ever needs the token **payload** (`sub`/`exp`), never the signature — the backend verifies on every request. So decode without the secret:

- Add secret-free `getTokenPayload` / `getTokenSub` to `src/lib/tokenExpiry.ts` (base64 decode — same approach already used by `getTokenExp`).
- Use `getTokenSub` in `src/providers/Auth.provider.tsx` and `src/App/AppTemplate/GoogleButtons/utils.tsx`; drop their `jwt-simple` imports.
- Remove `HashString` from `vite.config.ts` `APP_ENV_KEYS` and from `.env.example` so the secret can never be bundled again.
- Tests updated (replaced now-dead `jwt.decode` mocks with real tokens; added `getTokenSub` coverage). Version → 2.9.13.

## ⚠️ Required follow-up (ops, not in this PR)
**Rotate `HashString` on the backend after this deploys** — the current value has been shipping in production bundles and must be assumed compromised. Coordinate with `web-jam-back` so signing/verification stay in sync (existing tokens get invalidated → users re-login, which dovetails with the #1121/#1122 expiry work).

## Verification
- `npm test` (lint + 298 unit tests) green.
- `grep -rn 'process.env.HashString' src/` → none (only an explanatory comment remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)