### PR TITLE
Venue dates are incorrect please fix - suggest the proper fix first before code-work (wait for my approval)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/AdminVenues/VenuesTable.tsx
+++ b/src/containers/AdminVenues/VenuesTable.tsx
@@ -8,6 +8,7 @@ import {
 import LinearProgress from '@mui/material/LinearProgress';
 import InputAdornment from '@mui/material/InputAdornment';
 import { Search } from '@mui/icons-material';
+import { formatVenueDateYMD } from 'src/lib/venueTimezone';
 import {
   FIELD_HELP, prospectScore, type Ivenue,
 } from './admin-venues.utils';
@@ -55,12 +56,13 @@ function formatLastContacted(lc?: string): string {
   return lc;
 }
 
-// Format a gig's datetime to YYYY-MM-DD
-function formatGigDate(gig?: { datetime?: string | Date } | null): string {
+// Format a gig's datetime to YYYY-MM-DD in the venue's local timezone (#1222):
+// resolves the gig's own usState first, falling back to the venue's usState,
+// then the browser's local zone. Splitting the raw ISO string (the old
+// behavior) showed the UTC date, which is off by one for evening gigs.
+function formatGigDate(gig?: { datetime?: string | Date; usState?: string } | null, venueUsState?: string): string {
   if (!gig || !gig.datetime) return '—';
-  const dt = typeof gig.datetime === 'string' ? gig.datetime : gig.datetime.toISOString();
-  if (dt.includes('T')) return dt.split('T')[0];
-  return dt;
+  return formatVenueDateYMD(gig.datetime, gig.usState, venueUsState);
 }
 
 // The value a column sorts by. Booleans become 1/0 so yes sorts above no;
@@ -753,8 +755,8 @@ export function VenuesTable({
                     <TableCell>{yn(v.interested !== false)}</TableCell>
                     <TableCell data-testid={`venue-eligible-${v._id}`}>{yn(v.outreachEligible)}</TableCell>
                     <TableCell data-testid={`venue-lastcontacted-${v._id}`}>{formatLastContacted(v.lastContacted)}</TableCell>
-                    <TableCell data-testid={`venue-lastgig-${v._id}`}>{formatGigDate(v.lastGig)}</TableCell>
-                    <TableCell data-testid={`venue-nextgig-${v._id}`}>{formatGigDate(v.nextGig)}</TableCell>
+                    <TableCell data-testid={`venue-lastgig-${v._id}`}>{formatGigDate(v.lastGig, v.usState)}</TableCell>
+                    <TableCell data-testid={`venue-nextgig-${v._id}`}>{formatGigDate(v.nextGig, v.usState)}</TableCell>
                     <TableCell>{dash(v.originalsFit)}</TableCell>
                     <TableCell>{dash(v.payTier)}</TableCell>
                     <TableCell>{dash(v.travelBand)}</TableCell>

--- a/src/containers/Music/Gigs/gigs.utils.tsx
+++ b/src/containers/Music/Gigs/gigs.utils.tsx
@@ -2,6 +2,7 @@ import type { GridColDef, GridRenderCellParams, GridRowParams } from '@mui/x-dat
 import HtmlReactParser from 'html-react-parser';
 import scc from 'socketcluster-client';
 import commonUtils from 'src/lib/utils';
+import { formatInVenueTimeZone } from 'src/lib/venueTimezone';
 import type { Iauth } from 'src/providers/Auth.provider';
 import type { Igig } from 'src/providers/Data.provider';
 import { defaultGig } from 'src/providers/fetchGigs';
@@ -142,28 +143,35 @@ export const orderGigs = (
   setPageSize(10);
 };
 
-const makeDateValue = (datetime: string) => {
-  return new Date(datetime).toLocaleString('en-US', {
-    weekday: 'long',
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
-};
+// Rendered in the gig's venue timezone (#1222) rather than the viewer's
+// browser timezone, via the shared `formatInVenueTimeZone` (falls back to the
+// browser's local zone when the gig has no usState — the prior behavior).
+const makeDateValue = (datetime: string, usState?: string) => formatInVenueTimeZone(datetime, {
+  weekday: 'long',
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+}, usState);
 
-const makeShortDateValue = (datetime: string) => new Date(datetime)
-  .toLocaleString('en-US', { year: '2-digit', month: 'numeric', day: 'numeric' });
+const makeShortDateValue = (datetime: string, usState?: string) => formatInVenueTimeZone(
+  datetime,
+  { year: '2-digit', month: 'numeric', day: 'numeric' },
+  usState,
+);
 
-const makeTimeValue = (datetime: string) => new Date(datetime)
-  .toLocaleString('en-US', { hour: 'numeric', minute: '2-digit' });
+const makeTimeValue = (datetime: string, usState?: string) => formatInVenueTimeZone(
+  datetime,
+  { hour: 'numeric', minute: '2-digit' },
+  usState,
+);
 
 // With a duration (hours) the Time column becomes a range "8:00 AM to 5:00 PM";
 // with no duration it stays the start time alone.
-const makeTimeRange = (datetime: string, duration?: number) => {
-  const start = makeTimeValue(datetime);
+const makeTimeRange = (datetime: string, duration?: number, usState?: string) => {
+  const start = makeTimeValue(datetime, usState);
   if (!duration || duration <= 0) return start;
   const end = new Date(new Date(datetime).getTime() + duration * 60 * 60 * 1000);
-  return `${start} to ${makeTimeValue(end.toISOString())}`;
+  return `${start} to ${makeTimeValue(end.toISOString(), usState)}`;
 };
 
 const makeVenueValue = (value: string) => {

--- a/src/containers/Music/Gigs/index.tsx
+++ b/src/containers/Music/Gigs/index.tsx
@@ -23,9 +23,9 @@ export const makeColumns = (isMobile = false): GridColDef[] => {
     width: isMobile ? 110 : 220,
     editable: false,
     renderCell: (params: GridRenderCellParams) => {
-      const { row: { datetime } } = params;
+      const { row: { datetime, usState } } = params;
       if (!datetime) return '';
-      return isMobile ? utils.makeShortDateValue(datetime) : utils.makeDateValue(datetime);
+      return isMobile ? utils.makeShortDateValue(datetime, usState) : utils.makeDateValue(datetime, usState);
     },
   };
   const timeCol: GridColDef = {
@@ -34,9 +34,9 @@ export const makeColumns = (isMobile = false): GridColDef[] => {
     width: isMobile ? 140 : 170,
     editable: false,
     renderCell: (params: GridRenderCellParams) => {
-      const { row: { datetime, duration } } = params;
+      const { row: { datetime, duration, usState } } = params;
       if (!datetime) return '';
-      return utils.makeTimeRange(datetime, duration);
+      return utils.makeTimeRange(datetime, duration, usState);
     },
   };
   const locationCol: GridColDef = {

--- a/src/lib/venueTimezone.ts
+++ b/src/lib/venueTimezone.ts
@@ -1,0 +1,202 @@
+// Shared venue-timezone date formatting (#1222).
+//
+// Gig `datetime` is stored as a UTC instant. Formatting it against the
+// *browser's* local timezone (the old behavior) or by naively slicing the
+// ISO string (also the old behavior) both render the wrong calendar date
+// whenever the gig's venue isn't in the same zone as whoever's looking —
+// e.g. an Eastern-evening gig stored as `...T00:00Z` the next day. The fix:
+// resolve the venue's US state to an IANA timezone and format through
+// `Intl` (DST-aware for free), falling back to the browser's local zone
+// when no state is known.
+
+// Dominant IANA timezone per US state/territory (matches the full-name list
+// used by src/containers/Music/Gigs/gigs.utils.tsx `usStateOptions`). Split-
+// timezone states use their most-populous zone (e.g. Tennessee -> Chicago,
+// Michigan -> Detroit/Eastern).
+export const US_STATE_TIMEZONES: Record<string, string> = {
+  Alabama: 'America/Chicago',
+  Alaska: 'America/Anchorage',
+  'American Samoa': 'Pacific/Pago_Pago',
+  Arizona: 'America/Phoenix',
+  Arkansas: 'America/Chicago',
+  California: 'America/Los_Angeles',
+  Colorado: 'America/Denver',
+  Connecticut: 'America/New_York',
+  Delaware: 'America/New_York',
+  'District of Columbia': 'America/New_York',
+  'Federated States of Micronesia': 'Pacific/Pohnpei',
+  Florida: 'America/New_York',
+  Georgia: 'America/New_York',
+  Guam: 'Pacific/Guam',
+  Hawaii: 'Pacific/Honolulu',
+  Idaho: 'America/Boise',
+  Illinois: 'America/Chicago',
+  Indiana: 'America/Indiana/Indianapolis',
+  Iowa: 'America/Chicago',
+  Kansas: 'America/Chicago',
+  Kentucky: 'America/New_York',
+  Louisiana: 'America/Chicago',
+  Maine: 'America/New_York',
+  'Marshall Islands': 'Pacific/Majuro',
+  Maryland: 'America/New_York',
+  Massachusetts: 'America/New_York',
+  Michigan: 'America/Detroit',
+  Minnesota: 'America/Chicago',
+  Mississippi: 'America/Chicago',
+  Missouri: 'America/Chicago',
+  Montana: 'America/Denver',
+  Nebraska: 'America/Chicago',
+  Nevada: 'America/Los_Angeles',
+  'New Hampshire': 'America/New_York',
+  'New Jersey': 'America/New_York',
+  'New Mexico': 'America/Denver',
+  'New York': 'America/New_York',
+  'North Carolina': 'America/New_York',
+  'North Dakota': 'America/Chicago',
+  'Northern Mariana Islands': 'Pacific/Saipan',
+  Ohio: 'America/New_York',
+  Oklahoma: 'America/Chicago',
+  Oregon: 'America/Los_Angeles',
+  Palau: 'Pacific/Palau',
+  Pennsylvania: 'America/New_York',
+  'Puerto Rico': 'America/Puerto_Rico',
+  'Rhode Island': 'America/New_York',
+  'South Carolina': 'America/New_York',
+  'South Dakota': 'America/Chicago',
+  Tennessee: 'America/Chicago',
+  Texas: 'America/Chicago',
+  Utah: 'America/Denver',
+  Vermont: 'America/New_York',
+  'Virgin Island': 'America/St_Thomas',
+  Virginia: 'America/New_York',
+  Washington: 'America/Los_Angeles',
+  'West Virginia': 'America/New_York',
+  Wisconsin: 'America/Chicago',
+  Wyoming: 'America/Denver',
+};
+
+// Two-letter postal codes -> full state name, so callers that store the
+// abbreviated form (e.g. the Venues admin UI: usState: 'NC') resolve too.
+const US_STATE_ABBR_TO_NAME: Record<string, string> = {
+  AL: 'Alabama',
+  AK: 'Alaska',
+  AS: 'American Samoa',
+  AZ: 'Arizona',
+  AR: 'Arkansas',
+  CA: 'California',
+  CO: 'Colorado',
+  CT: 'Connecticut',
+  DE: 'Delaware',
+  DC: 'District of Columbia',
+  FM: 'Federated States of Micronesia',
+  FL: 'Florida',
+  GA: 'Georgia',
+  GU: 'Guam',
+  HI: 'Hawaii',
+  ID: 'Idaho',
+  IL: 'Illinois',
+  IN: 'Indiana',
+  IA: 'Iowa',
+  KS: 'Kansas',
+  KY: 'Kentucky',
+  LA: 'Louisiana',
+  ME: 'Maine',
+  MH: 'Marshall Islands',
+  MD: 'Maryland',
+  MA: 'Massachusetts',
+  MI: 'Michigan',
+  MN: 'Minnesota',
+  MS: 'Mississippi',
+  MO: 'Missouri',
+  MT: 'Montana',
+  NE: 'Nebraska',
+  NV: 'Nevada',
+  NH: 'New Hampshire',
+  NJ: 'New Jersey',
+  NM: 'New Mexico',
+  NY: 'New York',
+  NC: 'North Carolina',
+  ND: 'North Dakota',
+  MP: 'Northern Mariana Islands',
+  OH: 'Ohio',
+  OK: 'Oklahoma',
+  OR: 'Oregon',
+  PW: 'Palau',
+  PA: 'Pennsylvania',
+  PR: 'Puerto Rico',
+  RI: 'Rhode Island',
+  SC: 'South Carolina',
+  SD: 'South Dakota',
+  TN: 'Tennessee',
+  TX: 'Texas',
+  UT: 'Utah',
+  VT: 'Vermont',
+  VI: 'Virgin Island',
+  VA: 'Virginia',
+  WA: 'Washington',
+  WV: 'West Virginia',
+  WI: 'Wisconsin',
+  WY: 'Wyoming',
+};
+
+const US_STATE_TIMEZONES_LOWER: Record<string, string> = Object.fromEntries(
+  Object.entries(US_STATE_TIMEZONES).map(([name, tz]) => [name.toLowerCase(), tz]),
+);
+
+// Resolve a single `usState` value (full name like "Virginia" or 2-letter
+// postal code like "VA") to its IANA timezone. Returns undefined when
+// `usState` is missing/blank/unrecognized.
+export function resolveStateTimeZone(usState?: string): string | undefined {
+  if (!usState) return undefined;
+  const trimmed = usState.trim();
+  if (!trimmed) return undefined;
+  if (trimmed.length === 2) {
+    const fullName = US_STATE_ABBR_TO_NAME[trimmed.toUpperCase()];
+    if (fullName) return US_STATE_TIMEZONES[fullName];
+  }
+  return US_STATE_TIMEZONES_LOWER[trimmed.toLowerCase()];
+}
+
+// Fallback chain (#1222 approved design): the gig's own usState, else the
+// venue's usState, else undefined (caller omits `timeZone` and Intl falls
+// back to the browser's local zone — the pre-fix Gigs UI behavior).
+export function resolveVenueTimeZone(gigUsState?: string, venueUsState?: string): string | undefined {
+  return resolveStateTimeZone(gigUsState) || resolveStateTimeZone(venueUsState);
+}
+
+// General-purpose formatter: same as `new Date(dt).toLocaleString('en-US', options)`,
+// but resolved to the venue's timezone when known. Used by the Gigs UI so gig
+// date/time render in the venue's local time instead of the viewer's browser zone.
+export function formatInVenueTimeZone(
+  datetime: string | Date,
+  options: Intl.DateTimeFormatOptions,
+  gigUsState?: string,
+  venueUsState?: string,
+): string {
+  const dt = typeof datetime === 'string' ? new Date(datetime) : datetime;
+  const timeZone = resolveVenueTimeZone(gigUsState, venueUsState);
+  return dt.toLocaleString('en-US', timeZone ? { ...options, timeZone } : options);
+}
+
+// YYYY-MM-DD formatter (the Venues admin table's display format) — 'en-CA'
+// locale formats dates as YYYY-MM-DD by default, so this stays Intl-only.
+export function formatVenueDateYMD(
+  datetime: string | Date,
+  gigUsState?: string,
+  venueUsState?: string,
+): string {
+  const dt = typeof datetime === 'string' ? new Date(datetime) : datetime;
+  const timeZone = resolveVenueTimeZone(gigUsState, venueUsState);
+  const options: Intl.DateTimeFormatOptions = timeZone
+    ? { year: 'numeric', month: '2-digit', day: '2-digit', timeZone }
+    : { year: 'numeric', month: '2-digit', day: '2-digit' };
+  return dt.toLocaleDateString('en-CA', options);
+}
+
+export default {
+  US_STATE_TIMEZONES,
+  resolveStateTimeZone,
+  resolveVenueTimeZone,
+  formatInVenueTimeZone,
+  formatVenueDateYMD,
+};

--- a/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
+++ b/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
@@ -136,7 +136,7 @@ exports[`AppTemplate > renders the component 1`] = `
             <strong>
               Version
                
-              2.14.0
+              2.14.1
             </strong>
           </div>
           <p

--- a/test/lib/venueTimezone.spec.tsx
+++ b/test/lib/venueTimezone.spec.tsx
@@ -1,0 +1,78 @@
+import {
+  formatInVenueTimeZone, formatVenueDateYMD, resolveStateTimeZone, resolveVenueTimeZone,
+} from 'src/lib/venueTimezone';
+
+describe('venueTimezone', () => {
+  describe('resolveStateTimeZone', () => {
+    it('resolves a full state name', () => {
+      expect(resolveStateTimeZone('California')).toBe('America/Los_Angeles');
+    });
+    it('resolves a full state name case-insensitively', () => {
+      expect(resolveStateTimeZone('virginia')).toBe('America/New_York');
+    });
+    it('resolves a 2-letter postal code', () => {
+      expect(resolveStateTimeZone('NC')).toBe('America/New_York');
+    });
+    it('resolves a lowercase 2-letter postal code', () => {
+      expect(resolveStateTimeZone('tn')).toBe('America/Chicago');
+    });
+    it('returns undefined for missing/blank/unknown input', () => {
+      expect(resolveStateTimeZone(undefined)).toBeUndefined();
+      expect(resolveStateTimeZone('')).toBeUndefined();
+      expect(resolveStateTimeZone('  ')).toBeUndefined();
+      expect(resolveStateTimeZone('Narnia')).toBeUndefined();
+    });
+  });
+
+  describe('resolveVenueTimeZone', () => {
+    it('prefers the gig usState over the venue usState', () => {
+      expect(resolveVenueTimeZone('CA', 'NC')).toBe('America/Los_Angeles');
+    });
+    it('falls back to the venue usState when the gig has none', () => {
+      expect(resolveVenueTimeZone(undefined, 'NC')).toBe('America/New_York');
+    });
+    it('returns undefined when neither is known', () => {
+      expect(resolveVenueTimeZone(undefined, undefined)).toBeUndefined();
+    });
+  });
+
+  describe('formatVenueDateYMD', () => {
+    // Regression case (#1222): Dirty Bull's gig is stored as a UTC instant
+    // that rolls to the next UTC day for an Eastern-evening show. Slicing
+    // the raw ISO string (the old behavior) showed 11-15; venue-local
+    // (NC -> America/New_York) must show 11-14.
+    it('shows the venue-local date for a UTC instant that crosses midnight UTC', () => {
+      expect(formatVenueDateYMD('2026-11-15T00:00:00Z', undefined, 'NC')).toBe('2026-11-14');
+    });
+    it('prefers the gig usState over the venue usState', () => {
+      expect(formatVenueDateYMD('2026-11-15T00:00:00Z', 'CA', 'NC')).toBe('2026-11-14');
+    });
+    it('accepts a Date instance', () => {
+      expect(formatVenueDateYMD(new Date('2026-11-15T00:00:00Z'), undefined, 'NC')).toBe('2026-11-14');
+    });
+    it('falls back to the browser/test-runner local zone (UTC) when no usState is known', () => {
+      expect(formatVenueDateYMD('2026-07-01T19:00:00.000Z')).toBe('2026-07-01');
+    });
+  });
+
+  describe('formatInVenueTimeZone', () => {
+    it('formats using venue-local time with arbitrary Intl options', () => {
+      const result = formatInVenueTimeZone('2026-11-15T00:00:00Z', {
+        weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+      }, undefined, 'NC');
+      expect(result).toBe('Saturday, November 14, 2026');
+    });
+    it('formats time-of-day in venue-local time', () => {
+      const result = formatInVenueTimeZone('2026-11-15T00:00:00Z', {
+        hour: 'numeric', minute: '2-digit',
+      }, undefined, 'NC');
+      expect(result).toBe('7:00 PM');
+    });
+    it('falls back to the runner local zone (UTC) with no usState', () => {
+      const result = formatInVenueTimeZone('2026-11-15T00:00:00Z', {
+        hour: 'numeric', minute: '2-digit',
+      });
+      expect(result).toBe('12:00 AM');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add shared `src/lib/venueTimezone.ts` util: a US-state -> IANA timezone lookup (all 50 states + DC/territories, dominant zone for split states e.g. TN -> `America/Chicago`) plus `Intl`-based formatting helpers (`formatInVenueTimeZone`, `formatVenueDateYMD`) — zero new packages, DST-aware for free
- Fix `VenuesTable.tsx`'s `formatGigDate` to format the Last/Next Gig columns in venue-local time instead of slicing the raw UTC ISO string — fixes Dirty Bull showing 11-15 instead of 11-14
- Switch `gigs.utils.tsx`'s `makeDateValue`/`makeShortDateValue`/`makeTimeValue`/`makeTimeRange` to format in the gig's venue timezone (via the shared util) instead of the viewer's browser timezone; same output formats, only the timezone source changed
- Pass each row's `usState` through in `Gigs/index.tsx`'s date/time column renderers
- Timezone resolution fallback chain: gig's `usState` -> venue's `usState` -> browser's local timezone (unchanged prior behavior)
- Add `test/lib/venueTimezone.spec.tsx` covering the lookup, fallback chain, and the regression case (a UTC instant crossing midnight UTC formats as the prior Eastern calendar day)
- Bump `package.json` version 2.14.0 -> 2.14.1 (patch) and regenerate the AppTemplate footer snapshot

Closes #1222

## How to test locally
Run the full gate:
```sh
npm test
```
Expect: 69 test files / 503 tests passing, coverage 90.52/80.65/87.6/92.14 (gate 90/80/80/90 stmts/branches/funcs/lines), 0 lint errors.

Manual verification (exercises the actual fix):
1. `npm run dev` (HTTPS Vite dev server)
2. Log in as admin, open the Venues admin route (Admin -> Venues, i.e. `/adminvenues`) and find the venue 'Dirty Bull' (or any venue with a lastGig/nextGig stored as a UTC evening-gig instant, e.g. `2026-11-15T00:00:00Z` with `usState: NC`)
3. Expect: the Last Gig / Next Gig columns show `2026-11-14` (venue-local Eastern date), not `2026-11-15` (the old UTC-sliced date)
4. Open the Gigs page (`/music/gigs`) for the same gig
5. Expect: the Date column shows 'Saturday, November 14, 2026' (or the short-date/mobile equivalent `11/14/26`) and the Time column shows '7:00 PM' — venue-local time, matching the Venues page date, not the browser's local timezone

## Test evidence
```
> jammusic@2.14.1 test:lint
✖ 844 problems (0 errors, 844 warnings)

> jammusic@2.14.1 typecheck
> tsc --noEmit
(clean, no output)

> jammusic@2.14.1 test:unit
> TZ=UTC vitest run --coverage

 Test Files  69 passed (69)
      Tests  503 passed (503)

=============================== Coverage summary ===============================
Statements   : 90.52% ( 2418/2671 )
Branches     : 80.65% ( 1380/1711 )
Functions    : 87.6% ( 622/710 )
Lines        : 92.14% ( 2159/2343 )
================================================================================

New util file coverage:
  venueTimezone.ts | 100 | 88.88 | 100 | 100
```

🤖 Work by Claude Code — Sonnet 5