### PR TITLE
Add axe (vitest-axe) accessibility tests

### DIFF
--- a/__mocks__/@mui/material.tsx
+++ b/__mocks__/@mui/material.tsx
@@ -3,7 +3,9 @@ export function TextField(props:any) {
   const { children, slotProps, inputProps, inputRef, ...rest } = props;
   const testId = slotProps?.htmlInput?.['data-testid'] || inputProps?.['data-testid'] || rest['data-testid'];
   const style = slotProps?.htmlInput?.style || inputProps?.style || rest.style;
-  return <input ref={inputRef} data-testid={testId} style={style} {...rest}>{children}</input>;
+  // real MUI renders `label` as an associated <label>; expose it as the
+  // accessible name here so axe sees what real users get
+  return <input ref={inputRef} data-testid={testId} style={style} aria-label={rest.label} {...rest}>{children}</input>;
 }
 
 export function Checkbox(props:any) {
@@ -76,13 +78,15 @@ export function FormGroup(props:any) {
 }
 
 export function FormControlLabel(props:any) {
-  const { children, control } = props;
-  return <div {...props}>{control}{children}</div>;
+  const { children, control, label, ...rest } = props;
+  // real MUI wraps the control in a <label> with the label text
+  return <label {...rest}>{control}{label}{children}</label>;
 }
 
 export function Select(props:any) {
-  const { children } = props;
-  return <select {...props}>{children}</select>;
+  const { children, labelId, ...rest } = props;
+  // real MUI wires `labelId` to the combobox's accessible name
+  return <select aria-labelledby={labelId} {...rest}>{children}</select>;
 }
 
 export function MenuItem(props:any) {

--- a/__mocks__/@mui/x-date-pickers.tsx
+++ b/__mocks__/@mui/x-date-pickers.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export function DateTimePicker(props:any) {
-  const { children } = props;
-  return <input {...props}>{children}</input>;
+  const { children, label, ...rest } = props;
+  // real MUI pickers expose `label` as the field's accessible name
+  return <input aria-label={label} {...rest}>{children}</input>;
 }
 
 export function DatePicker(props:any) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jammusic",
-  "version": "2.9.30",
+  "version": "2.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jammusic",
-      "version": "2.9.30",
+      "version": "2.10.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -64,6 +64,7 @@
         "@testing-library/react": "^16.3.2",
         "@vitest/coverage-v8": "^4.1.7",
         "@vitest/eslint-plugin": "^1.6.18",
+        "axe-core": "^4.12.1",
         "eslint": "^10.4.0",
         "eslint-plugin-import-x": "^4.16.2",
         "eslint-plugin-json": "^4.0.1",
@@ -80,7 +81,8 @@
         "stylelint-config-standard": "^40.0.0",
         "stylelint-scss": "^7.1.1",
         "typescript-eslint": "^8.60.0",
-        "vitest": "^4.1.7"
+        "vitest": "^4.1.7",
+        "vitest-axe": "^0.1.0"
       },
       "engines": {
         "node": "24.18.0"
@@ -3833,9 +3835,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.11.4",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
-      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {
@@ -4383,6 +4385,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/chokidar": {
@@ -7863,6 +7878,13 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -11423,6 +11445,31 @@
           "optional": false
         }
       }
+    },
+    "node_modules/vitest-axe": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/vitest-axe/-/vitest-axe-0.1.0.tgz",
+      "integrity": "sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.0.0",
+        "axe-core": "^4.4.2",
+        "chalk": "^5.0.1",
+        "dom-accessibility-api": "^0.5.14",
+        "lodash-es": "^4.17.21",
+        "redent": "^3.0.0"
+      },
+      "peerDependencies": {
+        "vitest": ">=0.16.0"
+      }
+    },
+    "node_modules/vitest-axe/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vm-browserify": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.9.31",
+  "version": "2.10.0",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {
@@ -100,6 +100,7 @@
     "@testing-library/react": "^16.3.2",
     "@vitest/coverage-v8": "^4.1.7",
     "@vitest/eslint-plugin": "^1.6.18",
+    "axe-core": "^4.12.1",
     "eslint": "^10.4.0",
     "eslint-plugin-import-x": "^4.16.2",
     "eslint-plugin-json": "^4.0.1",
@@ -116,7 +117,8 @@
     "stylelint-config-standard": "^40.0.0",
     "stylelint-scss": "^7.1.1",
     "typescript-eslint": "^8.60.0",
-    "vitest": "^4.1.7"
+    "vitest": "^4.1.7",
+    "vitest-axe": "^0.1.0"
   },
   "overrides": {
     "uuid": "^11.1.1",

--- a/src/App/AppTemplate/DrawerContainer.tsx
+++ b/src/App/AppTemplate/DrawerContainer.tsx
@@ -9,7 +9,11 @@ export function DrawerContainer(props: IdrawerContainerProps) {
     userCount, heartBeat, className, handleClose, handleKeyPress,
   } = props;
   return (
-    <div tabIndex={0} role="button" id="sidebar" onClick={handleClose} onKeyPress={handleKeyPress} className={className}>
+    // Click/Escape-to-close conveniences only — the drawer wrapper is not a
+    // widget itself (its nav links are the interactive controls; a
+    // role="button" wrapper violates axe nested-interactive). Escape key
+    // events bubble up here from the focused links inside.
+    <div role="presentation" id="sidebar" onClick={handleClose} onKeyPress={handleKeyPress} className={className}>
       <div
         className="drawer"
         style={{

--- a/src/components/WjDropdown.tsx
+++ b/src/components/WjDropdown.tsx
@@ -3,19 +3,23 @@ interface WjDropdownProps {
   onChange: (event: any) => void,
   options: string[],
   htmlFor?: string,
+  label?: string,
   value?: string,
   style?: Record<string, unknown>,
   disabled?: boolean
 }
 export const WjDropdown = (props: WjDropdownProps) => {
   const {
-    style, htmlFor, onChange, value, options, disabled,
+    style, htmlFor, label, onChange, value, options, disabled,
   } = props;
   return (
     <select
       disabled={disabled || false}
       style={style}
       id={htmlFor || ''}
+      // no visible <label> exists for this control, so expose one to
+      // assistive tech (axe select-name)
+      aria-label={label || htmlFor}
       multiple={false}
       onChange={(event) => onChange(event)}
       value={value}

--- a/src/containers/BuyMusic/BuyLinks/AlbumBuyCard.tsx
+++ b/src/containers/BuyMusic/BuyLinks/AlbumBuyCard.tsx
@@ -12,7 +12,9 @@ export function AlbumBuyCard({
   return (
     <div className="col">
       <div className="material-content elevation2" style={{ maxWidth: '3in', margin: 'auto', height: '3in' }}>
-        <h5 style={{ textAlign: 'center' }}>{heading}</h5>
+        {/* h3 keeps heading order valid after the page h2 (axe heading-order);
+            font styles pinned to the old h5 look so the card is unchanged */}
+        <h3 style={{ textAlign: 'center', fontSize: '0.83em', margin: '1.67em 0' }}>{heading}</h3>
         <div style={{ textAlign: 'center' }}>
           <a
             href={href}

--- a/src/containers/Homepage/Inquiry/index.tsx
+++ b/src/containers/Homepage/Inquiry/index.tsx
@@ -154,6 +154,7 @@ export function InquiryForm(props: IinquiryFormProps) {
         disabled={!!staticCountry}
         style={{ width: '100%' }}
         htmlFor="country"
+        label="Country"
         value={staticCountry || country}
         onChange={(evt) => {
           const { target: { value } } = evt;
@@ -166,6 +167,7 @@ export function InquiryForm(props: IinquiryFormProps) {
         ? (
           <WjDropdown
             htmlFor="state"
+            label="State"
             value={uSAstate}
             onChange={(evt) => {
               const { target: { value } } = evt;
@@ -245,12 +247,16 @@ export function ContactForm(props: IcontactFormProps) {
     >
       {!hasSubmitted ? (
         <div className="contact-form">
-          <h4 style={{
-            textAlign: 'center', marginBottom: '0', marginTop: '1px', paddingTop: 0, fontWeight: 'bold',
-          }}
-          >
-            {hideTitle ? '' : 'Contact Us'}
-          </h4>
+          {/* render no heading at all when hidden — an empty <h4> is an axe
+              empty-heading violation */}
+          {hideTitle ? null : (
+            <h4 style={{
+              textAlign: 'center', marginBottom: '0', marginTop: '1px', paddingTop: 0, fontWeight: 'bold',
+            }}
+            >
+              Contact Us
+            </h4>
+          )}
           {submitError ? <InquiryError /> : null}
           <InquiryForm
             staticCountry={country}

--- a/src/containers/Music/instruments.tsx
+++ b/src/containers/Music/instruments.tsx
@@ -5,23 +5,25 @@ function Instruments(props: { type: string }) {
     <ol className="instruments">
       <li>Lead vocals</li>
       <li>Harmony vocals</li>
+      {/* fragments, not <span>, so the <ol> only directly contains <li>
+          (axe list / listitem rules) */}
       {type === 'Maria' ? (
-        <span>
+        <>
           <li>Bass guitar</li>
           <li>Accordion</li>
           <li>Bassoon</li>
           <li>Saxophone</li>
           <li>Tri-tom</li>
-        </span>
+        </>
       )
         : (
-          <span>
+          <>
             <li>Acoustic guitar</li>
             <li>Electric guitar</li>
             <li>Harmonica</li>
             <li>Trumpet</li>
             <li>Kazoo</li>
-          </span>
+          </>
         )}
     </ol>
   );

--- a/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
+++ b/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
@@ -8,8 +8,7 @@ exports[`AppTemplate > renders the component 1`] = `
     <div
       class="home-sidebar close drawer-container"
       id="sidebar"
-      role="button"
-      tabindex="0"
+      role="presentation"
     >
       <div
         class="drawer"
@@ -137,7 +136,7 @@ exports[`AppTemplate > renders the component 1`] = `
             <strong>
               Version
                
-              2.9.31
+              2.10.0
             </strong>
           </div>
           <p

--- a/test/a11y.spec.tsx
+++ b/test/a11y.spec.tsx
@@ -1,0 +1,73 @@
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import { axe } from 'vitest-axe';
+import store from 'src/redux/store/index';
+import { AppTemplate } from 'src/App/AppTemplate';
+import { ThemeProvider, type Theme } from 'src/providers/Theme.provider';
+import { MuiThemeProvider } from 'src/providers/MuiThemeProvider';
+import { Homepage } from 'src/containers/Homepage';
+import { Music } from 'src/containers/Music';
+import BuyMusic from 'src/containers/BuyMusic';
+import { Songs } from 'src/containers/Songs';
+import { BookUs } from 'src/containers/BookUs';
+import { Tipjar } from 'src/containers/Tipjar';
+import { AdminUsers } from 'src/containers/AdminUsers';
+import { AdminVenues } from 'src/containers/AdminVenues';
+import { AdminOutreach } from 'src/containers/AdminOutreach';
+import { AdminTemplates } from 'src/containers/AdminTemplates';
+
+// jsdom does not load the app's compiled stylesheets, so axe cannot compute
+// real foreground/background colors here — the color-contrast rule is
+// disabled rather than faked (see JaMmusic#1188; a browser-based axe pass via
+// Playwright would be needed for genuine contrast checks). All structural
+// rules (landmarks, roles, names, list semantics, etc.) run as normal.
+const axeOptions = {
+  rules: { 'color-contrast': { enabled: false } },
+  // jsdom iframes (e.g. the Stripe buy-button on BuyMusic) have no real
+  // browsing context for axe to message into — scan the top document only.
+  iframes: false,
+};
+
+// Mirrors the provider stack in src/Main.tsx (Google OAuth + Data/Auth
+// providers are exercised elsewhere; their context defaults apply here).
+const renderPage = (page: React.ReactNode) => render(
+  <ThemeProvider>
+    <MuiThemeProvider>
+      <Provider store={store.store}>
+        <MemoryRouter>
+          <AppTemplate>{page}</AppTemplate>
+        </MemoryRouter>
+      </Provider>
+    </MuiThemeProvider>
+  </ThemeProvider>,
+);
+
+const pages: [string, React.ReactNode][] = [
+  ['Homepage (/)', <Homepage key="home" />],
+  ['Music (/music)', <Music key="music" />],
+  ['BuyMusic (/music/buymusic)', <BuyMusic key="buy" />],
+  ['Songs (/music/songs)', <Songs key="songs" />],
+  ['BookUs (/music/bookus)', <BookUs key="bookus" />],
+  ['Tipjar (/music/tipjar)', <Tipjar key="tipjar" />],
+  ['AdminUsers (/admin/users)', <AdminUsers key="au" />],
+  ['AdminVenues (/admin/venues)', <AdminVenues key="av" />],
+  ['AdminOutreach (/admin/outreach)', <AdminOutreach key="ao" />],
+  ['AdminTemplates (/admin/templates)', <AdminTemplates key="at" />],
+];
+
+const themes: Theme[] = ['light', 'dark'];
+
+describe.each(themes)('axe accessibility — %s theme', (theme) => {
+  beforeEach(() => {
+    localStorage.clear();
+    localStorage.setItem('theme', theme);
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  it.each(pages)('%s has no axe violations', async (_name, page) => {
+    const { container } = renderPage(page);
+    expect(document.documentElement.getAttribute('data-theme')).toBe(theme);
+    expect(await axe(container, axeOptions)).toHaveNoViolations();
+  });
+});

--- a/test/containers/Bookus/__snapshots__/index.spec.tsx.snap
+++ b/test/containers/Bookus/__snapshots__/index.spec.tsx.snap
@@ -37,9 +37,6 @@ exports[`Bookus > renders correctly 1`] = `
         <div
           class="contact-form"
         >
-          <h4
-            style="text-align: center; margin-bottom: 0px; margin-top: 1px; padding-top: 0px; font-weight: bold;"
-          />
           <form
             class="col"
             id="new-contact"
@@ -124,6 +121,7 @@ exports[`Bookus > renders correctly 1`] = `
               </tbody>
             </table>
             <select
+              aria-label="Country"
               disabled=""
               id="country"
               style="width: 100%;"
@@ -1312,6 +1310,7 @@ exports[`Bookus > renders correctly 1`] = `
               </option>
             </select>
             <select
+              aria-label="State"
               id="state"
             >
               <option

--- a/test/containers/BuyMusic/__snapshots__/index.spec.tsx.snap
+++ b/test/containers/BuyMusic/__snapshots__/index.spec.tsx.snap
@@ -21,11 +21,11 @@ exports[`BuyMusic > renders correctly 1`] = `
           class="material-content elevation2"
           style="max-width: 3in; margin: auto; height: 3in;"
         >
-          <h5
-            style="text-align: center;"
+          <h3
+            style="text-align: center; font-size: 0.83em; margin: 1.67em 0px;"
           >
             Josh Sherman Band
-          </h5>
+          </h3>
           <div
             style="text-align: center;"
           >
@@ -62,11 +62,11 @@ exports[`BuyMusic > renders correctly 1`] = `
           class="material-content elevation2"
           style="max-width: 3in; margin: auto; height: 3in;"
         >
-          <h5
-            style="text-align: center;"
+          <h3
+            style="text-align: center; font-size: 0.83em; margin: 1.67em 0px;"
           >
             Solo Acoustic
-          </h5>
+          </h3>
           <div
             style="text-align: center;"
           >

--- a/test/containers/Homepage/__snapshots__/index.spec.tsx.snap
+++ b/test/containers/Homepage/__snapshots__/index.spec.tsx.snap
@@ -494,6 +494,7 @@ exports[`Homepage > renders correctly 1`] = `
                         </tbody>
                       </table>
                       <select
+                        aria-label="Country"
                         id="country"
                         style="width: 100%;"
                       >

--- a/test/containers/Music/__snapshots__/index.spec.tsx.snap
+++ b/test/containers/Music/__snapshots__/index.spec.tsx.snap
@@ -122,26 +122,26 @@ exports[`/music > renders the component 1`] = `
             Enter all *required fields to create a new picture.
           </div>
           <input
+            aria-label="* URL"
             label="* URL"
             sx="[object Object]"
             type="text"
             value=""
           />
           <input
+            aria-label="* Title"
             label="* Title"
             sx="[object Object]"
             type="text"
             value=""
           />
           <div>
-            <div
-              control="[object Object]"
-              label="Show Title In Caption"
-            >
+            <label>
               <input
                 type="checkbox"
               />
-            </div>
+              Show Title In Caption
+            </label>
           </div>
         </div>
         <div>
@@ -199,8 +199,8 @@ exports[`/music > renders the component 1`] = `
             </div>
             <div>
               <input
+                aria-label="* Date and Time"
                 class="createDatetime"
-                label="* Date and Time"
                 slotprops="[object Object]"
                 value="Sun Jan 01 2017 00:00:00 GMT+0000 (Coordinated Universal Time)"
               />
@@ -216,6 +216,7 @@ exports[`/music > renders the component 1`] = `
               id="create-venue"
             />
             <input
+              aria-label="* City"
               label="* City"
               sx="[object Object]"
               type="text"
@@ -230,9 +231,9 @@ exports[`/music > renders the component 1`] = `
                 * State
               </p>
               <select
+                aria-labelledby="create-us-state-label"
                 id="create-us-state"
                 label="* State"
-                labelid="create-us-state-label"
               >
                 <option
                   value="Alabama"
@@ -532,18 +533,21 @@ exports[`/music > renders the component 1`] = `
               </select>
             </div>
             <input
+              aria-label="Tickets"
               label="Tickets"
               sx="[object Object]"
               type="text"
               value=""
             />
             <input
+              aria-label="Duration (hours)"
               label="Duration (hours)"
               sx="[object Object]"
               type="number"
               value="0"
             />
             <input
+              aria-label="Promo image URL"
               label="Promo image URL"
               sx="[object Object]"
               type="text"
@@ -581,8 +585,8 @@ exports[`/music > renders the component 1`] = `
             </div>
             <div>
               <input
+                aria-label="* Date and Time"
                 class="editDateTime"
-                label="* Date and Time"
                 slotprops="[object Object]"
               />
             </div>
@@ -592,6 +596,7 @@ exports[`/music > renders the component 1`] = `
               * Venue
             </p>
             <input
+              aria-label="* City"
               label="* City"
               sx="[object Object]"
               type="text"
@@ -606,9 +611,9 @@ exports[`/music > renders the component 1`] = `
                 * State
               </p>
               <select
+                aria-labelledby="edit-us-state-label"
                 id="edit-us-state"
                 label="* State"
-                labelid="edit-us-state-label"
               >
                 <option
                   value="Alabama"
@@ -908,18 +913,21 @@ exports[`/music > renders the component 1`] = `
               </select>
             </div>
             <input
+              aria-label="Tickets"
               label="Tickets"
               sx="[object Object]"
               type="text"
               value=""
             />
             <input
+              aria-label="Duration (hours)"
               label="Duration (hours)"
               sx="[object Object]"
               type="number"
               value="0"
             />
             <input
+              aria-label="Promo image URL"
               label="Promo image URL"
               sx="[object Object]"
               type="text"
@@ -1022,23 +1030,21 @@ exports[`/music > renders the component 1`] = `
               <li>
                 Harmony vocals
               </li>
-              <span>
-                <li>
-                  Acoustic guitar
-                </li>
-                <li>
-                  Electric guitar
-                </li>
-                <li>
-                  Harmonica
-                </li>
-                <li>
-                  Trumpet
-                </li>
-                <li>
-                  Kazoo
-                </li>
-              </span>
+              <li>
+                Acoustic guitar
+              </li>
+              <li>
+                Electric guitar
+              </li>
+              <li>
+                Harmonica
+              </li>
+              <li>
+                Trumpet
+              </li>
+              <li>
+                Kazoo
+              </li>
             </ol>
           </aside>
         </div>
@@ -1097,23 +1103,21 @@ exports[`/music > renders the component 1`] = `
               <li>
                 Harmony vocals
               </li>
-              <span>
-                <li>
-                  Bass guitar
-                </li>
-                <li>
-                  Accordion
-                </li>
-                <li>
-                  Bassoon
-                </li>
-                <li>
-                  Saxophone
-                </li>
-                <li>
-                  Tri-tom
-                </li>
-              </span>
+              <li>
+                Bass guitar
+              </li>
+              <li>
+                Accordion
+              </li>
+              <li>
+                Bassoon
+              </li>
+              <li>
+                Saxophone
+              </li>
+              <li>
+                Tri-tom
+              </li>
             </ol>
           </aside>
         </div>

--- a/test/vitest.setup.ts
+++ b/test/vitest.setup.ts
@@ -1,5 +1,10 @@
 import { config } from 'dotenv';
-import { vi } from 'vitest';
+import { expect, vi } from 'vitest';
+// vitest-axe's `extend-expect` entry ships an empty dist file in 0.1.0, so
+// register the matchers explicitly instead of relying on its side effect.
+import * as axeMatchers from 'vitest-axe/matchers.js';
+
+expect.extend(axeMatchers);
 
 config();
 

--- a/types/vitest-globals/index.d.ts
+++ b/types/vitest-globals/index.d.ts
@@ -1,1 +1,11 @@
 /// <reference types="vitest/globals" />
+
+import 'vitest';
+
+declare module 'vitest' {
+  // Must mirror vitest's own `Assertion<T = any>` type parameter exactly.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  interface Assertion<T = any> {
+    toHaveNoViolations(): T;
+  }
+}


### PR DESCRIPTION
## Summary
- Add `test/a11y.spec.tsx`: axe-core runtime accessibility tests via `vitest-axe` — renders all 10 routed pages (public + admin) inside the `AppTemplate`/theme/redux provider stack and asserts **no axe violations in light AND dark theme** (20 tests), running inside the normal `test:unit`/coverage gate
- Add `vitest-axe` + `axe-core` as devDependencies; matchers registered in `test/vitest.setup.ts` via `expect.extend` (vitest-axe 0.1.0's `extend-expect` entry ships an empty dist file, so the side-effect import does nothing)
- **Real a11y violations found by axe and fixed:**
  - `DrawerContainer`: sidebar wrapper was `role="button"` + `tabIndex` around focusable nav links (axe **nested-interactive**, every page) → `role="presentation"`; click/Escape-to-close still work (key events bubble from the focused links)
  - `Instruments` (Music bios): `<ol>` contained `<span>`-wrapped `<li>`s (axe **list** + **listitem**) → React fragments
  - `AlbumBuyCard` (BuyMusic): `h2 → h5` jump (axe **heading-order**) → `<h3>` with font styles pinned to the old h5 look
  - `ContactForm` (BookUs): rendered an empty `<h4>` when `hideTitle` (axe **empty-heading**) → renders no heading
  - `WjDropdown` (Homepage/BookUs inquiry): country/state `<select>`s had no accessible name (axe **select-name**) → `aria-label` via new optional `label` prop
- Align MUI mocks with real MUI's accessible output so axe tests app-authored markup, not mock artifacts: `TextField` `label` → `aria-label`, `Select` `labelId` → `aria-labelledby`, `FormControlLabel` renders a real `<label>`, `DateTimePicker` `label` → `aria-label`
- **Limitation (not faked):** jsdom loads no stylesheets, so axe cannot compute real colors — the **color-contrast** rule is disabled with a comment in the spec; all structural rules run. A browser-based axe pass via the existing Playwright setup would be needed for genuine contrast checks (out of scope per the issue). Iframe traversal is also off (`iframes: false`) because jsdom frames (Stripe buy-button on BuyMusic) have no real browsing context.
- No new runtime dependencies; eslint config untouched; version bumped 2.9.31 → 2.10.0 (lockfile synced)

Closes #1188

## How to test locally
Run the full gate (stylelint, eslint, typecheck, jscpd, unit + coverage):
```sh
npm test
```
Expect: all steps green, 68 test files / 464 tests passed (includes the 20 new a11y tests), coverage above the 90/90/80/80 floors.

Run just the a11y suite:
```sh
TZ=UTC npx vitest run test/a11y.spec.tsx --coverage.enabled=false
```
Expect: 20 passed (10 pages x light/dark).

Exercise the visible fixes in the app:
```sh
npm run dev
```
- Open `/music/buymusic`: album card headings look unchanged (same size), but are `<h3>` in the inspector
- Open `/music/bookus`: no empty heading above the form; country/state dropdowns announce "Country"/"State" to screen readers
- Open any page: sidebar drawer still closes on outside click and Escape

## Test evidence
```
> jammusic@2.10.0 test:unit
> TZ=UTC vitest run --coverage

 Test Files  68 passed (68)
      Tests  464 passed (464)

Coverage summary
Statements   : 90.46% ( 2182/2412 )
Branches     : 80.17% ( 1205/1503 )
Functions    : 86.52% ( 565/653 )
Lines        : 92.14% ( 1948/2114 )
```
eslint: 0 errors (768 pre-existing warnings, same classes as the rest of the repo); stylelint, typecheck, jscpd all green. Snapshots updated via `npm run test:unit-u` (5 updated), then full `npm test` re-run green.

🤖 Work by Claude Code — Sonnet 5