### PR TITLE
https://web-jam.com/admin/venues more UX improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/AdminVenues/EditVenueDialog.tsx
+++ b/src/containers/AdminVenues/EditVenueDialog.tsx
@@ -136,7 +136,16 @@ export function EditVenueDialog({
   };
 
   return (
-    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+    <Dialog
+      open={open}
+      onClose={(_, reason) => {
+        if (reason !== 'backdropClick') {
+          onClose();
+        }
+      }}
+      fullWidth
+      maxWidth="sm"
+    >
       <DialogTitle data-testid="edit-venue-dialog-title">{venue ? `Edit Venue — ${venue.name}` : 'Add Venue'}</DialogTitle>
       <DialogContent>
         <TextField label="Name" fullWidth value={form.name || ''} onChange={(e) => set('name', e.target.value)}
@@ -247,7 +256,7 @@ export function EditVenueDialog({
             label="Contact verified" />
           <Help field="contactVerified" />
         </FormGroup>
-        <TextField label="Notes" fullWidth multiline rows={2} value={form.notes || ''} onChange={(e) => set('notes', e.target.value)}
+        <TextField label="Notes" fullWidth multiline rows={6} value={form.notes || ''} onChange={(e) => set('notes', e.target.value)}
           sx={{ marginTop: 2 }} data-testid="edit-venue-notes" />
         {error && <Typography color="error" sx={{ marginTop: 1 }} data-testid="edit-venue-error">{error}</Typography>}
       </DialogContent>

--- a/src/containers/AdminVenues/VenuesTable.tsx
+++ b/src/containers/AdminVenues/VenuesTable.tsx
@@ -3,6 +3,7 @@ import { useTheme } from '@mui/material/styles';
 import {
   Table, TableHead, TableBody, TableRow, TableCell, TableSortLabel, Tooltip, Button, Chip, Box, Typography,
   TextField, FormControlLabel, Switch, Select, MenuItem,
+  Dialog, DialogTitle, DialogContent, DialogActions,
 } from '@mui/material';
 import LinearProgress from '@mui/material/LinearProgress';
 import InputAdornment from '@mui/material/InputAdornment';
@@ -112,6 +113,16 @@ export function VenuesTable({
   const [rowsPerPage, setRowsPerPage] = useState(10);
   const [searchTerm, setSearchTerm] = useState('');
   const [needsVettingFilter, setNeedsVettingFilter] = useState(false);
+
+  const [copyDialogOpen, setCopyDialogOpen] = useState(false);
+  const [copyDialogTitle, setCopyDialogTitle] = useState('');
+  const [copyDialogContent, setCopyDialogContent] = useState('');
+
+  const handleOpenCopyDialog = (title: string, content: string) => {
+    setCopyDialogTitle(title);
+    setCopyDialogContent(content);
+    setCopyDialogOpen(true);
+  };
 
   // Un-vetted definition: no venueType set OR contactVerified is falsy.
   // This is Josh's vetting work queue.
@@ -597,7 +608,8 @@ export function VenuesTable({
                             <Typography
                               component="span"
                               data-testid={`venue-contact-name-${v._id}`}
-                              sx={{ fontSize: '1.1rem', cursor: 'help', color: 'primary.main' }}
+                              onClick={() => handleOpenCopyDialog('Contact Name', v.contactName!)}
+                              sx={{ fontSize: '1.1rem', cursor: 'pointer', color: 'primary.main' }}
                             >
                               👤
                             </Typography>
@@ -616,11 +628,12 @@ export function VenuesTable({
                         {v.email ? (
                           <Tooltip title={`Email: ${v.email}`} arrow>
                             <Box
-                              component="a"
-                              href={`mailto:${v.email}`}
+                              component="span"
+                              onClick={() => handleOpenCopyDialog('Email Address', v.email!)}
                               data-testid={`venue-contact-email-${v._id}`}
                               sx={{
                                 fontSize: '1.1rem',
+                                cursor: 'pointer',
                                 textDecoration: 'none',
                                 color: 'info.main',
                                 display: 'inline-flex',
@@ -644,11 +657,12 @@ export function VenuesTable({
                         {v.phone ? (
                           <Tooltip title={`Phone: ${v.phone}`} arrow>
                             <Box
-                              component="a"
-                              href={`tel:${v.phone}`}
+                              component="span"
+                              onClick={() => handleOpenCopyDialog('Phone Number', v.phone!)}
                               data-testid={`venue-contact-phone-${v._id}`}
                               sx={{
                                 fontSize: '1.1rem',
+                                cursor: 'pointer',
                                 textDecoration: 'none',
                                 color: 'success.main',
                                 display: 'inline-flex',
@@ -665,6 +679,35 @@ export function VenuesTable({
                             sx={{ fontSize: '1.1rem', opacity: 0.2, color: 'text.secondary', userSelect: 'none' }}
                           >
                             ☎
+                          </Typography>
+                        )}
+
+                        {/* Notes */}
+                        {v.notes ? (
+                          <Tooltip title={`Notes: ${v.notes}`} arrow>
+                            <Box
+                              component="span"
+                              onClick={() => handleOpenCopyDialog('Venue Notes', v.notes!)}
+                              data-testid={`venue-contact-notes-${v._id}`}
+                              sx={{
+                                fontSize: '1.1rem',
+                                cursor: 'pointer',
+                                textDecoration: 'none',
+                                color: 'warning.main',
+                                display: 'inline-flex',
+                                '&:hover': { opacity: 0.8 },
+                              }}
+                            >
+                              📝
+                            </Box>
+                          </Tooltip>
+                        ) : (
+                          <Typography
+                            component="span"
+                            data-testid={`venue-contact-notes-missing-${v._id}`}
+                            sx={{ fontSize: '1.1rem', opacity: 0.2, color: 'text.secondary', userSelect: 'none' }}
+                          >
+                            📝
                           </Typography>
                         )}
                       </Box>
@@ -736,6 +779,63 @@ export function VenuesTable({
           </Button>
         </Box>
       </Box>
+
+      <CopyDialog
+        open={copyDialogOpen}
+        title={copyDialogTitle}
+        content={copyDialogContent}
+        onClose={() => setCopyDialogOpen(false)}
+      />
     </Box>
+  );
+}
+
+interface IcopyDialogProps {
+  open: boolean;
+  title: string;
+  content: string;
+  onClose: () => void;
+}
+
+function CopyDialog({ open, title, content, onClose }: IcopyDialogProps) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setCopied(false);
+    }
+  }, [open]);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(content);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy text: ', err);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs" data-testid="copy-dialog">
+      <DialogTitle data-testid="copy-dialog-title">{title}</DialogTitle>
+      <DialogContent>
+        <TextField
+          fullWidth
+          multiline
+          maxRows={8}
+          value={content}
+          slotProps={{ input: { readOnly: true } }}
+          sx={{ marginTop: 1, backgroundColor: 'action.hover' }}
+          data-testid="copy-dialog-content"
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} data-testid="copy-dialog-close">Close</Button>
+        <Button onClick={handleCopy} variant="contained" color="primary" data-testid="copy-dialog-copy">
+          {copied ? 'Copied!' : 'Copy'}
+        </Button>
+      </DialogActions>
+    </Dialog>
   );
 }

--- a/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
+++ b/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
@@ -136,7 +136,7 @@ exports[`AppTemplate > renders the component 1`] = `
             <strong>
               Version
                
-              2.12.0
+              2.12.1
             </strong>
           </div>
           <p

--- a/test/containers/AdminVenues/EditVenueDialog.spec.tsx
+++ b/test/containers/AdminVenues/EditVenueDialog.spec.tsx
@@ -106,6 +106,16 @@ describe('EditVenueDialog', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
+  it('does not call onClose on backdrop click', async () => {
+    const onClose = vi.fn();
+    const { container } = render(<EditVenueDialog open venue={venue} token="tk" onClose={onClose} onSaved={vi.fn()} />);
+    const backdrop = container.querySelector('.MuiBackdrop-root');
+    if (backdrop) {
+      await act(async () => { fireEvent.click(backdrop); });
+      expect(onClose).not.toHaveBeenCalled();
+    }
+  });
+
   it('creates a new venue when venue is null', async () => {
     adminVenuesUtils.createVenue = vi.fn(() => Promise.resolve({} as Ivenue)) as any;
     const onSaved = vi.fn();

--- a/test/containers/AdminVenues/VenuesTable.spec.tsx
+++ b/test/containers/AdminVenues/VenuesTable.spec.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import { VenuesTable } from 'src/containers/AdminVenues/VenuesTable';
 import { type Ivenue } from 'src/containers/AdminVenues/admin-venues.utils';
@@ -33,6 +34,7 @@ describe('VenuesTable', () => {
         contactName: 'Alice',
         email: 'alice@example.com',
         phone: '123-456-7890',
+        notes: 'Alice notes',
         lastContacted: '2026-07-15T12:00:00.000Z',
       },
       {
@@ -46,12 +48,14 @@ describe('VenuesTable', () => {
     expect(screen.getByTestId('venue-contact-name-full-contact')).toBeDefined();
     expect(screen.getByTestId('venue-contact-email-full-contact')).toBeDefined();
     expect(screen.getByTestId('venue-contact-phone-full-contact')).toBeDefined();
+    expect(screen.getByTestId('venue-contact-notes-full-contact')).toBeDefined();
     expect(screen.getByTestId('venue-lastcontacted-full-contact').textContent).toBe('2026-07-15');
 
     // No contact venue indicators
     expect(screen.getByTestId('venue-contact-name-missing-no-contact')).toBeDefined();
     expect(screen.getByTestId('venue-contact-email-missing-no-contact')).toBeDefined();
     expect(screen.getByTestId('venue-contact-phone-missing-no-contact')).toBeDefined();
+    expect(screen.getByTestId('venue-contact-notes-missing-no-contact')).toBeDefined();
     expect(screen.getByTestId('venue-lastcontacted-no-contact').textContent).toBe('—');
   });
 
@@ -242,6 +246,46 @@ describe('VenuesTable', () => {
     expect(screen.getByTestId('venue-row-std')).toBeDefined();
     expect(screen.getByTestId('venue-row-nt')).toBeDefined();
     expect(screen.getByTestId('venue-row-arc')).toBeDefined();
+  });
+
+  it('opens CopyDialog when clicking contact icons and copies to clipboard', async () => {
+    const list: Ivenue[] = [
+      {
+        _id: 'v-contact',
+        name: 'Contact Venue',
+        contactName: 'Alice',
+        email: 'alice@example.com',
+        phone: '123-456-7890',
+        notes: 'These are some venue notes.',
+      },
+    ];
+
+    const writeTextMock = vi.fn(() => Promise.resolve());
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: writeTextMock,
+      },
+    });
+
+    render(<VenuesTable venues={list} onEdit={vi.fn()} />);
+
+    // Click Notes icon
+    fireEvent.click(screen.getByTestId('venue-contact-notes-v-contact'));
+
+    // Check Dialog opens
+    expect(screen.getByTestId('copy-dialog')).toBeDefined();
+    expect(screen.getByTestId('copy-dialog-title').textContent).toBe('Venue Notes');
+    expect(screen.getByTestId('copy-dialog-content')).toHaveValue('These are some venue notes.');
+
+    // Click Copy button
+    fireEvent.click(screen.getByTestId('copy-dialog-copy'));
+    expect(writeTextMock).toHaveBeenCalledWith('These are some venue notes.');
+
+    // Wait for copied text state
+    expect(await screen.findByText('Copied!')).toBeDefined();
+
+    // Click Close button
+    fireEvent.click(screen.getByTestId('copy-dialog-close'));
   });
 });
 


### PR DESCRIPTION
## Summary
This PR delivers substantial UX improvements to the Admin Venues screen: 1) Prevents edit venue form from closing on backdrop click; 2) Expands notes textfield to 6 rows on the edit form; 3) Adds a Notes icon (📝) to the Venues table Contact column; 4) Shows an interactive copy dialog when clicking Name, Email, Phone, or Notes icons to copy easily.

Closes #1211

## How to test locally
Verify backdrop click does not trigger onClose; verify notes rows=6; verify contact column has notes icon; verify clicking icons opens CopyDialog and copies to clipboard successfully.

## Test evidence
```
All unit tests, lints, and typechecks passed successfully (including updated snapshot and new unit tests for backdrop-click prevention and CopyDialog behavior).
```

🤖 Work by Antigravity — Gemini 1.5 Pro