### PR TITLE
AdminVenues vetting view: contact info + last-pitched visible per row; drop In-scope column

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jammusic",
-  "version": "2.10.2",
+  "version": "2.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jammusic",
-      "version": "2.10.2",
+      "version": "2.11.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.10.3",
+  "version": "2.11.0",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/AdminVenues/EditVenueDialog.tsx
+++ b/src/containers/AdminVenues/EditVenueDialog.tsx
@@ -228,13 +228,7 @@ export function EditVenueDialog({
             )}
             label="Outreach eligible (vetted — can be pitched)" />
           <Help field="outreachEligible" />
-          <FormControlLabel
-            control={(
-              <Checkbox checked={form.inScope !== false} onChange={(e) => set('inScope', e.target.checked)}
-                aria-label="in scope" data-testid="edit-venue-inscope" />
-            )}
-            label="In scope (a gig-booking venue)" />
-          <Help field="inScope" />
+
           <FormControlLabel
             control={(
               <Checkbox

--- a/src/containers/AdminVenues/VenuesTable.tsx
+++ b/src/containers/AdminVenues/VenuesTable.tsx
@@ -29,11 +29,12 @@ const COLUMNS: { key: string; label: string; help?: string }[] = [
   { key: 'name', label: 'Name' },
   { key: 'city', label: 'City' },
   { key: 'state', label: 'State' },
+  { key: 'contact', label: 'Contact' },
   { key: 'type', label: 'Type', help: 'venueType' },
-  { key: 'inScope', label: 'In scope', help: 'inScope' },
   { key: 'booking', label: 'Booking', help: 'bookingStatus' },
   { key: 'interested', label: 'Interested', help: 'interested' },
   { key: 'eligible', label: 'Eligible', help: 'outreachEligible' },
+  { key: 'lastContacted', label: 'Last pitched' },
   { key: 'originals', label: 'Originals', help: 'originalsFit' },
   { key: 'pay', label: 'Pay', help: 'payTier' },
   { key: 'travel', label: 'Travel', help: 'travelBand' },
@@ -44,6 +45,13 @@ const COLUMNS: { key: string; label: string; help?: string }[] = [
 const yn = (v: boolean | undefined) => (v ? 'yes' : 'no');
 const dash = (v: string | number | undefined) => (v === undefined || v === '' ? '—' : String(v));
 
+// Format ISO string date to YYYY-MM-DD
+function formatLastContacted(lc?: string): string {
+  if (!lc) return '—';
+  if (lc.includes('T')) return lc.split('T')[0];
+  return lc;
+}
+
 // The value a column sorts by. Booleans become 1/0 so yes sorts above no;
 // 'prospect' is the computed score.
 export function sortValue(v: Ivenue, key: string): string | number {
@@ -51,11 +59,12 @@ export function sortValue(v: Ivenue, key: string): string | number {
     case 'name': return v.name || '';
     case 'city': return v.city || '';
     case 'state': return v.usState || '';
+    case 'contact': return v.contactName || '';
     case 'type': return v.venueType || '';
-    case 'inScope': return v.inScope !== false ? 1 : 0;
     case 'booking': return v.bookingStatus || '';
     case 'interested': return v.interested !== false ? 1 : 0;
     case 'eligible': return v.outreachEligible ? 1 : 0;
+    case 'lastContacted': return v.lastContacted || '';
     case 'originals': return v.originalsFit || '';
     case 'pay': return v.payTier || '';
     case 'travel': return v.travelBand || '';
@@ -580,15 +589,95 @@ export function VenuesTable({
                     {/* Other standard columns */}
                     <TableCell>{dash(v.city)}</TableCell>
                     <TableCell>{dash(v.usState)}</TableCell>
+                    <TableCell data-testid={`venue-contact-${v._id}`}>
+                      <Box sx={{ display: 'flex', gap: 1.5, alignItems: 'center' }}>
+                        {/* Contact Name */}
+                        {v.contactName ? (
+                          <Tooltip title={`Contact Name: ${v.contactName}`} arrow>
+                            <Typography
+                              component="span"
+                              data-testid={`venue-contact-name-${v._id}`}
+                              sx={{ fontSize: '1.1rem', cursor: 'help', color: 'primary.main' }}
+                            >
+                              👤
+                            </Typography>
+                          </Tooltip>
+                        ) : (
+                          <Typography
+                            component="span"
+                            data-testid={`venue-contact-name-missing-${v._id}`}
+                            sx={{ fontSize: '1.1rem', opacity: 0.2, color: 'text.secondary', userSelect: 'none' }}
+                          >
+                            👤
+                          </Typography>
+                        )}
+
+                        {/* Email */}
+                        {v.email ? (
+                          <Tooltip title={`Email: ${v.email}`} arrow>
+                            <Box
+                              component="a"
+                              href={`mailto:${v.email}`}
+                              data-testid={`venue-contact-email-${v._id}`}
+                              sx={{
+                                fontSize: '1.1rem',
+                                textDecoration: 'none',
+                                color: 'info.main',
+                                display: 'inline-flex',
+                                '&:hover': { opacity: 0.8 },
+                              }}
+                            >
+                              ✉
+                            </Box>
+                          </Tooltip>
+                        ) : (
+                          <Typography
+                            component="span"
+                            data-testid={`venue-contact-email-missing-${v._id}`}
+                            sx={{ fontSize: '1.1rem', opacity: 0.2, color: 'text.secondary', userSelect: 'none' }}
+                          >
+                            ✉
+                          </Typography>
+                        )}
+
+                        {/* Phone */}
+                        {v.phone ? (
+                          <Tooltip title={`Phone: ${v.phone}`} arrow>
+                            <Box
+                              component="a"
+                              href={`tel:${v.phone}`}
+                              data-testid={`venue-contact-phone-${v._id}`}
+                              sx={{
+                                fontSize: '1.1rem',
+                                textDecoration: 'none',
+                                color: 'success.main',
+                                display: 'inline-flex',
+                                '&:hover': { opacity: 0.8 },
+                              }}
+                            >
+                              ☎
+                            </Box>
+                          </Tooltip>
+                        ) : (
+                          <Typography
+                            component="span"
+                            data-testid={`venue-contact-phone-missing-${v._id}`}
+                            sx={{ fontSize: '1.1rem', opacity: 0.2, color: 'text.secondary', userSelect: 'none' }}
+                          >
+                            ☎
+                          </Typography>
+                        )}
+                      </Box>
+                    </TableCell>
                     <TableCell>
                       {noType
                         ? <Chip label="no type" color="warning" size="small" data-testid={`venue-notype-${v._id}`} />
                         : v.venueType}
                     </TableCell>
-                    <TableCell>{yn(v.inScope !== false)}</TableCell>
                     <TableCell>{dash(v.bookingStatus)}</TableCell>
                     <TableCell>{yn(v.interested !== false)}</TableCell>
                     <TableCell data-testid={`venue-eligible-${v._id}`}>{yn(v.outreachEligible)}</TableCell>
+                    <TableCell data-testid={`venue-lastcontacted-${v._id}`}>{formatLastContacted(v.lastContacted)}</TableCell>
                     <TableCell>{dash(v.originalsFit)}</TableCell>
                     <TableCell>{dash(v.payTier)}</TableCell>
                     <TableCell>{dash(v.travelBand)}</TableCell>

--- a/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
+++ b/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
@@ -136,7 +136,7 @@ exports[`AppTemplate > renders the component 1`] = `
             <strong>
               Version
                
-              2.10.3
+              2.11.0
             </strong>
           </div>
           <p

--- a/test/containers/AdminVenues/EditVenueDialog.spec.tsx
+++ b/test/containers/AdminVenues/EditVenueDialog.spec.tsx
@@ -66,7 +66,6 @@ describe('EditVenueDialog', () => {
       change('edit-venue-pay', '$$$');
       change('edit-venue-notes', 'great room');
     });
-    await act(async () => { fireEvent.click(screen.getByTestId('edit-venue-inscope')); });
     await act(async () => { fireEvent.click(screen.getByTestId('edit-venue-interested')); });
     await act(async () => { fireEvent.click(screen.getByTestId('edit-venue-contactverified')); });
     await act(async () => { fireEvent.click(screen.getByTestId('edit-venue-save')); });

--- a/test/containers/AdminVenues/VenuesTable.spec.tsx
+++ b/test/containers/AdminVenues/VenuesTable.spec.tsx
@@ -25,6 +25,36 @@ describe('VenuesTable', () => {
     expect(screen.getByTestId('venue-score-v1')).toBeDefined();
   });
 
+  it('renders contact presence indicators and lastContacted date correctly', () => {
+    const list: Ivenue[] = [
+      {
+        _id: 'full-contact',
+        name: 'Full Contact',
+        contactName: 'Alice',
+        email: 'alice@example.com',
+        phone: '123-456-7890',
+        lastContacted: '2026-07-15T12:00:00.000Z',
+      },
+      {
+        _id: 'no-contact',
+        name: 'No Contact',
+      }
+    ];
+    render(<VenuesTable venues={list} onEdit={vi.fn()} />);
+    
+    // Full contact venue indicators
+    expect(screen.getByTestId('venue-contact-name-full-contact')).toBeDefined();
+    expect(screen.getByTestId('venue-contact-email-full-contact')).toBeDefined();
+    expect(screen.getByTestId('venue-contact-phone-full-contact')).toBeDefined();
+    expect(screen.getByTestId('venue-lastcontacted-full-contact').textContent).toBe('2026-07-15');
+
+    // No contact venue indicators
+    expect(screen.getByTestId('venue-contact-name-missing-no-contact')).toBeDefined();
+    expect(screen.getByTestId('venue-contact-email-missing-no-contact')).toBeDefined();
+    expect(screen.getByTestId('venue-contact-phone-missing-no-contact')).toBeDefined();
+    expect(screen.getByTestId('venue-lastcontacted-no-contact').textContent).toBe('—');
+  });
+
   it('calls onEdit with the venue when Edit is clicked', () => {
     const onEdit = vi.fn();
     render(<VenuesTable venues={venues} onEdit={onEdit} />);
@@ -60,6 +90,7 @@ describe('VenuesTable', () => {
         _id: 'a', name: 'Alpha', city: 'Roanoke', usState: 'VA', venueType: 'Originals',
         bookingStatus: 'booking', outreachEligible: true, inScope: true, interested: true,
         originalsFit: 'loves', payTier: '$$', travelBand: 'local', priority: 2,
+        contactName: 'John', email: 'john@example.com', phone: '555-1234', lastContacted: '2026-07-01',
       },
       {
         _id: 'b', name: 'Beta', city: 'Salem', usState: 'NC', venueType: 'MidRangeCafeBar',
@@ -68,7 +99,7 @@ describe('VenuesTable', () => {
       },
     ];
     render(<VenuesTable venues={list} onEdit={vi.fn()} />);
-    ['city', 'state', 'type', 'inScope', 'booking', 'interested', 'eligible',
+    ['city', 'state', 'contact', 'type', 'booking', 'interested', 'eligible', 'lastContacted',
       'originals', 'pay', 'travel', 'priority', 'prospect'].forEach((key) => {
       fireEvent.click(screen.getByTestId(`sort-${key}`));
       expect(screen.getAllByTestId(/^venue-row-/)).toHaveLength(2);


### PR DESCRIPTION
## Summary
AdminVenues vetting view updates: contact info and last-pitched columns are now visible per row in the table. Dropped the In-scope column and Edit dialog checkbox/help text as Josh consolidated it with outreachEligible.

Closes #1204

## How to test locally
1. Start development server using npm run dev.
2. Navigate to /admin/venues.
3. Observe the new Contact column with presence indicators (👤/✉/☎) and hover tooltips.
4. Observe the Last pitched column showing the formatted date.
5. Edit a venue and verify that the In-scope checkbox has been removed.

## Test evidence
```
All 471 unit tests passed successfully. ESLint/Stylelint ran clean without errors.

Test Files  68 passed (68)
Tests  471 passed (471)
Duration  28.19s
```

🤖 Work by agy — Gemini 3.5 Flash
