### PR TITLE
Delete picture not working in JaMmusic admin (jamPics)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jammusic",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jammusic",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jammusic",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jammusic",
-      "version": "2.10.1",
+      "version": "2.10.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/Music/Pictures/pictures.utils.tsx
+++ b/src/containers/Music/Pictures/pictures.utils.tsx
@@ -73,12 +73,27 @@ async function deletePic(
       secure: process.env.SOCKETCLUSTER_SECURE !== 'false',
     });
     socket.transmit('deleteImage', { data: picId, token });
-    await commonUtils.delay(2);
+    // Listen for the backend's socketError alongside the usual delay so a
+    // genuine deleteImage failure surfaces to the user instead of being a
+    // silent no-op (JaMmusic#1199).
+    const waitForError = async (): Promise<string | undefined> => {
+      const { value } = await socket.receiver('socketError').createConsumer().next();
+      return (value as { deleteImage?: string } | undefined)?.deleteImage;
+    };
+    const errorMessage = await Promise.race<string | undefined>([
+      waitForError(),
+      commonUtils.delay(2) as Promise<string | undefined>,
+    ]);
+    socket.disconnect();
     setters.setIsSubmitting(false);
+    if (errorMessage) {
+      commonUtils.notify('Error deleting picture', errorMessage, 'danger');
+      return;
+    }
     setters.setEditPic(defaultPic);
     getPics();
     setters.setShowTable(false);
-  } catch (err) { console.log((err as Error).message); }
+  } catch (err) { commonUtils.notify('Error deleting picture', (err as Error).message, 'danger'); }
 }
 
 const makeShowHideCaption = (setPic: (arg0: typeof defaultPic) => void, pic: typeof defaultPic) => (evt: any) => {

--- a/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
+++ b/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
@@ -136,7 +136,7 @@ exports[`AppTemplate > renders the component 1`] = `
             <strong>
               Version
                
-              2.10.1
+              2.10.2
             </strong>
           </div>
           <p

--- a/test/containers/Music/Pictures/pictures.utils.spec.tsx
+++ b/test/containers/Music/Pictures/pictures.utils.spec.tsx
@@ -46,16 +46,46 @@ describe('pictures.utils', () => {
     expect(getPics).not.toHaveBeenCalled();
   });
   it('deletes pic successfully', async () => {
+    commonUtils.delay = jest.fn();
     const auth = { token: 'token' } as any;
     const getPics = jest.fn();
     const setters = { setEditPic: jest.fn(), setShowTable: jest.fn(), setIsSubmitting: jest.fn() };
     const transmit = jest.fn();
-    const deleteMock: any = jest.fn(() => ({ transmit }));
+    const disconnect = jest.fn();
+    const next = jest.fn(() => new Promise(() => { /* never resolves: no socketError sent */ }));
+    const receiver = jest.fn(() => ({ createConsumer: () => ({ next }) }));
+    const deleteMock: any = jest.fn(() => ({
+      transmit, receiver, disconnect,
+    }));
     scc.create = deleteMock;
-    await utils.deletePic('', auth, getPics, setters);
+    await utils.deletePic('somePicId', auth, getPics, setters);
     expect(getPics).toHaveBeenCalled();
+    expect(setters.setEditPic).toHaveBeenCalled();
+    expect(setters.setShowTable).toHaveBeenCalledWith(false);
+    expect(disconnect).toHaveBeenCalled();
+  });
+  it('deletePic surfaces a backend socketError instead of silently no-oping (#1199)', async () => {
+    commonUtils.delay = jest.fn(() => new Promise(() => { /* never resolves: the error should win the race */ }));
+    commonUtils.notify = jest.fn();
+    const auth = { token: 'token' } as any;
+    const getPics = jest.fn();
+    const setters = { setEditPic: jest.fn(), setShowTable: jest.fn(), setIsSubmitting: jest.fn() };
+    const transmit = jest.fn();
+    const disconnect = jest.fn();
+    const next = jest.fn(() => Promise.resolve({ value: { deleteImage: 'Delete id not found' }, done: true }));
+    const receiver = jest.fn(() => ({ createConsumer: () => ({ next }) }));
+    const deleteMock: any = jest.fn(() => ({
+      transmit, receiver, disconnect,
+    }));
+    scc.create = deleteMock;
+    await utils.deletePic('somePicId', auth, getPics, setters);
+    expect(commonUtils.notify).toHaveBeenCalledWith('Error deleting picture', 'Delete id not found', 'danger');
+    expect(getPics).not.toHaveBeenCalled();
+    expect(setters.setShowTable).not.toHaveBeenCalledWith(false);
+    expect(disconnect).toHaveBeenCalled();
   });
   it('deletePic catches error', async () => {
+    commonUtils.notify = jest.fn();
     const auth = { token: 'token' } as any;
     const getPics = jest.fn();
     const setters = { setEditPic: jest.fn(), setShowTable: jest.fn(), setIsSubmitting: jest.fn() };
@@ -64,6 +94,7 @@ describe('pictures.utils', () => {
     scc.create = deleteMock;
     await utils.deletePic('', auth, getPics, setters);
     expect(getPics).not.toHaveBeenCalled();
+    expect(commonUtils.notify).toHaveBeenCalledWith('Error deleting picture', 'failed', 'danger');
   });
   it('handles event for makeShowHideCaption', () => {
     const setPic = jest.fn();


### PR DESCRIPTION
## Summary
- `deletePic()` in `src/containers/Music/Pictures/pictures.utils.tsx` transmitted `deleteImage` and refreshed the list after a fixed delay, but never listened for the backend's `socketError` — so any delete failure (e.g. the WJSC mongoose-9 `findByIdAndRemove` bug fixed alongside this in WebJamSocketCluster#pending) looked like a silent no-op.
- `deletePic()` now races a `socket.receiver('socketError')` listener against the existing refresh delay. On a genuine failure it calls `commonUtils.notify(...)` (the toast pattern already used in `songs.utils.tsx`) with the backend's real error message instead of closing the dialog/refreshing as if it succeeded.
- The socket is now explicitly `disconnect()`'d after the delete round-trip (it was previously left open).
- Added tests covering both the delete-success and delete-socketError paths; updated the existing sync-transmit-throw test to assert the new `notify`-based error surfacing.
- Companion backend fix (real root cause) is in a separate WebJamSocketCluster PR — see its summary.

Closes #1199

## How to test locally
Run:
```sh
npm run test:lint
npm run typecheck
npm run jscpd
npm run test:unit
```
Expect all four green (see test-evidence).

Manual verification in the admin UI (once both PRs are deployed): Music -> Pictures -> Edit -> select a picture -> Delete. Expect the picture to disappear from the table after refresh. To exercise the error path, attempt to delete a picture whose id no longer exists (e.g. double-click Delete quickly, or delete the same picture twice) — expect a red toast with the backend's real error message (e.g. "Delete id not found") instead of a silent nothing.

## Test evidence
```
> npm run test:lint
✖ 767 problems (0 errors, 767 warnings)   # all pre-existing warnings repo-wide; 0 errors

> npm run typecheck
tsc --noEmit   # clean, no output

> npm run jscpd
Total: 91 files, 9298 lines, 22 clones, 2.43% duplicated lines (threshold 5%) — pass

> npm run test:unit (TZ=UTC vitest run --coverage)
 Test Files  68 passed (68)
      Tests  465 passed (465)
Coverage summary:
Statements   : 90.49% ( 2189/2419 )
Branches     : 80.19% ( 1207/1505 )
Functions    : 86.54% ( 566/654 )
Lines        : 92.17% ( 1955/2121 )
(gate: statements/lines >=90, branches/functions >=80 — all pass)
```

🤖 Work by Claude Code — Sonnet 5