### PR TITLE
feat(admin): Template editing UI + per-template photo upload (Phase 2)

### DIFF
--- a/__mocks__/@mui/material.tsx
+++ b/__mocks__/@mui/material.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export function TextField(props:any) {
-  const { children } = props;
-  return <input {...props}>{children}</input>;
+  const { children, slotProps, inputProps, inputRef, ...rest } = props;
+  const testId = slotProps?.htmlInput?.['data-testid'] || inputProps?.['data-testid'] || rest['data-testid'];
+  const style = slotProps?.htmlInput?.style || inputProps?.style || rest.style;
+  return <input ref={inputRef} data-testid={testId} style={style} {...rest}>{children}</input>;
 }
 
 export function Checkbox(props:any) {
@@ -144,6 +146,54 @@ export function TableCell(props:any) {
 export function TableSortLabel(props:any) {
   const { children, active, direction, ...rest } = props;
   return <span role="button" {...rest}>{children}</span>;
+}
+
+export function Card(props:any) {
+  const { children } = props;
+  return <div {...props}>{children}</div>;
+}
+
+export function CardContent(props:any) {
+  const { children } = props;
+  return <div {...props}>{children}</div>;
+}
+
+import * as React from 'react';
+
+export function Tabs(props:any) {
+  const { children, value, onChange, ...rest } = props;
+  const childrenWithProps = React.Children.map(children, child => {
+    if (React.isValidElement(child)) {
+      return React.cloneElement(child as React.ReactElement<any>, {
+        active: child.props.value === value,
+        onClick: (e: any) => {
+          if (onChange) {
+            onChange(e, child.props.value);
+          }
+          if (child.props.onClick) {
+            child.props.onClick(e);
+          }
+        }
+      });
+    }
+    return child;
+  });
+  return <div {...rest}>{childrenWithProps}</div>;
+}
+
+export function Tab(props:any) {
+  const { label, active, ...rest } = props;
+  return <button type="button" {...rest}>{label}</button>;
+}
+
+export function Alert(props:any) {
+  const { children } = props;
+  return <div {...props}>{children}</div>;
+}
+
+export function Paper(props:any) {
+  const { children } = props;
+  return <div {...props}>{children}</div>;
 }
 
 // Default to desktop (false) in tests; suites can override per-case.

--- a/src/App/AppTemplate/menuConfig.ts
+++ b/src/App/AppTemplate/menuConfig.ts
@@ -61,6 +61,9 @@ const wjNav = [
     nav: 'wj', className: '', type: 'link', iconClass: 'fas fa-paper-plane', link: '/admin/outreach', name: 'Batch Outreach', auth: true,
   },
   {
+    nav: 'wj', className: '', type: 'link', iconClass: 'fas fa-envelope-open-text', link: '/admin/templates', name: 'Admin Templates', auth: true,
+  },
+  {
     nav: 'wj', className: 'home', type: 'link', iconClass: 'fas fa-home', link: '/', name: 'Web Jam LLC',
   },
   {

--- a/src/App/index.tsx
+++ b/src/App/index.tsx
@@ -6,6 +6,7 @@ import { Homepage } from 'src/containers/Homepage';
 import { AdminUsers } from '../containers/AdminUsers';
 import { AdminVenues } from '../containers/AdminVenues';
 import { AdminOutreach } from '../containers/AdminOutreach';
+import { AdminTemplates } from '../containers/AdminTemplates';
 import BuyMusic from '../containers/BuyMusic';
 import { Music } from '../containers/Music';
 import { AppTemplate } from './AppTemplate';
@@ -31,6 +32,7 @@ export function App() {
           <Route path="/admin/users" element={<AdminUsers />} />
           <Route path="/admin/venues" element={<AdminVenues />} />
           <Route path="/admin/outreach" element={<AdminOutreach />} />
+          <Route path="/admin/templates" element={<AdminTemplates />} />
           <Route path="/new-homepage" element={<Homepage />} />
           <Route path="/music" element={<Music />} />
           <Route path="/music/buymusic" element={<BuyMusic />} />

--- a/src/containers/AdminTemplates/admin-templates.utils.ts
+++ b/src/containers/AdminTemplates/admin-templates.utils.ts
@@ -1,0 +1,172 @@
+import { getAllowedAdminRoles } from '../AdminUsers/admin-users.utils';
+
+export interface Itemplate {
+  _id?: string;
+  type: 'Originals' | 'PubFestivalBrewery' | 'MidRangeCafeBar' | 'OnlineForm';
+  stage: 'cold' | 'returning';
+  subject?: string;
+  bodyHtml?: string;
+  footerPhotoRef?: string;
+  active?: boolean;
+  lastModifiedBy?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+const templateBaseUrl = `${process.env.BackendUrl}/template`;
+
+function headers(token: string, json = false): Record<string, string> {
+  const h: Record<string, string> = { Accept: 'application/json', Authorization: `Bearer ${token}` };
+  if (json) h['Content-Type'] = 'application/json';
+  return h;
+}
+
+async function listTemplates(token: string, filters?: { type?: string; stage?: string; active?: boolean }): Promise<Itemplate[]> {
+  const params = new URLSearchParams();
+  if (filters) {
+    if (filters.type) params.set('type', filters.type);
+    if (filters.stage) params.set('stage', filters.stage);
+    if (filters.active !== undefined) params.set('active', String(filters.active));
+  }
+  const qs = params.toString() ? `?${params.toString()}` : '';
+  const res = await fetch(`${templateBaseUrl}${qs}`, { headers: headers(token) });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return await res.json() as Itemplate[];
+}
+
+async function getTemplate(token: string, id: string): Promise<Itemplate> {
+  const res = await fetch(`${templateBaseUrl}/${id}`, { headers: headers(token) });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return await res.json() as Itemplate;
+}
+
+async function createTemplate(token: string, payload: Partial<Itemplate> & { photoData?: string }): Promise<Itemplate> {
+  const res = await fetch(templateBaseUrl, {
+    method: 'POST',
+    headers: headers(token, true),
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return await res.json() as Itemplate;
+}
+
+async function updateTemplate(token: string, id: string, payload: Partial<Itemplate> & { photoData?: string }): Promise<Itemplate> {
+  const res = await fetch(`${templateBaseUrl}/${id}`, {
+    method: 'PUT',
+    headers: headers(token, true),
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return await res.json() as Itemplate;
+}
+
+async function deleteTemplate(token: string, id: string): Promise<void> {
+  const res = await fetch(`${templateBaseUrl}/${id}`, {
+    method: 'DELETE',
+    headers: headers(token),
+  });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+}
+
+async function getTemplateAssetUrl(token: string, ref: string): Promise<string> {
+  const res = await fetch(`${templateBaseUrl}/assets/${ref}`, {
+    headers: headers(token),
+  });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  const blob = await res.blob();
+  return URL.createObjectURL(blob);
+}
+
+// Escapes values for CSV format
+function escapeCSV(val: unknown): string {
+  if (val === undefined || val === null) return '';
+  const str = String(val);
+  if (str.includes(',') || str.includes('"') || str.includes('\n') || str.includes('\r')) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+// Generates a CSV string from an array of templates
+export function exportToCSV(templates: Itemplate[]): string {
+  const headersList = ['type', 'stage', 'subject', 'bodyHtml', 'footerPhotoRef', 'active'];
+  const csvRows = [headersList.join(',')];
+  
+  for (const t of templates) {
+    const row = [
+      escapeCSV(t.type),
+      escapeCSV(t.stage),
+      escapeCSV(t.subject),
+      escapeCSV(t.bodyHtml),
+      escapeCSV(t.footerPhotoRef),
+      escapeCSV(t.active !== false),
+    ];
+    csvRows.push(row.join(','));
+  }
+  return csvRows.join('\r\n');
+}
+
+// Parses standard CSV with support for quoted strings containing newlines and commas
+export function parseCSV(text: string): Record<string, string>[] {
+  const lines: string[][] = [];
+  let row: string[] = [];
+  let inQuotes = false;
+  let currentVal = '';
+  
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i];
+    const nextChar = text[i + 1];
+    
+    if (char === '"') {
+      if (inQuotes && nextChar === '"') {
+        currentVal += '"';
+        i++; // Skip next quote
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (char === ',' && !inQuotes) {
+      row.push(currentVal);
+      currentVal = '';
+    } else if ((char === '\r' || char === '\n') && !inQuotes) {
+      if (char === '\r' && nextChar === '\n') {
+        i++; // Skip LF after CR
+      }
+      row.push(currentVal);
+      lines.push(row);
+      row = [];
+      currentVal = '';
+    } else {
+      currentVal += char;
+    }
+  }
+  if (row.length > 0 || currentVal !== '') {
+    row.push(currentVal);
+    lines.push(row);
+  }
+  
+  if (lines.length < 2) return [];
+  const headersRow = lines[0].map(h => h.trim());
+  const results: Record<string, string>[] = [];
+  for (let r = 1; r < lines.length; r++) {
+    const cells = lines[r];
+    if (cells.length === 1 && cells[0] === '') continue; // Skip empty rows
+    const obj: Record<string, string> = {};
+    headersRow.forEach((header, index) => {
+      obj[header] = cells[index] || '';
+    });
+    results.push(obj);
+  }
+  return results;
+}
+
+export default {
+  listTemplates,
+  getTemplate,
+  createTemplate,
+  updateTemplate,
+  deleteTemplate,
+  getTemplateAssetUrl,
+  getAllowedAdminRoles,
+  exportToCSV,
+  parseCSV,
+};

--- a/src/containers/AdminTemplates/index.tsx
+++ b/src/containers/AdminTemplates/index.tsx
@@ -1,0 +1,748 @@
+import {
+  useCallback, useContext, useEffect, useState, useRef,
+} from 'react';
+import {
+  Box, Typography, TextField, Button, Grid, Card, CardContent,
+  Tabs, Tab, FormControlLabel, Switch, Chip, Alert, CircularProgress,
+  Dialog, DialogTitle, DialogContent, DialogActions, Table, TableHead,
+  TableRow, TableCell, TableBody, Paper, Divider, IconButton,
+} from '@mui/material';
+import {
+  Save as SaveIcon,
+  FileUpload as FileUploadIcon,
+  FileDownload as FileDownloadIcon,
+  Delete as DeleteIcon,
+  CloudUpload as CloudUploadIcon,
+  Close as CloseIcon,
+  Undo as UndoIcon,
+} from '@mui/icons-material';
+import { AuthContext } from 'src/providers/Auth.provider';
+import adminTemplatesUtils, { type Itemplate, exportToCSV, parseCSV } from './admin-templates.utils';
+
+const TYPES = ['Originals', 'PubFestivalBrewery', 'MidRangeCafeBar', 'OnlineForm'] as const;
+const STAGES = ['cold', 'returning'] as const;
+
+const TOKENS = [
+  '[Contact Name]',
+  '[Venue Name]',
+  '[Booking Period]',
+  '[Target Dates]',
+];
+
+export function AdminTemplates() {
+  const { auth } = useContext(AuthContext);
+  const allowed = adminTemplatesUtils.getAllowedAdminRoles();
+  const isAuthorized = auth.isAuthenticated && allowed.indexOf(auth.user.userType) !== -1;
+
+  const [templates, setTemplates] = useState<Itemplate[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [saveLoading, setSaveLoading] = useState(false);
+
+  // Editor states
+  const [selectedType, setSelectedType] = useState<Itemplate['type']>('Originals');
+  const [selectedStage, setSelectedStage] = useState<Itemplate['stage']>('cold');
+  const [subject, setSubject] = useState('');
+  const [bodyHtml, setBodyHtml] = useState('');
+  const [active, setActive] = useState(true);
+  const [photoData, setPhotoData] = useState<string | null>(null);
+  const [photoPreview, setPhotoPreview] = useState<string | null>(null);
+  const [isDirty, setIsDirty] = useState(false);
+
+  // Import Dialog state
+  const [importOpen, setImportOpen] = useState(false);
+  const [importFile, setImportFile] = useState<File | null>(null);
+  const [importPreview, setImportPreview] = useState<Partial<Itemplate>[]>([]);
+  const [importing, setImporting] = useState(false);
+  const [importStatus, setImportStatus] = useState('');
+
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Find active template being edited
+  const currentTemplate = templates.find((t) => t.type === selectedType && t.stage === selectedStage);
+
+  const refresh = useCallback(async () => {
+    if (!isAuthorized) return;
+    setLoading(true);
+    setError('');
+    try {
+      const data = await adminTemplatesUtils.listTemplates(auth.token);
+      setTemplates(data);
+    } catch (e) {
+      setError((e as Error).message || 'Failed to load templates');
+    } finally {
+      setLoading(false);
+    }
+  }, [auth.token, isAuthorized]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  // Load selected template into editor states
+  useEffect(() => {
+    if (currentTemplate) {
+      setSubject(currentTemplate.subject || '');
+      setBodyHtml(currentTemplate.bodyHtml || '');
+      setActive(currentTemplate.active !== false);
+      setPhotoData(null);
+      setPhotoPreview(null);
+      setIsDirty(false);
+
+      if (currentTemplate.footerPhotoRef) {
+        setPhotoPreview(null); // Clear first
+        adminTemplatesUtils.getTemplateAssetUrl(auth.token, currentTemplate.footerPhotoRef)
+          .then((url) => {
+            setPhotoPreview(url);
+          })
+          .catch(() => {
+            // Asset could be missing or failed to fetch, silence
+          });
+      }
+    } else {
+      // Empty state
+      setSubject('');
+      setBodyHtml('');
+      setActive(true);
+      setPhotoData(null);
+      setPhotoPreview(null);
+      setIsDirty(false);
+    }
+  }, [currentTemplate, selectedType, selectedStage, auth.token]);
+
+  if (!isAuthorized) {
+    return (
+      <Box sx={{ padding: 3 }} data-testid="admin-templates-unauthorized">
+        <Typography variant="h6">Not authorized</Typography>
+        <Typography variant="body2">You must be signed in as an admin to view this page.</Typography>
+      </Box>
+    );
+  }
+
+  const handleInsertToken = (token: string) => {
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      setBodyHtml((prev) => prev + token);
+      setIsDirty(true);
+      return;
+    }
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const before = bodyHtml.substring(0, start);
+    const after = bodyHtml.substring(end, bodyHtml.length);
+    setBodyHtml(before + token + after);
+    setIsDirty(true);
+    setTimeout(() => {
+      textarea.focus();
+      textarea.selectionStart = textarea.selectionEnd = start + token.length;
+    }, 0);
+  };
+
+  const handlePhotoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      const base64 = reader.result as string;
+      setPhotoData(base64);
+      setPhotoPreview(base64);
+      setIsDirty(true);
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleRemovePhoto = () => {
+    setPhotoData(''); // Setting empty to let backend know to clear
+    setPhotoPreview(null);
+    setIsDirty(true);
+  };
+
+  const handleReset = () => {
+    if (currentTemplate) {
+      setSubject(currentTemplate.subject || '');
+      setBodyHtml(currentTemplate.bodyHtml || '');
+      setActive(currentTemplate.active !== false);
+      setPhotoData(null);
+      setPhotoPreview(null);
+      setIsDirty(false);
+
+      if (currentTemplate.footerPhotoRef) {
+        adminTemplatesUtils.getTemplateAssetUrl(auth.token, currentTemplate.footerPhotoRef)
+          .then((url) => {
+            setPhotoPreview(url);
+          })
+          .catch(() => {});
+      }
+    } else {
+      setSubject('');
+      setBodyHtml('');
+      setActive(true);
+      setPhotoData(null);
+      setPhotoPreview(null);
+      setIsDirty(false);
+    }
+  };
+
+  const handleSave = async () => {
+    setSaveLoading(true);
+    setError('');
+    try {
+      const payload: Partial<Itemplate> & { photoData?: string } = {
+        type: selectedType,
+        stage: selectedStage,
+        subject,
+        bodyHtml,
+        active,
+      };
+      if (photoData !== null) {
+        payload.photoData = photoData;
+      }
+
+      if (currentTemplate?._id) {
+        await adminTemplatesUtils.updateTemplate(auth.token, currentTemplate._id, payload);
+      } else {
+        await adminTemplatesUtils.createTemplate(auth.token, payload);
+      }
+      setIsDirty(false);
+      await refresh();
+    } catch (e) {
+      setError((e as Error).message || 'Failed to save template');
+    } finally {
+      setSaveLoading(false);
+    }
+  };
+
+  // Export functions
+  const handleExportJSON = () => {
+    const blob = new Blob([JSON.stringify(templates, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'pitch_templates.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleExportCSV = () => {
+    const csvContent = exportToCSV(templates);
+    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'pitch_templates.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  // Import parsing
+  const handleImportFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setImportFile(file);
+    setImportStatus('');
+    const reader = new FileReader();
+
+    reader.onload = (event) => {
+      const content = event.target?.result as string;
+      try {
+        if (file.name.endsWith('.json')) {
+          const parsed = JSON.parse(content) as unknown;
+          if (Array.isArray(parsed)) {
+            setImportPreview(parsed as Partial<Itemplate>[]);
+          } else if (parsed && typeof parsed === 'object') {
+            setImportPreview([parsed as Partial<Itemplate>]);
+          } else {
+            setImportStatus('Invalid JSON structure: expected array or object');
+          }
+        } else {
+          // Parse CSV
+          const parsed = parseCSV(content);
+          const mapped: Partial<Itemplate>[] = parsed.map((row) => ({
+            type: row.type as Itemplate['type'],
+            stage: (row.stage || 'cold') as Itemplate['stage'],
+            subject: row.subject || '',
+            bodyHtml: row.bodyHtml || '',
+            footerPhotoRef: row.footerPhotoRef || '',
+            active: row.active !== 'false',
+          }));
+          setImportPreview(mapped);
+        }
+      } catch (err) {
+        setImportStatus(`Failed to parse file: ${(err as Error).message}`);
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  const handleConfirmImport = async () => {
+    if (importPreview.length === 0) return;
+    setImporting(true);
+    setImportStatus('');
+    let successCount = 0;
+    let failCount = 0;
+
+    for (let i = 0; i < importPreview.length; i++) {
+      const item = importPreview[i];
+      setImportStatus(`Importing ${i + 1}/${importPreview.length}...`);
+      try {
+        if (!item.type || TYPES.indexOf(item.type as 'Originals') === -1) {
+          throw new Error(`Invalid type: ${item.type || 'missing'}`);
+        }
+        const stage = (item.stage || 'cold') as Itemplate['stage'];
+        if (STAGES.indexOf(stage) === -1) {
+          throw new Error(`Invalid stage: ${stage}`);
+        }
+
+        const payload: Partial<Itemplate> = {
+          type: item.type,
+          stage,
+          subject: item.subject || '',
+          bodyHtml: item.bodyHtml || '',
+          active: item.active !== false,
+          footerPhotoRef: item.footerPhotoRef || undefined,
+        };
+
+        // Check if duplicate already exists in loaded templates list
+        const existing = templates.find((t) => t.type === item.type && t.stage === stage);
+        if (existing?._id) {
+          await adminTemplatesUtils.updateTemplate(auth.token, existing._id, payload);
+        } else {
+          await adminTemplatesUtils.createTemplate(auth.token, payload);
+        }
+        successCount++;
+      } catch (err) {
+        failCount++;
+        console.error(`Import failed for item:`, item, err);
+      }
+    }
+
+    setImportStatus(`Import complete. Success: ${successCount}, Failures: ${failCount}`);
+    setImporting(false);
+    setImportPreview([]);
+    setImportFile(null);
+    await refresh();
+  };
+
+  return (
+    <Box
+      sx={{
+        padding: 3, maxWidth: 1200, margin: 'auto', width: '100%', minWidth: 0,
+      }}
+      data-testid="admin-templates-page"
+    >
+      <Box sx={{
+        display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 3, flexWrap: 'wrap', gap: 2,
+      }}>
+        <Typography variant="h5">Admin Pitch Templates</Typography>
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          <Button
+            size="small"
+            variant="outlined"
+            startIcon={<FileDownloadIcon />}
+            onClick={handleExportJSON}
+            data-testid="export-json-btn"
+          >
+            Export JSON
+          </Button>
+          <Button
+            size="small"
+            variant="outlined"
+            startIcon={<FileDownloadIcon />}
+            onClick={handleExportCSV}
+            data-testid="export-csv-btn"
+          >
+            Export CSV
+          </Button>
+          <Button
+            size="small"
+            variant="contained"
+            color="secondary"
+            startIcon={<FileUploadIcon />}
+            onClick={() => {
+              setImportFile(null);
+              setImportPreview([]);
+              setImportStatus('');
+              setImportOpen(true);
+            }}
+            data-testid="import-btn"
+          >
+            Import
+          </Button>
+        </Box>
+      </Box>
+
+      {error && <Alert severity="error" sx={{ marginBottom: 2 }} data-testid="admin-templates-error">{error}</Alert>}
+      {loading && <CircularProgress data-testid="admin-templates-loading" sx={{ display: 'block', margin: '20px auto' }} />}
+
+      {!loading && (
+        <Grid container spacing={3}>
+          {/* Sidebar selector */}
+          <Grid size={{ xs: 12, md: 4 }}>
+            <Card sx={{ height: '100%' }}>
+              <CardContent sx={{ padding: 2 }}>
+                <Typography variant="subtitle2" sx={{ marginBottom: 1, fontWeight: 'bold' }}>
+                  1. RELATIONSHIP STAGE
+                </Typography>
+                <Tabs
+                  value={selectedStage}
+                  onChange={(_, val: Itemplate['stage']) => setSelectedStage(val)}
+                  variant="fullWidth"
+                  sx={{ marginBottom: 2, borderBottom: 1, borderColor: 'divider' }}
+                >
+                  <Tab label="Cold" value="cold" data-testid="templates-tab-stage-cold" />
+                  <Tab label="Returning" value="returning" data-testid="templates-tab-stage-returning" />
+                </Tabs>
+
+                <Typography variant="subtitle2" sx={{ marginBottom: 1, fontWeight: 'bold' }}>
+                  2. TEMPLATE TYPE
+                </Typography>
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                  {TYPES.map((type) => {
+                    const hasTemplate = templates.some((t) => t.type === type && t.stage === selectedStage);
+                    const isSelected = selectedType === type;
+                    return (
+                      <Button
+                        key={type}
+                        variant={isSelected ? 'contained' : 'outlined'}
+                        color={isSelected ? 'primary' : 'inherit'}
+                        onClick={() => setSelectedType(type)}
+                        data-testid={`template-type-${type}`}
+                        sx={{
+                          justifyContent: 'space-between',
+                          textTransform: 'none',
+                          padding: '10px 15px',
+                        }}
+                      >
+                        <Typography variant="body2" sx={{ fontWeight: isSelected ? 'bold' : 'normal' }}>
+                          {type === 'Originals' && 'Originals Listening Room'}
+                          {type === 'PubFestivalBrewery' && 'Pub / Festival / Brewery'}
+                          {type === 'MidRangeCafeBar' && 'Mid-Range Cafe & Bar'}
+                          {type === 'OnlineForm' && 'Online Form / Info Block'}
+                        </Typography>
+                        {hasTemplate ? (
+                          <Chip label="Configured" size="small" color={isSelected ? 'secondary' : 'default'} />
+                        ) : (
+                          <Chip label="Not Configured" size="small" variant="outlined" color="warning" />
+                        )}
+                      </Button>
+                    );
+                  })}
+                </Box>
+              </CardContent>
+            </Card>
+          </Grid>
+
+          {/* Main Editor */}
+          <Grid size={{ xs: 12, md: 8 }}>
+            <Card>
+              <CardContent sx={{ padding: 3 }}>
+                <Box sx={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  marginBottom: 2,
+                  borderBottom: '1px solid',
+                  borderColor: 'divider',
+                  pb: 1,
+                }}>
+                  <Typography variant="h6">
+                    {selectedType === 'Originals' && 'Originals Listening Room'}
+                    {selectedType === 'PubFestivalBrewery' && 'Pub / Festival / Brewery'}
+                    {selectedType === 'MidRangeCafeBar' && 'Mid-Range Cafe & Bar'}
+                    {selectedType === 'OnlineForm' && 'Online Form / Info Block'}
+                    {' '}
+                    <Chip label={selectedStage.toUpperCase()} size="small" color="primary" sx={{ ml: 1 }} />
+                  </Typography>
+                  <FormControlLabel
+                    control={(
+                      <Switch
+                        checked={active}
+                        onChange={(e) => {
+                          setActive(e.target.checked);
+                          setIsDirty(true);
+                        }}
+                        data-testid="template-active-toggle"
+                      />
+                    )}
+                    label="Active"
+                  />
+                </Box>
+
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2.5 }}>
+                  <TextField
+                    label="Subject Line"
+                    fullWidth
+                    size="small"
+                    value={subject}
+                    onChange={(e) => {
+                      setSubject(e.target.value);
+                      setIsDirty(true);
+                    }}
+                    slotProps={{ htmlInput: { 'data-testid': 'template-subject-input' } }}
+                    placeholder="e.g. Booking inquiry - JaM"
+                  />
+
+                  <Box>
+                    <Box sx={{
+                      display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 1,
+                    }}>
+                      <Typography variant="body2" sx={{ fontWeight: 'medium' }}>
+                        Body HTML Content
+                      </Typography>
+                      <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+                        {TOKENS.map((token) => (
+                          <Chip
+                            key={token}
+                            label={token}
+                            size="small"
+                            onClick={() => handleInsertToken(token)}
+                            data-testid={`token-chip-${token}`}
+                            color="secondary"
+                            variant="outlined"
+                            sx={{ cursor: 'pointer', fontFamily: 'monospace' }}
+                          />
+                        ))}
+                      </Box>
+                    </Box>
+                    <TextField
+                      multiline
+                      rows={12}
+                      fullWidth
+                      value={bodyHtml}
+                      onChange={(e) => {
+                        setBodyHtml(e.target.value);
+                        setIsDirty(true);
+                      }}
+                      inputRef={textareaRef}
+                      slotProps={{ htmlInput: { 'data-testid': 'template-body-textarea', style: { fontFamily: 'monospace' } } }}
+                      placeholder="Enter HTML or text pitch template content..."
+                    />
+                  </Box>
+
+                  {/* Photo upload section */}
+                  <Paper variant="outlined" sx={{ padding: 2, background: 'background.default' }}>
+                    <Typography variant="subtitle2" sx={{ marginBottom: 1, fontWeight: 'bold' }}>
+                      Footer Photo
+                    </Typography>
+                    <Grid container spacing={2} sx={{ alignItems: 'center' }}>
+                      <Grid size={{ xs: 12, sm: 4 }}>
+                        {photoPreview ? (
+                          <Box sx={{ position: 'relative', width: '100%', height: 120 }}>
+                            <img
+                              src={photoPreview}
+                              alt="Footer Preview"
+                              style={{
+                                width: '100%', height: '100%', objectFit: 'cover', borderRadius: 4,
+                              }}
+                              data-testid="template-photo-preview"
+                            />
+                            <IconButton
+                              size="small"
+                              onClick={handleRemovePhoto}
+                              sx={{
+                                position: 'absolute',
+                                top: 4,
+                                right: 4,
+                                background: 'rgba(0,0,0,0.6)',
+                                color: 'white',
+                                '&:hover': { background: 'rgba(0,0,0,0.8)' },
+                              }}
+                            >
+                              <DeleteIcon fontSize="small" />
+                            </IconButton>
+                          </Box>
+                        ) : (
+                          <Box sx={{
+                            width: '100%',
+                            height: 120,
+                            border: '1px dashed',
+                            borderColor: 'text.secondary',
+                            borderRadius: 1,
+                            display: 'flex',
+                            flexDirection: 'column',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            background: 'rgba(0,0,0,0.03)',
+                          }}>
+                            <Typography variant="caption" color="text.secondary">No photo uploaded</Typography>
+                          </Box>
+                        )}
+                      </Grid>
+                      <Grid size={{ xs: 12, sm: 8 }}>
+                        <Typography variant="body2" color="text.secondary" sx={{ marginBottom: 1.5 }}>
+                          Upload a template-specific image (JPG/PNG). It will be embedded inline as CID during mailing.
+                        </Typography>
+                        <Button
+                          variant="outlined"
+                          component="label"
+                          size="small"
+                          startIcon={<CloudUploadIcon />}
+                        >
+                          Choose Photo File
+                          <input
+                            type="file"
+                            accept="image/*"
+                            hidden
+                            onChange={handlePhotoChange}
+                            data-testid="template-photo-input"
+                            aria-label="Upload template photo"
+                          />
+                        </Button>
+                      </Grid>
+                    </Grid>
+                  </Paper>
+
+                  {/* Actions row */}
+                  <Box sx={{
+                    display: 'flex',
+                    justifyContent: 'flex-end',
+                    gap: 2,
+                    borderTop: '1px solid',
+                    borderColor: 'divider',
+                    pt: 2,
+                    marginTop: 1,
+                  }}>
+                    {currentTemplate && (
+                      <Typography variant="caption" color="text.secondary" sx={{ flexGrow: 1, alignSelf: 'center' }}>
+                        Last updated: {currentTemplate.updated_at ? new Date(currentTemplate.updated_at).toLocaleString() : 'N/A'}
+                        {currentTemplate.lastModifiedBy ? ` by ${currentTemplate.lastModifiedBy}` : ''}
+                      </Typography>
+                    )}
+                    <Button
+                      variant="outlined"
+                      startIcon={<UndoIcon />}
+                      onClick={handleReset}
+                      disabled={!isDirty}
+                      size="small"
+                    >
+                      Revert
+                    </Button>
+                    <Button
+                      variant="contained"
+                      color="primary"
+                      startIcon={<SaveIcon />}
+                      onClick={handleSave}
+                      disabled={saveLoading || (!isDirty && currentTemplate !== undefined)}
+                      size="small"
+                      data-testid="template-save-btn"
+                    >
+                      {saveLoading ? 'Saving...' : 'Save Template'}
+                    </Button>
+                  </Box>
+                </Box>
+              </CardContent>
+            </Card>
+          </Grid>
+        </Grid>
+      )}
+
+      {/* Bulk Import Dialog */}
+      <Dialog
+        open={importOpen}
+        onClose={() => !importing && setImportOpen(false)}
+        maxWidth="md"
+        fullWidth
+        data-testid="import-dialog"
+      >
+        <DialogTitle sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          Bulk Import Templates (JSON / CSV)
+          <IconButton onClick={() => setImportOpen(false)} disabled={importing}>
+            <CloseIcon />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, paddingY: 1 }}>
+            <Typography variant="body2" color="text.secondary">
+              Select a JSON or CSV file exported from JaMmusic or other template managers.
+              {' '}
+              Uploading will automatically match against existing configurations and upsert them (Type + Stage).
+            </Typography>
+
+            <Button
+              variant="outlined"
+              component="label"
+              startIcon={<CloudUploadIcon />}
+              disabled={importing}
+              sx={{ width: 'fit-content' }}
+            >
+              Choose JSON or CSV File
+              <input
+                type="file"
+                accept=".json,.csv"
+                hidden
+                onChange={handleImportFileChange}
+                data-testid="import-file-input"
+                aria-label="Upload import file"
+              />
+            </Button>
+
+            {importFile && (
+              <Typography variant="body2" sx={{ fontWeight: 'medium' }}>
+                Selected file: {importFile.name} ({Math.round(importFile.size / 102.4) / 10} KB)
+              </Typography>
+            )}
+
+            {importStatus && (
+              <Alert severity={importStatus.includes('Success') ? 'success' : 'info'}>
+                {importStatus}
+              </Alert>
+            )}
+
+            {importPreview.length > 0 && (
+              <Box>
+                <Typography variant="subtitle2" sx={{ marginBottom: 1, fontWeight: 'bold' }}>
+                  Parsed templates to import ({importPreview.length}):
+                </Typography>
+                <Table size="small" component={Paper} variant="outlined">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Type</TableCell>
+                      <TableCell>Stage</TableCell>
+                      <TableCell>Subject</TableCell>
+                      <TableCell>Active</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {importPreview.slice(0, 5).map((item, index) => (
+                      <TableRow key={index}>
+                        <TableCell>{item.type}</TableCell>
+                        <TableCell>{item.stage || 'cold'}</TableCell>
+                        <TableCell>{item.subject || '—'}</TableCell>
+                        <TableCell>{item.active !== false ? 'Yes' : 'No'}</TableCell>
+                      </TableRow>
+                    ))}
+                    {importPreview.length > 5 && (
+                      <TableRow>
+                        <TableCell colSpan={4} align="center">
+                          <Typography variant="caption" color="text.secondary">
+                            and {importPreview.length - 5} more items...
+                          </Typography>
+                        </TableCell>
+                      </TableRow>
+                    )}
+                  </TableBody>
+                </Table>
+              </Box>
+            )}
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setImportOpen(false)} disabled={importing}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={handleConfirmImport}
+            disabled={importing || importPreview.length === 0}
+            data-testid="confirm-import-btn"
+          >
+            {importing ? 'Importing...' : 'Confirm Import'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/test/containers/AdminTemplates/admin-templates.utils.spec.tsx
+++ b/test/containers/AdminTemplates/admin-templates.utils.spec.tsx
@@ -1,0 +1,121 @@
+import adminTemplatesUtils, { type Itemplate, exportToCSV, parseCSV } from 'src/containers/AdminTemplates/admin-templates.utils';
+
+const okJson = (data: unknown) => Promise.resolve({ ok: true, json: () => Promise.resolve(data) } as Response);
+const okBlob = (blobData: Blob) => Promise.resolve({ ok: true, blob: () => Promise.resolve(blobData) } as Response);
+const failed = () => Promise.resolve({ ok: false, status: 500, statusText: 'Server Error' } as Response);
+
+describe('AdminTemplates utils', () => {
+  describe('fetch-backed API calls', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+    beforeEach(() => {
+      fetchMock = vi.fn();
+      global.fetch = fetchMock as unknown as typeof fetch;
+      global.URL.createObjectURL = vi.fn(() => 'blob:mock-url');
+    });
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('listTemplates GETs with a bearer token, active filter, and returns templates', async () => {
+      fetchMock.mockReturnValue(okJson([{ _id: '1', type: 'Originals', stage: 'cold', subject: 'hi' }]));
+      const templates = await adminTemplatesUtils.listTemplates('tok', { type: 'Originals', stage: 'cold', active: true });
+      expect(templates).toHaveLength(1);
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toContain('/template');
+      expect(url).toContain('type=Originals');
+      expect(url).toContain('stage=cold');
+      expect(url).toContain('active=true');
+      expect((opts as RequestInit).headers).toMatchObject({ Authorization: 'Bearer tok' });
+    });
+
+    it('getTemplate GETs a specific template by id', async () => {
+      fetchMock.mockReturnValue(okJson({ _id: '123', type: 'OnlineForm' }));
+      const t = await adminTemplatesUtils.getTemplate('tok', '123');
+      expect(t.type).toBe('OnlineForm');
+      expect(fetchMock.mock.calls[0][0]).toContain('/template/123');
+    });
+
+    it('createTemplate POSTs the template data', async () => {
+      fetchMock.mockReturnValue(okJson({ _id: 'new', type: 'PubFestivalBrewery' }));
+      const payload: Partial<Itemplate> = { type: 'PubFestivalBrewery', stage: 'cold', subject: 'Inquiry' };
+      const t = await adminTemplatesUtils.createTemplate('tok', payload);
+      expect(t._id).toBe('new');
+      const opts = fetchMock.mock.calls[0][1] as RequestInit;
+      expect(opts.method).toBe('POST');
+      expect(JSON.parse(opts.body as string)).toMatchObject({ type: 'PubFestivalBrewery' });
+    });
+
+    it('updateTemplate PUTs template modifications', async () => {
+      fetchMock.mockReturnValue(okJson({ _id: '1', subject: 'Updated' }));
+      const t = await adminTemplatesUtils.updateTemplate('tok', '1', { subject: 'Updated' });
+      expect(t.subject).toBe('Updated');
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toContain('/template/1');
+      expect((opts as RequestInit).method).toBe('PUT');
+    });
+
+    it('deleteTemplate DELETEs the template by id', async () => {
+      fetchMock.mockReturnValue(okJson({}));
+      await adminTemplatesUtils.deleteTemplate('tok', '1');
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toContain('/template/1');
+      expect((opts as RequestInit).method).toBe('DELETE');
+    });
+
+    it('getTemplateAssetUrl requests the asset and builds an object URL', async () => {
+      const mockBlob = new Blob(['foo'], { type: 'image/jpeg' });
+      fetchMock.mockReturnValue(okBlob(mockBlob));
+      const url = await adminTemplatesUtils.getTemplateAssetUrl('tok', 'template-123');
+      expect(url).toBe('blob:mock-url');
+      expect(fetchMock.mock.calls[0][0]).toContain('/template/assets/template-123');
+      expect(global.URL.createObjectURL).toHaveBeenCalledWith(mockBlob);
+    });
+
+    it.each([
+      ['listTemplates', () => adminTemplatesUtils.listTemplates('t')],
+      ['getTemplate', () => adminTemplatesUtils.getTemplate('t', '1')],
+      ['createTemplate', () => adminTemplatesUtils.createTemplate('t', { type: 'Originals' })],
+      ['updateTemplate', () => adminTemplatesUtils.updateTemplate('t', '1', {})],
+      ['deleteTemplate', () => adminTemplatesUtils.deleteTemplate('t', '1')],
+      ['getTemplateAssetUrl', () => adminTemplatesUtils.getTemplateAssetUrl('t', 'ref')],
+    ])('%s throws on a non-ok response', async (_name, call) => {
+      fetchMock.mockReturnValue(failed());
+      await expect(call()).rejects.toThrow('500');
+    });
+  });
+
+  describe('CSV parsing and exporting', () => {
+    const sampleTemplates: Itemplate[] = [
+      { type: 'Originals', stage: 'cold', subject: 'Subject, with comma', bodyHtml: 'Hello "World"\nLine 2', footerPhotoRef: 'ref-1', active: true },
+      { type: 'MidRangeCafeBar', stage: 'returning', subject: 'Subject2', bodyHtml: 'Plain', footerPhotoRef: '', active: false },
+    ];
+
+    it('roundtrips a CSV export and import successfully', () => {
+      const csv = exportToCSV(sampleTemplates);
+      expect(csv).toContain('Originals');
+      expect(csv).toContain('"Subject, with comma"');
+      expect(csv).toContain('Hello ""World""');
+
+      const parsed = parseCSV(csv);
+      expect(parsed).toHaveLength(2);
+      expect(parsed[0].type).toBe('Originals');
+      expect(parsed[0].stage).toBe('cold');
+      expect(parsed[0].subject).toBe('Subject, with comma');
+      expect(parsed[0].bodyHtml).toBe('Hello "World"\nLine 2');
+      expect(parsed[0].footerPhotoRef).toBe('ref-1');
+      expect(parsed[0].active).toBe('true');
+
+      expect(parsed[1].type).toBe('MidRangeCafeBar');
+      expect(parsed[1].stage).toBe('returning');
+      expect(parsed[1].subject).toBe('Subject2');
+      expect(parsed[1].bodyHtml).toBe('Plain');
+      expect(parsed[1].footerPhotoRef).toBe('');
+      expect(parsed[1].active).toBe('false');
+    });
+
+    it('returns empty array when CSV has no data rows', () => {
+      expect(parseCSV('')).toEqual([]);
+      expect(parseCSV('type,stage\n')).toEqual([]);
+    });
+  });
+});

--- a/test/containers/AdminTemplates/index.spec.tsx
+++ b/test/containers/AdminTemplates/index.spec.tsx
@@ -1,0 +1,322 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { render, screen, act, fireEvent, waitFor } from '@testing-library/react';
+import { AuthContext, defaultAuth, type Iauth } from 'src/providers/Auth.provider';
+import { AdminTemplates } from 'src/containers/AdminTemplates';
+import adminTemplatesUtils, { type Itemplate } from 'src/containers/AdminTemplates/admin-templates.utils';
+
+const adminAuth: Iauth = {
+  isAuthenticated: true,
+  error: '',
+  token: 'tk',
+  user: { userType: 'JaM-admin', email: 'a@b.com' },
+};
+
+const mockTemplates: Itemplate[] = [
+  {
+    _id: 'temp-1',
+    type: 'Originals',
+    stage: 'cold',
+    subject: 'Cold Originals Subject',
+    bodyHtml: 'Cold Originals Body',
+    footerPhotoRef: 'photo-ref-1',
+    active: true,
+    updated_at: '2026-06-27T12:00:00Z',
+    lastModifiedBy: 'admin',
+  },
+  {
+    _id: 'temp-2',
+    type: 'PubFestivalBrewery',
+    stage: 'returning',
+    subject: 'Warm Pub Subject',
+    bodyHtml: 'Warm Pub Body [Contact Name]',
+    active: false,
+    updated_at: '2026-06-27T13:00:00Z',
+  },
+];
+
+const wrap = (auth: Iauth) => (
+  <AuthContext.Provider value={{ auth, setAuth: () => { /* noop */ } }}>
+    <AdminTemplates />
+  </AuthContext.Provider>
+);
+
+describe('AdminTemplates page container', () => {
+  beforeEach(() => {
+    adminTemplatesUtils.listTemplates = vi.fn(() => Promise.resolve(mockTemplates)) as any;
+    adminTemplatesUtils.getAllowedAdminRoles = vi.fn(() => ['JaM-admin', 'Developer']) as any;
+    adminTemplatesUtils.getTemplateAssetUrl = vi.fn(() => Promise.resolve('blob:mock-asset-url')) as any;
+    adminTemplatesUtils.createTemplate = vi.fn(() => Promise.resolve({})) as any;
+    adminTemplatesUtils.updateTemplate = vi.fn(() => Promise.resolve({})) as any;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders not-authorized when user is not authenticated', () => {
+    render(wrap(defaultAuth));
+    expect(screen.getByTestId('admin-templates-unauthorized')).toBeDefined();
+  });
+
+  it('renders authorized UI and lists templates on load', async () => {
+    await act(async () => {
+      render(wrap(adminAuth));
+    });
+
+    expect(screen.getByTestId('admin-templates-page')).toBeDefined();
+    expect(adminTemplatesUtils.listTemplates).toHaveBeenCalledWith('tk');
+  });
+
+  it('allows switching stage tabs and selected types', async () => {
+    await act(async () => {
+      render(wrap(adminAuth));
+    });
+
+    // Default selection is Originals / Cold
+    const subjectInput = screen.getByTestId('template-subject-input') as HTMLInputElement;
+    expect(subjectInput.value).toBe('Cold Originals Subject');
+
+    // Switch to returning stage tab
+    const warmTab = screen.getByTestId('templates-tab-stage-returning');
+    await act(async () => {
+      fireEvent.click(warmTab);
+    });
+
+    // No returning template exists for Originals, should show empty/blank editor fields
+    expect(subjectInput.value).toBe('');
+
+    // Switch template type to PubFestivalBrewery
+    const pubBtn = screen.getByTestId('template-type-PubFestivalBrewery');
+    await act(async () => {
+      fireEvent.click(pubBtn);
+    });
+
+    // Should load temp-2 which is PubFestivalBrewery + returning
+    expect(subjectInput.value).toBe('Warm Pub Subject');
+  });
+
+  it('inserts personalization tokens into body html at cursor', async () => {
+    await act(async () => {
+      render(wrap(adminAuth));
+    });
+
+    const textarea = screen.getByTestId('template-body-textarea') as HTMLTextAreaElement;
+    expect(textarea.value).toBe('Cold Originals Body');
+
+    const tokenChip = screen.getByTestId('token-chip-[Venue Name]');
+    await act(async () => {
+      fireEvent.click(tokenChip);
+    });
+
+    expect(textarea.value).toBe('Cold Originals Body[Venue Name]');
+  });
+
+  it('handles custom photo selection and Base64 loading', async () => {
+    await act(async () => {
+      render(wrap(adminAuth));
+    });
+
+    // Initially loads the existing asset from backend via getTemplateAssetUrl mock
+    expect(adminTemplatesUtils.getTemplateAssetUrl).toHaveBeenCalledWith('tk', 'photo-ref-1');
+
+    // Mock choosing a local file
+    const file = new File(['dummy content'], 'photo.png', { type: 'image/png' });
+    const fileInput = screen.getByTestId('template-photo-input');
+
+    await act(async () => {
+      fireEvent.change(fileInput, { target: { files: [file] } });
+    });
+
+    // Mock FileReader behavior
+    await waitFor(() => {
+      expect(screen.getByTestId('template-photo-preview')).toBeDefined();
+    });
+  });
+
+  it('saves edits when Save Template is clicked', async () => {
+    await act(async () => {
+      render(wrap(adminAuth));
+    });
+
+    const subjectInput = screen.getByTestId('template-subject-input');
+    await act(async () => {
+      fireEvent.change(subjectInput, { target: { value: 'New Subject!' } });
+    });
+
+    const saveBtn = screen.getByTestId('template-save-btn');
+    await act(async () => {
+      fireEvent.click(saveBtn);
+    });
+
+    expect(adminTemplatesUtils.updateTemplate).toHaveBeenCalledWith('tk', 'temp-1', expect.objectContaining({
+      subject: 'New Subject!',
+      type: 'Originals',
+      stage: 'cold',
+    }));
+  });
+
+  it('creates a new template when saving non-configured type+stage', async () => {
+    await act(async () => {
+      render(wrap(adminAuth));
+    });
+
+    // Select MidRangeCafeBar (not configured)
+    const cafeBtn = screen.getByTestId('template-type-MidRangeCafeBar');
+    await act(async () => {
+      fireEvent.click(cafeBtn);
+    });
+
+    const subjectInput = screen.getByTestId('template-subject-input');
+    await act(async () => {
+      fireEvent.change(subjectInput, { target: { value: 'Cafe Cold Subject' } });
+    });
+
+    const saveBtn = screen.getByTestId('template-save-btn');
+    await act(async () => {
+      fireEvent.click(saveBtn);
+    });
+
+    expect(adminTemplatesUtils.createTemplate).toHaveBeenCalledWith('tk', expect.objectContaining({
+      type: 'MidRangeCafeBar',
+      stage: 'cold',
+      subject: 'Cafe Cold Subject',
+    }));
+  });
+
+  it('triggers JSON and CSV exports', async () => {
+    const createObjectURLMock = vi.fn(() => 'blob:mock-url');
+    global.URL.createObjectURL = createObjectURLMock;
+    global.URL.revokeObjectURL = vi.fn();
+
+    await act(async () => {
+      render(wrap(adminAuth));
+    });
+
+    const exportJsonBtn = screen.getByTestId('export-json-btn');
+    const exportCsvBtn = screen.getByTestId('export-csv-btn');
+
+    await act(async () => {
+      fireEvent.click(exportJsonBtn);
+      fireEvent.click(exportCsvBtn);
+    });
+
+    expect(createObjectURLMock).toHaveBeenCalledTimes(2); // 2 for exports (image loading is mocked)
+  });
+
+  it('opens import dialog and confirms bulk JSON uploads', async () => {
+    await act(async () => {
+      render(wrap(adminAuth));
+    });
+
+    const importBtn = screen.getByTestId('import-btn');
+    await act(async () => {
+      fireEvent.click(importBtn);
+    });
+
+    expect(screen.getByTestId('import-dialog')).toBeDefined();
+
+    // Mock choosing a JSON file
+    const fileContent = JSON.stringify([{ type: 'Originals', stage: 'cold', subject: 'Imported Sub' }]);
+    const file = new File([fileContent], 'templates.json', { type: 'application/json' });
+    const fileInput = screen.getByTestId('import-file-input');
+
+    await act(async () => {
+      fireEvent.change(fileInput, { target: { files: [file] } });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Imported Sub')).toBeDefined();
+    });
+
+    const confirmBtn = screen.getByTestId('confirm-import-btn');
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    // Should call updateTemplate for existing Originals Cold
+    await waitFor(() => {
+      expect(adminTemplatesUtils.updateTemplate).toHaveBeenCalledWith('tk', 'temp-1', expect.objectContaining({
+        subject: 'Imported Sub',
+      }));
+    });
+  });
+
+  it('allows reverting unsaved changes', async () => {
+    await act(async () => {
+      render(wrap(adminAuth));
+    });
+
+    const subjectInput = screen.getByTestId('template-subject-input') as HTMLInputElement;
+    expect(subjectInput.value).toBe('Cold Originals Subject');
+
+    await act(async () => {
+      fireEvent.change(subjectInput, { target: { value: 'Temporary Unsaved Change' } });
+    });
+    expect(subjectInput.value).toBe('Temporary Unsaved Change');
+
+    const revertBtn = screen.getByRole('button', { name: /revert/i }) as HTMLButtonElement;
+    expect(revertBtn.disabled).toBe(false);
+
+    await act(async () => {
+      fireEvent.click(revertBtn);
+    });
+
+    expect(subjectInput.value).toBe('Cold Originals Subject');
+  });
+
+  it('allows removing footer photo', async () => {
+    await act(async () => {
+      render(wrap(adminAuth));
+    });
+
+    // Wait for initial image preview
+    await waitFor(() => {
+      expect(screen.getByTestId('template-photo-preview')).toBeDefined();
+    });
+
+    // Click remove photo button (DeleteIcon is inside an IconButton)
+    const removePhotoBtn = screen.getByTestId('DeleteIcon').closest('button');
+    expect(removePhotoBtn).not.toBeNull();
+
+    await act(async () => {
+      fireEvent.click(removePhotoBtn!);
+    });
+
+    expect(screen.queryByTestId('template-photo-preview')).toBeNull();
+  });
+
+  it('opens import dialog and confirms bulk CSV uploads', async () => {
+    await act(async () => {
+      render(wrap(adminAuth));
+    });
+
+    const importBtn = screen.getByTestId('import-btn');
+    await act(async () => {
+      fireEvent.click(importBtn);
+    });
+
+    // Mock choosing a CSV file
+    const csvContent = 'type,stage,subject,bodyHtml,active\nOriginals,cold,Imported CSV Sub,Imported CSV Body,true';
+    const file = new File([csvContent], 'templates.csv', { type: 'text/csv' });
+    const fileInput = screen.getByTestId('import-file-input');
+
+    await act(async () => {
+      fireEvent.change(fileInput, { target: { files: [file] } });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Imported CSV Sub')).toBeDefined();
+    });
+
+    const confirmBtn = screen.getByTestId('confirm-import-btn');
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(adminTemplatesUtils.updateTemplate).toHaveBeenCalledWith('tk', 'temp-1', expect.objectContaining({
+        subject: 'Imported CSV Sub',
+      }));
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Implements administrative template editing UI with stages ('cold', 'returning') and customizable template types. Supports monospace body template text editing, personalization token cursor insertion (e.g., [Venue Name], [Contact Name]), per-template photo uploads via REST/Base64 payloads, and interactive bulk CSV/JSON imports/exports.

Closes #1116

## How to test locally
Run 'npm test' to verify typecheck, linting, and unit tests are clean. Run 'npm run dev' to verify the UI loads and functions.

## Test evidence
All assertions for AdminTemplates passed successfully. npm test executed successfully with 0 errors, meeting statement coverage gates.

🤖 Work by Antigravity — Gemini 3.5 Flash