### PR TITLE
AGENTS.md: branch & memory hygiene — never push to merged branches; lessons ship inside the PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,20 @@ from a `<lane>/<issue#>-<slug>` branch.
 - **Vite Production Builds**: Local environment variables (e.g., `NODE_ENV=development` in `.env`) can bleed into `npm run build` and compile a development-mode bundle containing React development helpers. This causes a critical browser runtime crash with the error: `TypeError: (0, X.jsxDEV) is not a function`. To compile a pure, clean production bundle, always prefix the build command: `NODE_ENV=production npm run build`.
 - **Playwright selectors for Material-UI Typography**: Material-UI's `<Typography>` component compiles to `<p>` tags (or other tags like `<h1>` or `<h6>` based on variants) by default, **never** `<span>` tags. Avoid utilizing tag-locked selectors like `span:has-text("...")` in E2E/Playwright tests, as they will timeout. Instead, use tag-agnostic text selectors like `:text("...")` or `p:has-text("...")`.
 
+## Branch & memory hygiene
+
+- One branch per task: never create or push any branch other than the one
+  created for the current task.
+- Once your PR is merged or closed, its branch is DEAD — never commit to it or
+  push it again. Follow-up work (including afterthoughts like docs or lessons
+  learned) starts on a NEW branch off the latest `dev`, with its own PR.
+- Save lessons BEFORE the merge, not after: anything you learned during the task
+  worth keeping (build quirks, selector gotchas, testing patterns — e.g. the
+  output of a `/learn`-style memory pass) gets committed to this file's
+  Troubleshooting/Memory sections on the SAME task branch while the PR is still
+  open, so it ships inside the PR. A post-merge push to the old branch strands
+  the lesson and forces manual cleanup.
+
 ## Snyk and security audits
 
 - If a task involves resolving Snyk security failures in a PR or build, and you cannot access the Snyk reports locally (e.g., due to local authorization or API limits), always ask the user to provide the exact Snyk failures and vulnerability IDs first. Do not attempt to guess or audit blindly, as this can lead to going down the wrong path.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.9.30",
+  "version": "2.9.31",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {


### PR DESCRIPTION
## Summary
Adds a 'Branch & memory hygiene' section to AGENTS.md so agy/Flash stops pushing to merged branches: one branch per task; a merged/closed PR's branch is dead (follow-ups start fresh off dev); lessons learned (/learn-style notes) must be committed on the same task branch while the PR is open, so they ship inside the PR instead of stranding on a dead branch post-merge (what happened on gemini/1168 after PR #1171 merged). Docs-only; version 2.9.31.

Closes #1177

## How to test locally
Docs-only (AGENTS.md + version bump) — no runtime surface. Review the rendered section; confirm no src/test changes: git diff dev --stat

## Test evidence
git diff dev --stat: AGENTS.md +14 lines, package.json version 2.9.30→2.9.31 only. No code touched, so lint/unit gates unaffected.

🤖 Work by Claude Code — Fable 5