### PR TITLE
fix(ci): update AppTemplate snapshot for 2.12.3 bump + AGENTS.md snapshot rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ from a `<lane>/<issue#>-<slug>` branch.
 - **Test evidence**: paste the REAL runner output verbatim (the lines showing pass/fail and test counts), inside a ``` fence — never a description like "all tests passed". If the output has scrolled out of view, re-run the test command and paste what it prints.
 - **Test plan**: exact commands and manual steps that exercise the change (start command, route/page, what to click, expected visible result) — a green test suite alone is not a plan.
 - **Attribution**: `--author` names the model actually doing the work. Antigravity/agy sessions are ALWAYS `Antigravity — Gemini 3.5 Flash (Medium)` or `(High)` — never write any other Gemini model name (models misremember their own identity; use this exact string).
+- **Version bump ⇒ snapshot update**: the AppTemplate footer renders the package.json version into a snapshot, so after bumping the version run `npm run test:unit-u` (never bare `vitest -u` — the script sets TZ=UTC) and commit the updated snapshot in the same PR.
 
 ## Troubleshooting & Guardrails
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.12.2",
+  "version": "2.12.3",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
+++ b/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
@@ -136,7 +136,7 @@ exports[`AppTemplate > renders the component 1`] = `
             <strong>
               Version
                
-              2.12.1
+              2.12.3
             </strong>
           </div>
           <p


### PR DESCRIPTION
## Summary
- Update AppTemplate snapshot for the 2.12.3 version bump (dev CI was red: #1214 bumped to 2.12.2 without regenerating the version-bearing snapshot)
- Add AGENTS.md rule: version bump requires `npm run test:unit-u` snapshot regeneration in the same PR
- Patch version bump

## How to test locally
Run:
```sh
npm test
```
Expect: all suites green including test/App/AppTemplate/index.spec.tsx. CI on this PR must be green — that IS the change being verified.

## Test evidence
```
Test Files  68 passed (68)
      Tests  487 passed (487)
   Start at  22:10:58
   Duration  29.07s (transform 3.66s, setup 4.77s, import 104.52s, tests 51.07s, environment 81.57s)
```

🤖 Work by Claude Code — Haiku 4.5