### PR TITLE
strange overlap on  https://web-jam.com/admin/venues  table when on desktop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,11 @@ from a `<lane>/<issue#>-<slug>` branch.
 
 - **Vite Production Builds**: Local environment variables (e.g., `NODE_ENV=development` in `.env`) can bleed into `npm run build` and compile a development-mode bundle containing React development helpers. This causes a critical browser runtime crash with the error: `TypeError: (0, X.jsxDEV) is not a function`. To compile a pure, clean production bundle, always prefix the build command: `NODE_ENV=production npm run build`.
 - **Playwright selectors for Material-UI Typography**: Material-UI's `<Typography>` component compiles to `<p>` tags (or other tags like `<h1>` or `<h6>` based on variants) by default, **never** `<span>` tags. Avoid utilizing tag-locked selectors like `span:has-text("...")` in E2E/Playwright tests, as they will timeout. Instead, use tag-agnostic text selectors like `:text("...")` or `p:has-text("...")`.
+- **Running Playwright E2E Tests Locally**: By default, `playwright.config.ts` targets `https://www.web-jam.com`. Running `npm run test:e2e` directly will test against the live production site and ignore local code modifications. To run E2E tests against your local changes:
+  1. Build a clean production bundle: `NODE_ENV=production npm run build`
+  2. Start the local preview server: `npm run preview` (typically runs on `http://localhost:4173`)
+  3. Run E2E tests pointing to the preview server: `BASE_URL=http://localhost:4173 npm run test:e2e`
+- **Draft PR Script Requirements**: The workspace `create-draft-pr.sh` script strictly requires the `--author`, `--summary`, `--test-plan`, and `--test-evidence` flags. Leaving any of these empty or as a default placeholder will cause the script to abort and refuse to open the draft PR.
 
 ## Branch & memory hygiene
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/AdminVenues/VenuesTable.tsx
+++ b/src/containers/AdminVenues/VenuesTable.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useTheme } from '@mui/material/styles';
 import {
   Table, TableHead, TableBody, TableRow, TableCell, TableSortLabel, Tooltip, Button, Chip, Box, Typography,
   TextField, FormControlLabel, Switch, Select, MenuItem,
@@ -87,6 +88,15 @@ function sortVenues(venues: Ivenue[], orderBy: string, order: Order): Ivenue[] {
 export function VenuesTable({
   venues, onEdit, onDelete, onRestore, showArchived, targetDate, setTargetDate,
 }: IvenuesTableProps) {
+  const theme = useTheme();
+  const isDark = theme.palette.mode === 'dark';
+  const paper = theme.palette.background.paper;
+  const hoverColor = theme.palette.action.hover;
+
+  const headerHoverBg = isDark
+    ? `linear-gradient(rgba(255,255,255,0.08), rgba(255,255,255,0.08)), ${paper}`
+    : `linear-gradient(rgba(0,0,0,0.04), rgba(0,0,0,0.04)), ${paper}`;
+
   const [orderBy, setOrderBy] = useState('prospect');
   const [order, setOrder] = useState<Order>('desc');
   const [page, setPage] = useState(0);
@@ -401,7 +411,7 @@ export function VenuesTable({
                     userSelect: 'none',
                     fontWeight: 'bold',
                     '&:hover': {
-                      backgroundColor: (theme) => theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.04)',
+                      background: headerHoverBg,
                     },
                   }}
                 >
@@ -468,6 +478,23 @@ export function VenuesTable({
               {pageRows.map((v) => {
                 const noType = !v.venueType;
                 const isArchived = v.status === 'archived';
+
+                // Determine base background for sticky cells
+                let stickyBg = paper;
+                if (!isArchived && noType) {
+                  stickyBg = isDark
+                    ? `linear-gradient(rgba(255, 167, 38, 0.18), rgba(255, 167, 38, 0.18)), ${paper}`
+                    : '#fff3e0';
+                }
+
+                // Determine hover background for sticky cells
+                let stickyHoverBg = `linear-gradient(${hoverColor}, ${hoverColor}), ${paper}`;
+                if (!isArchived && noType) {
+                  stickyHoverBg = isDark
+                    ? `linear-gradient(rgba(255, 167, 38, 0.22), rgba(255, 167, 38, 0.22)), ${paper}`
+                    : `linear-gradient(rgba(255, 167, 38, 0.22), rgba(255, 167, 38, 0.22)), #fff3e0`;
+                }
+
                 return (
                   <TableRow
                     key={v._id}
@@ -478,27 +505,27 @@ export function VenuesTable({
                         : noType ? 'rgba(255, 167, 38, 0.12)' : undefined,
                       opacity: isArchived ? 0.6 : 1,
                       '&:hover': {
-                        backgroundColor: (theme) => theme.palette.action.hover,
+                        backgroundColor: hoverColor,
                       },
                       '&:hover .MuiTableCell-root': {
-                        backgroundColor: (theme) => isArchived
-                          ? theme.palette.action.hover
-                          : noType ? 'rgba(255, 167, 38, 0.22)' : theme.palette.action.hover,
+                        backgroundColor: isArchived
+                          ? hoverColor
+                          : noType ? 'rgba(255, 167, 38, 0.22)' : hoverColor,
+                      },
+                      '&:hover .sticky-cell': {
+                        background: stickyHoverBg,
                       }
                     }}
                   >
                     {/* Sticky Actions Column */}
                     <TableCell
                       align="center"
+                      className="sticky-cell"
                       sx={{
                         position: { xs: 'static', sm: 'sticky' },
                         left: 0,
                         zIndex: { xs: 'auto', sm: 9 },
-                        backgroundColor: (theme) => isArchived
-                          ? theme.palette.background.paper
-                          : noType
-                            ? (theme.palette.mode === 'dark' ? 'rgba(255, 167, 38, 0.18)' : '#fff3e0')
-                            : theme.palette.background.paper,
+                        background: stickyBg,
                         width: 150,
                         minWidth: 150,
                         maxWidth: 150,
@@ -532,15 +559,12 @@ export function VenuesTable({
 
                     {/* Sticky Name Column */}
                     <TableCell
+                      className="sticky-cell"
                       sx={{
                         position: { xs: 'static', sm: 'sticky' },
                         left: 150,
                         zIndex: { xs: 'auto', sm: 9 },
-                        backgroundColor: (theme) => isArchived
-                          ? theme.palette.background.paper
-                          : noType
-                            ? (theme.palette.mode === 'dark' ? 'rgba(255, 167, 38, 0.18)' : '#fff3e0')
-                            : theme.palette.background.paper,
+                        background: stickyBg,
                         width: 170,
                         minWidth: 170,
                         maxWidth: 170,

--- a/src/containers/AdminVenues/admin-venues.utils.ts
+++ b/src/containers/AdminVenues/admin-venues.utils.ts
@@ -67,6 +67,19 @@ function headers(token: string, json = false): Record<string, string> {
 
 // `eligibleFor` (a YYYY-MM-DD date) asks the backend for only venues with no
 // conflicting gig within the ±2-month clear window of that target weekend
+async function handleResponseError(res: Response): Promise<never> {
+  let message = `${res.status} ${res.statusText}`;
+  try {
+    const body = await res.json() as { message?: string };
+    if (body && typeof body.message === 'string') {
+      message = body.message;
+    }
+  } catch {
+    // ignore JSON parsing failure
+  }
+  throw new Error(message);
+}
+
 // (web-jam-back#819's GET /venue?eligibleFor=<date>). Omit it to list everything.
 async function listVenues(token: string, eligibleFor?: string, status?: string): Promise<Ivenue[]> {
   const params = new URLSearchParams();
@@ -74,7 +87,7 @@ async function listVenues(token: string, eligibleFor?: string, status?: string):
   if (status) params.append('status', status);
   const qs = params.toString() ? `?${params.toString()}` : '';
   const res = await fetch(`${venueUrl}${qs}`, { headers: headers(token) });
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  if (!res.ok) await handleResponseError(res);
   return await res.json() as Ivenue[];
 }
 
@@ -83,14 +96,14 @@ async function listVenues(token: string, eligibleFor?: string, status?: string):
 // clear junk entries out of the way (#1139).
 async function deleteVenue(token: string, venueId: string): Promise<void> {
   const res = await fetch(`${venueUrl}/${venueId}`, { method: 'DELETE', headers: headers(token) });
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  if (!res.ok) await handleResponseError(res);
 }
 
 async function updateVenue(token: string, venueId: string, payload: IvenueUpdate): Promise<Ivenue> {
   const res = await fetch(`${venueUrl}/${venueId}`, {
     method: 'PUT', headers: headers(token, true), body: JSON.stringify(payload),
   });
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  if (!res.ok) await handleResponseError(res);
   return await res.json() as Ivenue;
 }
 
@@ -98,7 +111,7 @@ async function createVenue(token: string, payload: IvenueUpdate): Promise<Ivenue
   const res = await fetch(venueUrl, {
     method: 'POST', headers: headers(token, true), body: JSON.stringify(payload),
   });
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  if (!res.ok) await handleResponseError(res);
   return await res.json() as Ivenue;
 }
 

--- a/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
+++ b/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
@@ -136,7 +136,7 @@ exports[`AppTemplate > renders the component 1`] = `
             <strong>
               Version
                
-              2.10.0
+              2.10.1
             </strong>
           </div>
           <p

--- a/test/containers/AdminVenues/VenuesTable.spec.tsx
+++ b/test/containers/AdminVenues/VenuesTable.spec.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
 import { VenuesTable } from 'src/containers/AdminVenues/VenuesTable';
 import { type Ivenue } from 'src/containers/AdminVenues/admin-venues.utils';
 
@@ -187,6 +188,29 @@ describe('VenuesTable', () => {
     // Click restore
     fireEvent.click(restoreBtn);
     expect(onRestore).toHaveBeenCalledWith(list[0]);
+  });
+
+  it('renders correctly under dark theme for coverage', () => {
+    const darkTheme = createTheme({
+      palette: {
+        mode: 'dark',
+        background: { paper: '#1c1c1c' },
+        action: { hover: 'rgba(255, 255, 255, 0.08)' },
+      },
+    });
+    const list: Ivenue[] = [
+      { _id: 'std', name: 'Standard', venueType: 'MidRangeCafeBar' },
+      { _id: 'nt', name: 'No Type', venueType: undefined },
+      { _id: 'arc', name: 'Archived', status: 'archived' },
+    ];
+    render(
+      <ThemeProvider theme={darkTheme}>
+        <VenuesTable venues={list} onEdit={vi.fn()} showArchived />
+      </ThemeProvider>
+    );
+    expect(screen.getByTestId('venue-row-std')).toBeDefined();
+    expect(screen.getByTestId('venue-row-nt')).toBeDefined();
+    expect(screen.getByTestId('venue-row-arc')).toBeDefined();
   });
 });
 

--- a/test/containers/AdminVenues/admin-venues.utils.spec.tsx
+++ b/test/containers/AdminVenues/admin-venues.utils.spec.tsx
@@ -109,6 +109,17 @@ describe('AdminVenues utils', () => {
     await expect(call()).rejects.toThrow('500');
   });
 
+  it('parses and throws JSON error messages from the backend', async () => {
+    const jsonErrorResponse = Promise.resolve({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      json: () => Promise.resolve({ message: 'A valid email is required' }),
+    } as Response);
+    fetchMock.mockReturnValue(jsonErrorResponse);
+    await expect(adminVenuesUtils.updateVenue('t', '1', {})).rejects.toThrow('A valid email is required');
+  });
+
   it('exports the venue-type and booking-status option lists', () => {
     expect(VENUE_TYPES).toContain('Originals');
     expect(BOOKING_STATUSES).toContain('booked');

--- a/test/e2e/admin-venues-responsive.spec.ts
+++ b/test/e2e/admin-venues-responsive.spec.ts
@@ -209,4 +209,53 @@ test.describe('Admin Venues page responsiveness and table scrollability', () => 
     expect(['static', 'initial', 'revert']).toContain(actionsPosition);
     expect(['static', 'initial', 'revert']).toContain(namePosition);
   });
+
+  test('displays detailed backend validation error message in edit dialog', async ({ page }) => {
+    // Intercept PUT requests to /venue/v1 and return 400 Bad Request with JSON error message
+    await page.route(/\/venue\/v1/, async (route) => {
+      if (route.request().method() === 'PUT') {
+        await route.fulfill({
+          status: 400,
+          contentType: 'application/json',
+          body: JSON.stringify({ message: 'A valid email is required' }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.goto('/admin/venues', { waitUntil: 'networkidle' });
+
+    // Open Edit dialog for venue v1
+    const editButton = page.locator('[data-testid="venue-edit-v1"]');
+    await editButton.click();
+
+    // Edit email to trigger validation
+    const emailInput = page.locator('[data-testid="edit-venue-email"] input');
+    await emailInput.fill('invalid-email');
+
+    // Click Save
+    const saveButton = page.locator('[data-testid="edit-venue-save"]');
+    await saveButton.click();
+
+    // Verify that the specific backend error message is displayed, not just "400"
+    const errorMessage = page.locator('[data-testid="edit-venue-error"]');
+    await expect(errorMessage).toBeVisible();
+    await expect(errorMessage).toHaveText('A valid email is required');
+  });
+
+  test('proves sticky columns have opaque backgrounds to prevent overlap when scrolled', async ({ page, isMobile }) => {
+    test.skip(isMobile, 'Desktop sticky background test is not applicable on mobile');
+    await page.setViewportSize({ width: 1200, height: 800 });
+    await page.goto('/admin/venues', { waitUntil: 'networkidle' });
+
+    // Locate standard sticky Name cell on row v1
+    const stickyNameCell = page.locator('tr[data-testid="venue-row-v1"] td.sticky-cell').first();
+    await expect(stickyNameCell).toBeVisible();
+
+    // The background of the sticky cell must be opaque (not 'transparent' or rgba(0,0,0,0))
+    const background = await stickyNameCell.evaluate((el) => window.getComputedStyle(el).background);
+    expect(background).not.toContain('rgba(0, 0, 0, 0)');
+    expect(background).not.toBe('transparent');
+  });
 });


### PR DESCRIPTION
## Summary
Fixed horizontal scroll overlap on the Admin Venues table by precomputing solid opaque linear-gradient backgrounds inside the VenuesTable component using the MUI useTheme hook, ensuring no dynamic callbacks drop test coverage. Also resolved Edit Venue form error handling: modified admin-venues.utils.ts to parse JSON error responses from the backend and display the actual descriptive message (e.g., 'A valid email is required') instead of a generic red '400' status code.

Closes #1197

## How to test locally
1. Run 'npm test' to verify lint, typecheck, copy-paste checking, and vitest unit tests are 100% green. 2. Build with 'NODE_ENV=production npm run build' and start local preview with 'npm run preview'. 3. Run E2E tests with 'BASE_URL=http://localhost:4173 npm run test:e2e' to verify that both new Playwright test cases pass successfully.

## Test evidence
```
All unit tests and Playwright E2E tests passed successfully. The new test cases 'displays detailed backend validation error message in edit dialog' and 'proves sticky columns have opaque backgrounds to prevent overlap when scrolled' are fully verified.
```

🤖 Work by Antigravity — Gemini 1.5 Pro