### PR TITLE
feat(admin): venue editor controls for relationshipStage + templateOverride

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jammusic",
-  "version": "2.9.18",
+  "version": "2.9.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jammusic",
-      "version": "2.9.18",
+      "version": "2.9.19",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.9.18",
+  "version": "2.9.19",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/AdminVenues/EditVenueDialog.tsx
+++ b/src/containers/AdminVenues/EditVenueDialog.tsx
@@ -4,7 +4,7 @@ import {
   Button, Typography, FormGroup, FormControlLabel, Checkbox, FormControl, InputLabel, Select, MenuItem, TextField,
 } from '@mui/material';
 import adminVenuesUtils, {
-  VENUE_TYPES, BOOKING_STATUSES, type Ivenue, type IvenueUpdate,
+  VENUE_TYPES, BOOKING_STATUSES, RELATIONSHIP_STAGES, type Ivenue, type IvenueUpdate,
 } from './admin-venues.utils';
 
 interface IeditVenueDialogProps {
@@ -40,6 +40,8 @@ export function EditVenueDialog({
         payTier: venue.payTier || '',
         contactVerified: !!venue.contactVerified,
         notes: venue.notes || '',
+        relationshipStage: venue.relationshipStage || '',
+        templateOverride: venue.templateOverride || '',
       });
     }
     setError('');
@@ -90,6 +92,22 @@ export function EditVenueDialog({
           <Select labelId="edit-venue-booking-label" label="Booking Status" value={form.bookingStatus || 'booking'}
             onChange={(e) => set('bookingStatus', e.target.value)} data-testid="edit-venue-booking">
             {BOOKING_STATUSES.map((s) => (<MenuItem key={s} value={s}>{s}</MenuItem>))}
+          </Select>
+        </FormControl>
+        <FormControl fullWidth sx={{ marginBottom: 2 }}>
+          <InputLabel id="edit-venue-stage-label">Relationship Stage</InputLabel>
+          <Select labelId="edit-venue-stage-label" label="Relationship Stage" value={form.relationshipStage || ''}
+            onChange={(e) => set('relationshipStage', e.target.value)} data-testid="edit-venue-stage">
+            <MenuItem value="">Auto (derive from history)</MenuItem>
+            {RELATIONSHIP_STAGES.map((s) => (<MenuItem key={s} value={s}>{s}</MenuItem>))}
+          </Select>
+        </FormControl>
+        <FormControl fullWidth sx={{ marginBottom: 2 }}>
+          <InputLabel id="edit-venue-override-label">Template Override</InputLabel>
+          <Select labelId="edit-venue-override-label" label="Template Override" value={form.templateOverride || ''}
+            onChange={(e) => set('templateOverride', e.target.value)} data-testid="edit-venue-override">
+            <MenuItem value="">None (use venue type)</MenuItem>
+            {VENUE_TYPES.map((t) => (<MenuItem key={t} value={t}>{t}</MenuItem>))}
           </Select>
         </FormControl>
         <TextField label="Contact Name" fullWidth value={form.contactName || ''} onChange={(e) => set('contactName', e.target.value)}

--- a/src/containers/AdminVenues/admin-venues.utils.ts
+++ b/src/containers/AdminVenues/admin-venues.utils.ts
@@ -21,6 +21,8 @@ export interface Ivenue {
   payTier?: string;
   contactVerified?: boolean;
   notes?: string;
+  relationshipStage?: string;
+  templateOverride?: string;
 }
 
 export interface IvenueUpdate {
@@ -39,6 +41,8 @@ export interface IvenueUpdate {
   payTier?: string;
   contactVerified?: boolean;
   notes?: string;
+  relationshipStage?: string;
+  templateOverride?: string;
 }
 
 export interface Icandidate {
@@ -114,6 +118,7 @@ async function setConfig(token: string, autoApprove: boolean): Promise<{ autoApp
 
 export const VENUE_TYPES = ['Originals', 'PubFestivalBrewery', 'MidRangeCafeBar'] as const;
 export const BOOKING_STATUSES = ['booking', 'not-booking', 'booked'] as const;
+export const RELATIONSHIP_STAGES = ['cold', 'returning'] as const;
 
 export default {
   listVenues, updateVenue, getCandidates, sendBatch, getConfig, setConfig, getAllowedAdminRoles,

--- a/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
+++ b/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
@@ -139,7 +139,7 @@ exports[`AppTemplate > renders the component 1`] = `
             <strong>
               Version
                
-              2.9.18
+              2.9.19
             </strong>
           </div>
           <p

--- a/test/containers/AdminVenues/EditVenueDialog.spec.tsx
+++ b/test/containers/AdminVenues/EditVenueDialog.spec.tsx
@@ -24,6 +24,16 @@ describe('EditVenueDialog', () => {
     expect(onSaved).toHaveBeenCalled();
   });
 
+  it('saves the relationshipStage + templateOverride selections (#1136)', async () => {
+    await act(async () => { render(<EditVenueDialog open venue={venue} token="tk" onClose={vi.fn()} onSaved={vi.fn()} />); });
+    await act(async () => { fireEvent.change(screen.getByTestId('edit-venue-stage'), { target: { value: 'returning' } }); });
+    await act(async () => { fireEvent.change(screen.getByTestId('edit-venue-override'), { target: { value: 'MidRangeCafeBar' } }); });
+    await act(async () => { fireEvent.click(screen.getByTestId('edit-venue-save')); });
+    expect(adminVenuesUtils.updateVenue).toHaveBeenCalledWith('tk', 'v1', expect.objectContaining({
+      relationshipStage: 'returning', templateOverride: 'MidRangeCafeBar',
+    }));
+  });
+
   it('propagates a toggled checkbox into the saved payload', async () => {
     await act(async () => { render(<EditVenueDialog open venue={venue} token="tk" onClose={vi.fn()} onSaved={vi.fn()} />); });
     await act(async () => { fireEvent.click(screen.getByRole('checkbox', { name: /outreach eligible/i })); });


### PR DESCRIPTION
## Summary
Follow-up to #848/#1133: venue editor gets two selects so Josh can set the template-selection fields in the browser. Relationship Stage (Auto=derive / cold / returning) and Template Override (None=use venue type / Originals / PubFestivalBrewery / MidRangeCafeBar), both persisted via the existing PUT /venue/:id. Empty value = auto/none (backend treats it as unset). Needs web-jam-back #848 deployed for the fields to persist (merged).

Closes #1136

## How to test locally
npm test   # stylelint + eslint . + jscpd + TZ=UTC vitest run --coverage

## Test evidence
npm test exit 0 → 64 files, 366 tests passed. Coverage 90.08/82.17/85.01/91.75 (over 90/80/80/90 gate). eslint 0 errors. EditVenueDialog spec covers the new selects saving relationshipStage + templateOverride. Snapshot updated for 2.9.19.

🤖 Work by Claude Code — Opus 4.8