### PR TITLE
Update AppTemplate snapshot for version bump to 2.10.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.10.2",
+  "version": "2.10.3",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/AdminUsers/UsersTable.tsx
+++ b/src/containers/AdminUsers/UsersTable.tsx
@@ -10,6 +10,7 @@ const COLUMNS: { key: string; label: string }[] = [
   { key: 'name', label: 'Name' },
   { key: 'email', label: 'Email' },
   { key: 'role', label: 'Role' },
+  { key: 'artist', label: 'Artist' },
   { key: 'type', label: 'Type' },
   { key: 'privileges', label: 'Privileges' },
   { key: 'notes', label: 'Notes' },
@@ -21,6 +22,7 @@ export function sortValue(u: IadminUser, key: string): string {
     case 'name': return u.name || '';
     case 'email': return u.email || '';
     case 'role': return u.userType || 'N/A';
+    case 'artist': return u.artist || '';
     case 'type': return u.userStatus || 'human';
     case 'privileges': return (u.privileges || []).join(', ');
     case 'notes': return u.userDetails || '';
@@ -116,6 +118,7 @@ export function UsersTable({
               <TableCell>
                 <Chip label={u.userType || 'N/A'} color="primary" variant="outlined" size="small" />
               </TableCell>
+              <TableCell>{u.artist || ''}</TableCell>
               <TableCell>
                 <Chip label={u.userStatus || 'human'} size="small" />
               </TableCell>

--- a/src/containers/AdminUsers/admin-users.utils.ts
+++ b/src/containers/AdminUsers/admin-users.utils.ts
@@ -6,6 +6,9 @@ export interface IadminUser {
   userStatus?: string;
   privileges?: string[];
   userDetails?: string;
+  // Artist slug an artist-scoped admin (e.g. tim-admin) owns (web-jam-back#885).
+  // Absent for super-admins / non-artist-scoped roles.
+  artist?: string;
 }
 
 const baseUrl = `${process.env.BackendUrl}/admin/user`;
@@ -86,9 +89,7 @@ async function deleteUser(token: string, userId: string): Promise<void> {
 }
 
 export function getAllowedAdminRoles(): string[] {
-  return process.env.NODE_ENV === 'production'
-    ? ['JaM-admin', 'Developer', 'clc-admin']
-    : ['JaM-admin', 'Developer', 'clc-admin'];
+  return ['JaM-admin', 'Developer', 'clc-admin', 'tim-admin'];
 }
 
 export default {

--- a/src/containers/AdminUsers/capabilities.ts
+++ b/src/containers/AdminUsers/capabilities.ts
@@ -38,5 +38,5 @@ export const CAPABILITY_GROUPS: { label: string; items: Capability[] }[] = [
 export const USER_STATUS_OPTIONS = ['human', 'ai-agent'] as const;
 export type UserStatus = (typeof USER_STATUS_OPTIONS)[number];
 
-export const USER_ROLES = ['JaM-admin', 'Developer', 'clc-admin', 'web-jam-llm'] as const;
+export const USER_ROLES = ['JaM-admin', 'Developer', 'clc-admin', 'tim-admin', 'web-jam-llm'] as const;
 export type UserRole = (typeof USER_ROLES)[number];

--- a/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
+++ b/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
@@ -136,7 +136,7 @@ exports[`AppTemplate > renders the component 1`] = `
             <strong>
               Version
                
-              2.10.2
+              2.10.3
             </strong>
           </div>
           <p

--- a/test/containers/AdminUsers/UsersTable.spec.tsx
+++ b/test/containers/AdminUsers/UsersTable.spec.tsx
@@ -83,6 +83,14 @@ describe('UsersTable', () => {
     expect(document.querySelectorAll('tbody tr')[0].getAttribute('data-testid')).toBe('user-row-b');
   });
 
+  it('renders an Artist column for artist-scoped admins', () => {
+    const scoped: IadminUser[] = [{
+      _id: 'u10', name: 'Tim', email: 't@x.com', userType: 'tim-admin', artist: 'tim-sherman', privileges: [],
+    }];
+    render(<UsersTable users={scoped} token="tk" onShowToken={vi.fn()} onEditPrivileges={vi.fn()} onChange={vi.fn()} />);
+    expect(screen.getByText('tim-sherman')).toBeDefined();
+  });
+
   it('sorts rows by type correctly when userStatus is missing and defaults to human', () => {
     const mixed: IadminUser[] = [
       { _id: 'u1', name: 'Alice', email: 'a@x.com', userStatus: 'ai-agent', privileges: [] },

--- a/test/containers/AdminUsers/admin-users.utils.spec.tsx
+++ b/test/containers/AdminUsers/admin-users.utils.spec.tsx
@@ -66,17 +66,21 @@ describe('AdminUsers utils', () => {
     const originalEnv = process.env.NODE_ENV;
     afterEach(() => { process.env.NODE_ENV = originalEnv; });
 
-    it('returns only JaM-admin in production', () => {
+    it('returns the same fixed list of roles in production', () => {
       process.env.NODE_ENV = 'production';
       const roles = adminUtils.getAllowedAdminRoles();
-      expect(roles).toEqual(['JaM-admin', 'Developer', 'clc-admin']);
+      expect(roles).toEqual(['JaM-admin', 'Developer', 'clc-admin', 'tim-admin']);
     });
 
-    it('includes Developer in non-production', () => {
+    it('returns the same fixed list of roles in non-production (no env branching)', () => {
       process.env.NODE_ENV = 'development';
       const roles = adminUtils.getAllowedAdminRoles();
-      expect(roles).toContain('JaM-admin');
-      expect(roles).toContain('Developer');
+      expect(roles).toEqual(['JaM-admin', 'Developer', 'clc-admin', 'tim-admin']);
+    });
+
+    it('includes the artist-scoped tim-admin role', () => {
+      const roles = adminUtils.getAllowedAdminRoles();
+      expect(roles).toContain('tim-admin');
     });
   });
 

--- a/test/containers/AdminUsers/capabilities.spec.tsx
+++ b/test/containers/AdminUsers/capabilities.spec.tsx
@@ -1,4 +1,6 @@
-import { CAPABILITIES, CAPABILITY_GROUPS, USER_STATUS_OPTIONS } from 'src/containers/AdminUsers/capabilities';
+import {
+  CAPABILITIES, CAPABILITY_GROUPS, USER_STATUS_OPTIONS, USER_ROLES,
+} from 'src/containers/AdminUsers/capabilities';
 
 describe('AdminUsers capabilities registry', () => {
   it('includes tour, song, book, venue, template, and outreach capabilities', () => {
@@ -30,5 +32,12 @@ describe('AdminUsers capabilities registry', () => {
   it('USER_STATUS_OPTIONS includes human and ai-agent', () => {
     expect(USER_STATUS_OPTIONS).toContain('human');
     expect(USER_STATUS_OPTIONS).toContain('ai-agent');
+  });
+
+  // The artist-scoped admin role (renamed from the generic artist-admin to
+  // slug-derived tim-admin), so the /admin/users edit form can show and set
+  // it without wiping it on save (TimShermanMusic#34).
+  it('USER_ROLES includes the artist-scoped tim-admin role', () => {
+    expect(USER_ROLES).toContain('tim-admin');
   });
 });


### PR DESCRIPTION
## Summary
- Add `tim-admin` to `getAllowedAdminRoles()` in `src/containers/AdminUsers/admin-users.utils.ts` and collapse its dead `NODE_ENV === 'production' ? X : X` ternary (both branches returned the identical array) to a single returned list: `['JaM-admin', 'Developer', 'clc-admin', 'tim-admin']`
- Add `tim-admin` to `USER_ROLES` in `src/containers/AdminUsers/capabilities.ts` — this is what actually drives the Role `<Select>` in `EditUserDialog.tsx`/`CreateUserForm.tsx`; without this the edit form's dropdown still couldn't show or set the role, and saving an artist-scoped admin's edit would silently clear their role (the reported bug)
- `grep -rn "artist-admin"` across `src` and `test` found zero references, so no rename cleanup was needed there
- Optional: added an `artist` field to `IadminUser` and a sortable "Artist" column to `UsersTable.tsx` (backend's `user-schema.ts` already carries this field for artist-scoped admins per web-jam-back#885) so a scoped admin reads clearly in the table
- Part of cross-repo tracking issue TimShermanMusic#34 (tim-admin rename)

## How to test locally
Run the full gate:
```sh
cd ~/WebJamApps/JaMmusic
npm test
```
Expect: lint 0 errors, typecheck clean, jscpd unchanged (18 pre-existing clones, none new), 68 test files / 470 tests passing, coverage gate (90/90/80/80) green.

Manual: `npm run dev`, sign in as a `JaM-admin`/`Developer` user, open `/admin/users`, click "Edit User" on any row, open the Role dropdown — confirm `tim-admin` appears as an option, can be selected, and Save persists it (no longer silently cleared).

## Test evidence
```
✖ 763 problems (0 errors, 763 warnings)

> jammusic@2.10.3 typecheck
> tsc --noEmit
(clean, no output)

> jammusic@2.10.3 jscpd
> jscpd src
Found 18 clones. (pre-existing, none introduced by this change)

> jammusic@2.10.3 test:unit
> TZ=UTC vitest run --coverage

 Test Files  68 passed (68)
      Tests  470 passed (470)

=============================== Coverage summary ===============================
Statements   : 90.7% ( 2206/2432 )
Branches     : 81.28% ( 1229/1512 )
Functions    : 87.23% ( 567/650 )
Lines        : 92.4% ( 1972/2134 )
================================================================================
```

🤖 Work by Claude Code — Sonnet 5