### PR TITLE
AdminVenues form: validated state ("North Carolina (NC)") + country dropdowns, website URL field; clickable website in table

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/AdminVenues/EditVenueDialog.tsx
+++ b/src/containers/AdminVenues/EditVenueDialog.tsx
@@ -8,6 +8,93 @@ import adminVenuesUtils, {
   type Ivenue, type IvenueUpdate,
 } from './admin-venues.utils';
 
+export const US_STATES = [
+  { code: 'AL', name: 'Alabama' },
+  { code: 'AK', name: 'Alaska' },
+  { code: 'AS', name: 'American Samoa' },
+  { code: 'AZ', name: 'Arizona' },
+  { code: 'AR', name: 'Arkansas' },
+  { code: 'CA', name: 'California' },
+  { code: 'CO', name: 'Colorado' },
+  { code: 'CT', name: 'Connecticut' },
+  { code: 'DE', name: 'Delaware' },
+  { code: 'DC', name: 'District of Columbia' },
+  { code: 'FM', name: 'Federated States of Micronesia' },
+  { code: 'FL', name: 'Florida' },
+  { code: 'GA', name: 'Georgia' },
+  { code: 'GU', name: 'Guam' },
+  { code: 'HI', name: 'Hawaii' },
+  { code: 'ID', name: 'Idaho' },
+  { code: 'IL', name: 'Illinois' },
+  { code: 'IN', name: 'Indiana' },
+  { code: 'IA', name: 'Iowa' },
+  { code: 'KS', name: 'Kansas' },
+  { code: 'KY', name: 'Kentucky' },
+  { code: 'LA', name: 'Louisiana' },
+  { code: 'ME', name: 'Maine' },
+  { code: 'MH', name: 'Marshall Islands' },
+  { code: 'MD', name: 'Maryland' },
+  { code: 'MA', name: 'Massachusetts' },
+  { code: 'MI', name: 'Michigan' },
+  { code: 'MN', name: 'Minnesota' },
+  { code: 'MS', name: 'Mississippi' },
+  { code: 'MO', name: 'Missouri' },
+  { code: 'MT', name: 'Montana' },
+  { code: 'NE', name: 'Nebraska' },
+  { code: 'NV', name: 'Nevada' },
+  { code: 'NH', name: 'New Hampshire' },
+  { code: 'NJ', name: 'New Jersey' },
+  { code: 'NM', name: 'New Mexico' },
+  { code: 'NY', name: 'New York' },
+  { code: 'NC', name: 'North Carolina' },
+  { code: 'ND', name: 'North Dakota' },
+  { code: 'MP', name: 'Northern Mariana Islands' },
+  { code: 'OH', name: 'Ohio' },
+  { code: 'OK', name: 'Oklahoma' },
+  { code: 'OR', name: 'Oregon' },
+  { code: 'PW', name: 'Palau' },
+  { code: 'PA', name: 'Pennsylvania' },
+  { code: 'PR', name: 'Puerto Rico' },
+  { code: 'RI', name: 'Rhode Island' },
+  { code: 'SC', name: 'South Carolina' },
+  { code: 'SD', name: 'South Dakota' },
+  { code: 'TN', name: 'Tennessee' },
+  { code: 'TX', name: 'Texas' },
+  { code: 'UT', name: 'Utah' },
+  { code: 'VT', name: 'Vermont' },
+  { code: 'VI', name: 'Virgin Island' },
+  { code: 'VA', name: 'Virginia' },
+  { code: 'WA', name: 'Washington' },
+  { code: 'WV', name: 'West Virginia' },
+  { code: 'WI', name: 'Wisconsin' },
+  { code: 'WY', name: 'Wyoming' },
+] as const;
+
+export const COUNTRIES = [
+  { code: 'US', name: 'United States (US)' },
+  { code: 'CA', name: 'Canada (CA)' },
+  { code: 'GB', name: 'United Kingdom (GB)' },
+  { code: 'IE', name: 'Ireland (IE)' },
+  { code: 'AU', name: 'Australia (AU)' },
+  { code: 'NZ', name: 'New Zealand (NZ)' },
+  { code: 'DE', name: 'Germany (DE)' },
+  { code: 'FR', name: 'France (FR)' },
+  { code: 'IT', name: 'Italy (IT)' },
+  { code: 'ES', name: 'Spain (ES)' },
+  { code: 'NL', name: 'Netherlands (NL)' },
+  { code: 'BE', name: 'Belgium (BE)' },
+  { code: 'CH', name: 'Switzerland (CH)' },
+  { code: 'AT', name: 'Austria (AT)' },
+  { code: 'SE', name: 'Sweden (SE)' },
+  { code: 'NO', name: 'Norway (NO)' },
+  { code: 'DK', name: 'Denmark (DK)' },
+  { code: 'FI', name: 'Finland (FI)' },
+  { code: 'JP', name: 'Japan (JP)' },
+  { code: 'MX', name: 'Mexico (MX)' },
+  { code: 'BR', name: 'Brazil (BR)' },
+  { code: 'ZA', name: 'South Africa (ZA)' },
+] as const;
+
 // Inline consequence help shown under a field, so a manual edit can't quietly
 // make the data worse (#1139 §4/§8). `field` is a FIELD_HELP key.
 function Help({ field }: { field: string }) {
@@ -41,6 +128,8 @@ export function EditVenueDialog({
           name: venue.name || '',
           city: venue.city || '',
           usState: venue.usState || '',
+          country: venue.country || 'US',
+          region: venue.region || '',
           venueType: venue.venueType || '',
           contactName: venue.contactName || '',
           email: venue.email || '',
@@ -65,6 +154,8 @@ export function EditVenueDialog({
           name: '',
           city: '',
           usState: '',
+          country: 'US',
+          region: '',
           venueType: '',
           contactName: '',
           email: '',
@@ -108,22 +199,55 @@ export function EditVenueDialog({
       }
     }
 
+    // Validate state when country is US
+    const currentCountry = form.country || 'US';
+    if (currentCountry === 'US' && (!form.usState || !form.usState.trim())) {
+      setError('State is required for US venues');
+      return;
+    }
+
+    // Validate and format website URL
+    let websiteUrl = form.website ? form.website.trim() : '';
+    if (websiteUrl) {
+      if (!/^https?:\/\//i.test(websiteUrl)) {
+        websiteUrl = `https://${websiteUrl}`;
+      }
+      try {
+        const parsed = new URL(websiteUrl);
+        if (!parsed.hostname.includes('.')) {
+          throw new Error('Invalid host');
+        }
+      } catch {
+        setError('A valid website URL is required');
+        return;
+      }
+    }
+
+    const finalForm: IvenueUpdate = {
+      ...form,
+      name: form.name.trim(),
+      venueType: form.venueType || undefined,
+      website: websiteUrl,
+      country: currentCountry,
+    };
+    if (currentCountry === 'US') {
+      finalForm.region = '';
+    } else {
+      finalForm.usState = '';
+    }
+
     setSubmitting(true);
     setError('');
     try {
       if (venue) {
         // Edit mode
         await adminVenuesUtils.updateVenue(token, venue._id, {
-          ...form,
-          name: form.name.trim(),
-          venueType: form.venueType || undefined,
+          ...finalForm,
         });
       } else {
         // Create mode
         await adminVenuesUtils.createVenue(token, {
-          ...form,
-          name: form.name.trim(),
-          venueType: form.venueType || undefined,
+          ...finalForm,
         });
       }
       onSaved();
@@ -152,8 +276,60 @@ export function EditVenueDialog({
           sx={{ marginTop: 1, marginBottom: 2 }} data-testid="edit-venue-name" />
         <TextField label="City" fullWidth value={form.city || ''} onChange={(e) => set('city', e.target.value)}
           sx={{ marginBottom: 2 }} data-testid="edit-venue-city" />
-        <TextField label="State" fullWidth value={form.usState || ''} onChange={(e) => set('usState', e.target.value)}
-          sx={{ marginBottom: 2 }} data-testid="edit-venue-state" />
+        <FormControl fullWidth sx={{ marginBottom: 2 }}>
+          <InputLabel id="edit-venue-country-label">Country</InputLabel>
+          <Select
+            labelId="edit-venue-country-label"
+            label="Country"
+            value={form.country || 'US'}
+            onChange={(e) => {
+              const newCountry = e.target.value;
+              setForm((f) => ({
+                ...f,
+                country: newCountry,
+                usState: newCountry === 'US' ? f.usState : '',
+                region: newCountry === 'US' ? '' : f.region,
+              }));
+            }}
+            data-testid="edit-venue-country"
+          >
+            {COUNTRIES.map((c) => (
+              <MenuItem key={c.code} value={c.code}>
+                {c.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        {(!form.country || form.country === 'US') ? (
+          <FormControl fullWidth sx={{ marginBottom: 2 }}>
+            <InputLabel id="edit-venue-state-label">State</InputLabel>
+            <Select
+              labelId="edit-venue-state-label"
+              label="State"
+              value={form.usState || ''}
+              onChange={(e) => set('usState', e.target.value)}
+              data-testid="edit-venue-state"
+            >
+              <MenuItem value="">
+                <em>None</em>
+              </MenuItem>
+              {US_STATES.map((s) => (
+                <MenuItem key={s.code} value={s.code}>
+                  {`${s.name} (${s.code})`}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        ) : (
+          <TextField
+            label="State/Province/Region"
+            fullWidth
+            value={form.region || ''}
+            onChange={(e) => set('region', e.target.value)}
+            sx={{ marginBottom: 2 }}
+            data-testid="edit-venue-region"
+          />
+        )}
         <FormControl fullWidth sx={{ marginBottom: 2 }}>
           <InputLabel id="edit-venue-type-label">Venue Type</InputLabel>
           <Select labelId="edit-venue-type-label" label="Venue Type" value={form.venueType || ''}

--- a/src/containers/AdminVenues/VenuesTable.tsx
+++ b/src/containers/AdminVenues/VenuesTable.tsx
@@ -32,6 +32,7 @@ const COLUMNS: { key: string; label: string; help?: string }[] = [
   { key: 'city', label: 'City' },
   { key: 'state', label: 'State' },
   { key: 'contact', label: 'Contact' },
+  { key: 'website', label: 'Website' },
   { key: 'type', label: 'Type', help: 'venueType' },
   { key: 'booking', label: 'Booking', help: 'bookingStatus' },
   { key: 'interested', label: 'Interested', help: 'interested' },
@@ -71,8 +72,9 @@ export function sortValue(v: Ivenue, key: string): string | number {
   switch (key) {
     case 'name': return v.name || '';
     case 'city': return v.city || '';
-    case 'state': return v.usState || '';
+    case 'state': return v.usState || v.region || '';
     case 'contact': return v.contactName || '';
+    case 'website': return v.website || '';
     case 'type': return v.venueType || '';
     case 'booking': return v.bookingStatus || '';
     case 'interested': return v.interested !== false ? 1 : 0;
@@ -626,10 +628,27 @@ export function VenuesTable({
                     <TableCell data-testid={`venue-state-${v._id}`}>
                       {v.usState ? (
                         v.usState
+                      ) : v.region ? (
+                        v.region
                       ) : v.locationFallback?.usState ? (
                         <span style={{ fontStyle: 'italic', opacity: 0.6 }} data-testid={`venue-state-fallback-${v._id}`}>
                           {v.locationFallback.usState}
                         </span>
+                      ) : (
+                        '—'
+                      )}
+                    </TableCell>
+                    <TableCell data-testid={`venue-website-${v._id}`}>
+                      {v.website ? (
+                        <a
+                          href={v.website}
+                          target="_blank"
+                          rel="noopener"
+                          style={{ fontWeight: 'bold', textDecoration: 'underline' }}
+                          data-testid={`venue-website-link-${v._id}`}
+                        >
+                          {v.website}
+                        </a>
                       ) : (
                         '—'
                       )}

--- a/src/containers/AdminVenues/admin-venues.utils.ts
+++ b/src/containers/AdminVenues/admin-venues.utils.ts
@@ -9,6 +9,8 @@ export interface Ivenue {
   name: string;
   city?: string;
   usState?: string;
+  country?: string;
+  region?: string;
   venueType?: string;
   contactName?: string;
   email?: string;
@@ -40,6 +42,8 @@ export interface IvenueUpdate {
   name?: string;
   city?: string;
   usState?: string;
+  country?: string;
+  region?: string;
   venueType?: string;
   contactName?: string;
   email?: string;

--- a/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
+++ b/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
@@ -136,7 +136,7 @@ exports[`AppTemplate > renders the component 1`] = `
             <strong>
               Version
                
-              2.15.0
+              2.16.0
             </strong>
           </div>
           <p

--- a/test/containers/AdminVenues/EditVenueDialog.spec.tsx
+++ b/test/containers/AdminVenues/EditVenueDialog.spec.tsx
@@ -126,14 +126,83 @@ describe('EditVenueDialog', () => {
     });
     await act(async () => {
       fireEvent.change(screen.getByTestId('edit-venue-name'), { target: { value: 'New Cafe' } });
+      fireEvent.change(screen.getByTestId('edit-venue-state'), { target: { value: 'NC' } });
     });
     await act(async () => {
       fireEvent.click(screen.getByTestId('edit-venue-save'));
     });
     expect(adminVenuesUtils.createVenue).toHaveBeenCalledWith('tk', expect.objectContaining({
       name: 'New Cafe',
+      usState: 'NC',
+      country: 'US',
     }));
     expect(onSaved).toHaveBeenCalled();
+  });
+
+  it('validates that state is required for US venues', async () => {
+    adminVenuesUtils.createVenue = vi.fn() as any;
+    await act(async () => {
+      render(<EditVenueDialog open venue={null} token="tk" onClose={vi.fn()} onSaved={vi.fn()} />);
+    });
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('edit-venue-name'), { target: { value: 'New Cafe' } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('edit-venue-save'));
+    });
+    expect(screen.getByTestId('edit-venue-error').innerHTML).toBe('State is required for US venues');
+    expect(adminVenuesUtils.createVenue).not.toHaveBeenCalled();
+  });
+
+  it('validates and auto-prefixes website URL', async () => {
+    await act(async () => {
+      render(<EditVenueDialog open venue={venue} token="tk" onClose={vi.fn()} onSaved={vi.fn()} />);
+    });
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('edit-venue-website'), { target: { value: 'google.com' } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('edit-venue-save'));
+    });
+    expect(adminVenuesUtils.updateVenue).toHaveBeenCalledWith('tk', 'v1', expect.objectContaining({
+      website: 'https://google.com',
+    }));
+  });
+
+  it('rejects invalid website URLs', async () => {
+    await act(async () => {
+      render(<EditVenueDialog open venue={venue} token="tk" onClose={vi.fn()} onSaved={vi.fn()} />);
+    });
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('edit-venue-website'), { target: { value: 'not-a-url' } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('edit-venue-save'));
+    });
+    expect(screen.getByTestId('edit-venue-error').innerHTML).toBe('A valid website URL is required');
+  });
+
+  it('supports non-US countries with free-text region field', async () => {
+    adminVenuesUtils.createVenue = vi.fn(() => Promise.resolve({} as Ivenue)) as any;
+    await act(async () => {
+      render(<EditVenueDialog open venue={null} token="tk" onClose={vi.fn()} onSaved={vi.fn()} />);
+    });
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('edit-venue-name'), { target: { value: 'Global Club' } });
+      fireEvent.change(screen.getByTestId('edit-venue-country'), { target: { value: 'CA' } });
+    });
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('edit-venue-region'), { target: { value: 'Ontario' } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('edit-venue-save'));
+    });
+    expect(adminVenuesUtils.createVenue).toHaveBeenCalledWith('tk', expect.objectContaining({
+      name: 'Global Club',
+      country: 'CA',
+      region: 'Ontario',
+      usState: '',
+    }));
   });
 
   it('warns on duplicate venue name and cancels save if user rejects confirm', async () => {

--- a/test/containers/AdminVenues/VenuesTable.spec.tsx
+++ b/test/containers/AdminVenues/VenuesTable.spec.tsx
@@ -314,5 +314,38 @@ describe('VenuesTable', () => {
     expect(fallbackState.textContent).toBe('NC');
     expect(fallbackState).toHaveStyle('font-style: italic');
   });
+
+  it('renders website column and non-US region in State column', () => {
+    const list: Ivenue[] = [
+      {
+        _id: 'v-intl',
+        name: 'London Club',
+        city: 'London',
+        country: 'GB',
+        region: 'Greater London',
+        website: 'https://londonclub.co.uk',
+      },
+      {
+        _id: 'v-no-website',
+        name: 'Plain Club',
+        city: 'Salem',
+        usState: 'VA',
+      }
+    ];
+    render(<VenuesTable venues={list} onEdit={vi.fn()} />);
+
+    // Website column renders clickable link with target="_blank" and rel="noopener"
+    const link = screen.getByTestId('venue-website-link-v-intl');
+    expect(link).toBeDefined();
+    expect(link.getAttribute('href')).toBe('https://londonclub.co.uk');
+    expect(link.getAttribute('target')).toBe('_blank');
+    expect(link.getAttribute('rel')).toBe('noopener');
+
+    // Missing website shows '—'
+    expect(screen.getByTestId('venue-website-v-no-website').textContent).toBe('—');
+
+    // State column renders non-US region
+    expect(screen.getByTestId('venue-state-v-intl').textContent).toBe('Greater London');
+  });
 });
 

--- a/test/containers/Music/__snapshots__/index.spec.tsx.snap
+++ b/test/containers/Music/__snapshots__/index.spec.tsx.snap
@@ -216,7 +216,7 @@ exports[`/music > renders the component 1`] = `
                 aria-label="* Date and Time"
                 class="createDatetime"
                 slotprops="[object Object]"
-                value="Sat Dec 31 2016 19:00:00 GMT-0500 (Eastern Standard Time)"
+                value="Sun Jan 01 2017 00:00:00 GMT+0000 (Coordinated Universal Time)"
               />
             </div>
             <div

--- a/test/containers/Music/__snapshots__/index.spec.tsx.snap
+++ b/test/containers/Music/__snapshots__/index.spec.tsx.snap
@@ -216,7 +216,7 @@ exports[`/music > renders the component 1`] = `
                 aria-label="* Date and Time"
                 class="createDatetime"
                 slotprops="[object Object]"
-                value="Sun Jan 01 2017 00:00:00 GMT+0000 (Coordinated Universal Time)"
+                value="Sat Dec 31 2016 19:00:00 GMT-0500 (Eastern Standard Time)"
               />
             </div>
             <div


### PR DESCRIPTION
## Summary
Implement AdminVenues enhancements to support validation and world-tour readiness (#1221):

- **US State Dropdown Migration**: Migrated state input on the AdminVenues form from a simple free-text input to a robust select dropdown. Options explicitly display full names and abbreviations (e.g. `'North Carolina (NC)'`). It is the single source of truth for venue states, and stores the standard 2-letter uppercase postal code in `usState`.
- **Country Dropdown & World-Tour Readiness**: Added a Country select dropdown defaulting to `'United States (US)'` (stored as `'US'`). The US state dropdown is shown and required only when country is `'US'`. For other countries, an optional free-text `'State/Province/Region'` text field is rendered instead, saving to `region`.
- **Website URL Validation & Formatting**: Implemented URL scheme auto-prefixing (`https://`) when missing on non-empty website entries. Added validation to reject invalid non-URLs with a clear error dialog block, while still supporting empty values.
- **Clickable Website Link in Table**: Added a brand new 'Website' column to `VenuesTable` that renders the URL as a bold, underlined, clickable link opening in a new tab (`target="_blank" rel="noopener"`), or falls back to `'—'` when blank.
- **State Column Regional Support**: Updated the State column in the `VenuesTable` to seamlessly display the non-US free-text `region` if `usState` is not set.

Closes #1221

## How to test locally
## Manual Verification Plan

1. Navigate to the Admin Venues screen.
2. Click **Add Venue** to open the Dialog.
3. Verify that the **Country** dropdown defaults to `United States (US)`.
4. Verify that the **State** dropdown is visible. Leave it blank and click **Save**. Observe the validation error: `"State is required for US venues"`.
5. Open the **State** dropdown and select `"North Carolina (NC)"`. Verify the visual display and save: it should save correctly.
6. Open **Add Venue** again, change **Country** to `"Canada (CA)"`.
7. Verify that the **State** dropdown is hidden, and the optional free-text **State/Province/Region** input is shown.
8. Enter `"Ontario"` and click **Save**. Verify that it saves with the region correctly and displays `"Ontario"` in the **State** column of the table.
9. Edit a venue, enter `"google.com"` in the **Website** field, and click **Save**.
10. Verify that it saves successfully, and is auto-prefixed to `"https://google.com"`.
11. Edit a venue, enter `"not-a-url"` in **Website**, and click **Save**. Verify the error dialog blocks saving: `"A valid website URL is required"`.
12. In the **Venues Table**, verify the new **Website** column.
13. Click a website link, and verify it opens in a new tab with `target="_blank"` and `rel="noopener"`. Verify that empty websites display `"—"`.

## Automated Tests

Run the newly added unit tests in `EditVenueDialog.spec.tsx` and `VenuesTable.spec.tsx`:
- `npm run test:unit test/containers/AdminVenues/EditVenueDialog.spec.tsx`
- `npm run test:unit test/containers/AdminVenues/VenuesTable.spec.tsx`

## Test evidence
```
> jammusic@2.16.0 test
> npm run test:lint && npm run typecheck && npm run jscpd && npm run test:unit


> jammusic@2.16.0 test:stylelint
> stylelint "src/styles/**/*.scss"


> jammusic@2.16.0 eslint
> eslint .


> jammusic@2.16.0 typecheck
> tsc --noEmit


> jammusic@2.16.0 jscpd
> jscpd src

Format analyzed: tsx, typescript
Total lines: 11070
Clones found: 30
Duplicated lines: 378 (3.41%)
Found 30 clones.
time: 14.119ms

> jammusic@2.16.0 test:unit
> TZ=UTC vitest run --coverage


 RUN  v4.1.7 /home/joshua/WebJamApps/JaMmusic
      Coverage enabled with v8

Not implemented: navigation to another Document
Not implemented: navigation to another Document

 Test Files  69 passed (69)
      Tests  517 passed (517)
   Start at  09:31:24
   Duration  29.67s (transform 3.85s, setup 5.30s, import 115.73s, tests 55.27s, environment 85.94s)

=============================== Coverage summary ===============================
Statements   : 90.86% ( 2555/2812 )
Branches     : 80.49% ( 1535/1907 )
Functions    : 88.31% ( 650/736 )
Lines        : 92.6% ( 2293/2476 )
================================================================================
```

🤖 Work by agy — Gemini 3.5 Flash (Medium)