### PR TITLE
ci: chain typecheck into npm test (close the local type-check gap)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jammusic",
-  "version": "2.9.20",
+  "version": "2.9.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jammusic",
-      "version": "2.9.20",
+      "version": "2.9.23",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.9.20",
+  "version": "2.9.23",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {
@@ -36,7 +36,7 @@
     "test:lint-fix": "npm run test:stylelint && npm run lint:fix",
     "test:lint": "npm run test:stylelint && eslint .",
     "jscpd": "jscpd src",
-    "test": "npm run test:lint && npm run jscpd && npm run test:unit",
+    "test": "npm run test:lint && npm run typecheck && npm run jscpd && npm run test:unit",
     "test:unit": "TZ=UTC vitest run --coverage",
     "test:watch": "TZ=UTC vitest",
     "test:unit-u": "TZ=UTC vitest run -u",

--- a/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
+++ b/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
@@ -139,7 +139,7 @@ exports[`AppTemplate > renders the component 1`] = `
             <strong>
               Version
                
-              2.9.20
+              2.9.23
             </strong>
           </div>
           <p


### PR DESCRIPTION
## Summary
- Wire `npm run typecheck` (`tsc --noEmit`, ~4.5s, covers src + tests) into the `npm test` chain so type errors fail **locally** before push — they previously only surfaced in CI's `vite build` step (e.g. #1145's MUI-v9 `slotProps` errors passed local `npm test`).
- Closes the JaMmusic side of the long-standing vitest/eslint type-check gap; sibling repos (WebJamSocketCluster) likely need the same.
- `test` is now: `test:lint && typecheck && jscpd && test:unit`.

Closes #1146

## How to test locally
Run:
```sh
npm test
```
Expect the new `typecheck` step to run (`tsc --noEmit`) and the whole chain to pass.

## Test evidence
```
> npm run test:lint && npm run typecheck && npm run jscpd && npm run test:unit
✖ 592 problems (0 errors, 592 warnings)   # lint (pre-existing warnings only)
> typecheck — tsc --noEmit                # NEW step, passed
> jscpd src                               # clean
 Test Files  64 passed (64)
      Tests  366 passed (366)
exit: 0
```

🤖 Work by Claude Code — Opus 4.8