### PR TITLE
Repoint slideshow to jamPics + artist-scoped gigs (wj-prod consolidation)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,20 @@ from a `<lane>/<issue#>-<slug>` branch.
 - **Vite Production Builds**: Local environment variables (e.g., `NODE_ENV=development` in `.env`) can bleed into `npm run build` and compile a development-mode bundle containing React development helpers. This causes a critical browser runtime crash with the error: `TypeError: (0, X.jsxDEV) is not a function`. To compile a pure, clean production bundle, always prefix the build command: `NODE_ENV=production npm run build`.
 - **Playwright selectors for Material-UI Typography**: Material-UI's `<Typography>` component compiles to `<p>` tags (or other tags like `<h1>` or `<h6>` based on variants) by default, **never** `<span>` tags. Avoid utilizing tag-locked selectors like `span:has-text("...")` in E2E/Playwright tests, as they will timeout. Instead, use tag-agnostic text selectors like `:text("...")` or `p:has-text("...")`.
 
+## Branch & memory hygiene
+
+- One branch per task: never create or push any branch other than the one
+  created for the current task.
+- Once your PR is merged or closed, its branch is DEAD — never commit to it or
+  push it again. Follow-up work (including afterthoughts like docs or lessons
+  learned) starts on a NEW branch off the latest `dev`, with its own PR.
+- Save lessons BEFORE the merge, not after: anything you learned during the task
+  worth keeping (build quirks, selector gotchas, testing patterns — e.g. the
+  output of a `/learn`-style memory pass) gets committed to this file's
+  Troubleshooting/Memory sections on the SAME task branch while the PR is still
+  open, so it ships inside the PR. A post-merge push to the old branch strands
+  the lesson and forces manual cleanup.
+
 ## Snyk and security audits
 
 - If a task involves resolving Snyk security failures in a PR or build, and you cannot access the Snyk reports locally (e.g., due to local authorization or API limits), always ask the user to provide the exact Snyk failures and vulnerability IDs first. Do not attempt to guess or audit blindly, as this can lead to going down the wrong path.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.9.30",
+  "version": "2.9.31",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/Music/Gigs/gigs.utils.tsx
+++ b/src/containers/Music/Gigs/gigs.utils.tsx
@@ -24,7 +24,7 @@ const createGig = async (
   try {
     const { token } = auth;
     const gig = {
-      datetime, venue, tickets, city, usState, duration, promoImageUrl,
+      datetime, venue, tickets, city, usState, duration, promoImageUrl, artist: 'josh',
     };
     const socket = scc.create({
       hostname: process.env.SCS_HOST,
@@ -47,7 +47,7 @@ const updateGig = async (
   token: string,
 ) => {
   try {
-    const gig: Igig = { ...editGig };
+    const gig: Igig = { ...editGig, artist: 'josh' };
     delete gig.date;
     delete gig.time;
     delete gig.location;

--- a/src/providers/Data.provider.tsx
+++ b/src/providers/Data.provider.tsx
@@ -19,6 +19,7 @@ export interface Igig {
   usState?: string;
   duration?: number;
   promoImageUrl?: string;
+  artist?: string;
 }
 
 export interface Isong {

--- a/src/providers/fetchGigs.tsx
+++ b/src/providers/fetchGigs.tsx
@@ -14,6 +14,7 @@ export const defaultGig: Igig = {
   id: 0,
   duration: 0,
   promoImageUrl: '',
+  artist: 'josh',
 };
 
 const getGigs = (

--- a/src/providers/fetchPics.tsx
+++ b/src/providers/fetchPics.tsx
@@ -1,6 +1,6 @@
 import type { Ipic } from './Data.provider';
 import socketClusterMessages from './socketClusterMessages';
 
-const getPics = (setPics: (_arg0: Ipic[] | null) => void): boolean => socketClusterMessages.initialMessage(setPics, 'allBooks');
+const getPics = (setPics: (_arg0: Ipic[] | null) => void): boolean => socketClusterMessages.initialMessage(setPics, 'jamPics');
 
 export default { getPics };

--- a/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
+++ b/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
@@ -137,7 +137,7 @@ exports[`AppTemplate > renders the component 1`] = `
             <strong>
               Version
                
-              2.9.30
+              2.9.31
             </strong>
           </div>
           <p


### PR DESCRIPTION
## Summary
Repointed homepage slideshow from legacy allBooks collection to the new jamPics socket message/collection. Scoped all gig read/write requests to the default artist 'josh' by adding the artist property in the client socket payload/default model.

Closes #1182

## How to test locally
1. Run npm test to verify all unit, eslint, stylelint, and copy-paste tests pass. 2. Verify homepage slideshow reads from jamPics and admin write paths (newImage, editImage, deleteImage) target jamPics. 3. Verify newly created and edited gigs carry artist: 'josh'.

## Test evidence
Ran npm test successfully. All 444 unit tests, lint checks, stylelint checks, and copy-paste checks (jscpd) passed without errors. Adjusted the AppTemplate snapshot to match the bumped version (2.9.31).

🤖 Work by agy — Gemini 3.5 Flash