### PR TITLE
chore(deps): npm 11 allowScripts for native install scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jammusic",
-  "version": "2.9.23",
+  "version": "2.9.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jammusic",
-      "version": "2.9.23",
+      "version": "2.9.26",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.9.25",
+  "version": "2.9.26",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {
@@ -119,5 +119,9 @@
   },
   "overrides": {
     "uuid": "^11.1.1"
+  },
+  "allowScripts": {
+    "@parcel/watcher@2.5.6": true,
+    "unrs-resolver@1.11.1": true
   }
 }

--- a/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
+++ b/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
@@ -139,7 +139,7 @@ exports[`AppTemplate > renders the component 1`] = `
             <strong>
               Version
                
-              2.9.25
+              2.9.26
             </strong>
           </div>
           <p


### PR DESCRIPTION
npm 11.17 no longer auto-runs dependencies' install/postinstall scripts until they're allow-listed (supply-chain safeguard). This approves the two packages that genuinely need native builds:

- `@parcel/watcher` — `node-gyp rebuild` (native file-watcher)
- `unrs-resolver` — `napi-postinstall` (native eslint import resolver)

`core-js` is intentionally left unapproved — its postinstall is a cosmetic funding banner wrapped in try/catch, nothing to build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)