### PR TITLE
AdminOutreach page layout broken: footer overlaps Batch Outreach section

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.14.1",
+  "version": "2.14.2",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/AdminOutreach/index.tsx
+++ b/src/containers/AdminOutreach/index.tsx
@@ -447,10 +447,14 @@ export function AdminOutreach() {
 
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns}>
-      <Box sx={{
-        padding: { xs: 2, sm: 4 }, maxWidth: 1200, margin: 'auto', width: '100%', minWidth: 0,
-        backgroundColor: 'background.default', minHeight: '100vh',
-      }} data-testid="admin-outreach-page">
+      <Box
+        className="page-content"
+        sx={{
+          padding: { xs: 2, sm: 4 }, maxWidth: 1200, margin: 'auto', width: '100%', minWidth: 0,
+          backgroundColor: 'background.default',
+        }}
+        data-testid="admin-outreach-page"
+      >
 
         {/* Pinned Search and Dashboard Header */}
         <Paper elevation={3} sx={{

--- a/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
+++ b/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
@@ -136,7 +136,7 @@ exports[`AppTemplate > renders the component 1`] = `
             <strong>
               Version
                
-              2.14.1
+              2.14.2
             </strong>
           </div>
           <p


### PR DESCRIPTION
## Summary
### Summary

Closes #1226

* Fixed a major layout bug on the Admin Outreach Workspace page where the site footer floated/overlapped on top of the Batch Outreach section.
* Resolved by adding the standard `page-content` class to the outermost `Box` wrapper of the `AdminOutreach` component, ensuring it integrates correctly with the parent flex layout in `MainPanel`.
* Removed the inline `minHeight: '100vh'` from the outer `Box` container to prevent unnecessary viewport stretching and allow standard flexbox flow.
* Bumped package.json version to 2.14.2 (patch bump) as required by project conventions.

Closes #1226

## How to test locally
### Test Plan

1. Run the local linter to ensure styles and typescript are conforming to conventions:
   * Command: `npm run test:lint`
   * Expected Result: Linter runs successfully with no errors.
2. Run vitest unit tests:
   * Command: `npm run test:unit`
   * Expected Result: 503 tests in 69 files pass successfully.
3. Verify that the updated snapshot matches the new package version:
   * Command: `npm run test:unit-u` to update the snapshots, then verify unit tests pass.

## Test evidence
### Test Evidence

* Linter passed successfully:
```
✖ 844 problems (0 errors, 844 warnings)
```

* Snapshot updated and all unit tests passed successfully:
```
Test Files  69 passed (69)
     Tests  503 passed (503)
  Snapshots  1 updated
```

🤖 Work by agy — Gemini 3.5 Flash (Medium)