### PR TITLE
feat(admin): add outreach:* and template:* to Admin Users capability picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.9.13",
+  "version": "2.9.14",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/AdminUsers/capabilities.ts
+++ b/src/containers/AdminUsers/capabilities.ts
@@ -14,6 +14,14 @@ export const CAPABILITIES = [
   'venue:create',
   'venue:edit',
   'venue:delete',
+  // Pitch-email template management (web-jam-back#822). No template:read.
+  'template:create',
+  'template:edit',
+  'template:delete',
+  // Booking-outreach send + log (web-jam-back#823/#836). No outreach:read.
+  'outreach:create',
+  'outreach:edit',
+  'outreach:delete',
 ] as const;
 
 export type Capability = (typeof CAPABILITIES)[number];
@@ -23,6 +31,8 @@ export const CAPABILITY_GROUPS: { label: string; items: Capability[] }[] = [
   { label: 'Songs', items: ['song:create', 'song:edit', 'song:delete'] },
   { label: 'Books', items: ['book:create', 'book:edit', 'book:delete'] },
   { label: 'Venues', items: ['venue:create', 'venue:edit', 'venue:delete'] },
+  { label: 'Templates', items: ['template:create', 'template:edit', 'template:delete'] },
+  { label: 'Outreach', items: ['outreach:create', 'outreach:edit', 'outreach:delete'] },
 ];
 
 export const USER_STATUS_OPTIONS = ['human', 'ai-agent'] as const;

--- a/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
+++ b/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
@@ -139,7 +139,7 @@ exports[`AppTemplate > renders the component 1`] = `
             <strong>
               Version
                
-              2.9.13
+              2.9.14
             </strong>
           </div>
           <p

--- a/test/containers/AdminUsers/capabilities.spec.tsx
+++ b/test/containers/AdminUsers/capabilities.spec.tsx
@@ -1,11 +1,15 @@
 import { CAPABILITIES, CAPABILITY_GROUPS, USER_STATUS_OPTIONS } from 'src/containers/AdminUsers/capabilities';
 
 describe('AdminUsers capabilities registry', () => {
-  it('includes tour, song, book, and venue capabilities', () => {
+  it('includes tour, song, book, venue, template, and outreach capabilities', () => {
     expect(CAPABILITIES).toContain('gig:create');
     expect(CAPABILITIES).toContain('song:create');
     expect(CAPABILITIES).toContain('book:delete');
     expect(CAPABILITIES).toContain('venue:create');
+    for (const c of ['template:create', 'template:edit', 'template:delete',
+      'outreach:create', 'outreach:edit', 'outreach:delete']) {
+      expect(CAPABILITIES).toContain(c);
+    }
   });
 
   it('does not include user:* capabilities', () => {


### PR DESCRIPTION
## Summary
Adds template:create/edit/delete and outreach:create/edit/delete to the Admin Users capability picker (src/containers/AdminUsers/capabilities.ts), each as its own CAPABILITY_GROUPS entry (Templates, Outreach). The backend already validates these caps (web-jam-back #822/#823/#836) but the UI only listed gig/song/book/venue, so they couldn't be granted to the web-jam-llm agent / admins. Version bumped 2.9.13 -> 2.9.14.

Closes #1127

## How to test locally
Run `npm test` (lint + vitest). Expected all green; the AdminUsers capabilities spec asserts the new caps and that CAPABILITY_GROUPS covers every capability exactly once.

## Test evidence
npm test -> 298 passed (57 files). The 'CAPABILITY_GROUPS covers every capability exactly once' invariant test passes with the two new groups. Lint clean (pre-existing console warnings only, no errors). Footer-version snapshots (AppTemplate, Music) updated for the 2.9.14 bump — diff is the version line only.

🤖 Work by Claude Code — Opus 4.8