### PR TITLE
AdminVenues form: primary + secondary email fields; remove contactVerified

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/AdminVenues/EditVenueDialog.tsx
+++ b/src/containers/AdminVenues/EditVenueDialog.tsx
@@ -133,13 +133,13 @@ export function EditVenueDialog({
           venueType: venue.venueType || '',
           contactName: venue.contactName || '',
           email: venue.email || '',
+          secondaryEmail: venue.secondaryEmail || '',
           phone: venue.phone || '',
           website: venue.website || '',
           outreachEligible: !!venue.outreachEligible,
           bookingStatus: venue.bookingStatus || 'booking',
           interested: venue.interested !== false,
           payTier: venue.payTier || '',
-          contactVerified: !!venue.contactVerified,
           lastVerified: venue.lastVerified ? venue.lastVerified.substring(0, 10) : '',
           notes: venue.notes || '',
           relationshipStage: venue.relationshipStage || '',
@@ -159,13 +159,13 @@ export function EditVenueDialog({
           venueType: '',
           contactName: '',
           email: '',
+          secondaryEmail: '',
           phone: '',
           website: '',
           outreachEligible: false,
           bookingStatus: 'booking',
           interested: true,
           payTier: '',
-          contactVerified: false,
           lastVerified: '',
           notes: '',
           relationshipStage: '',
@@ -223,9 +223,24 @@ export function EditVenueDialog({
       }
     }
 
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    const primaryEmail = form.email ? form.email.trim() : '';
+    const secondaryEmail = form.secondaryEmail ? form.secondaryEmail.trim() : '';
+
+    if (primaryEmail && !emailRegex.test(primaryEmail)) {
+      setError('Primary Email is invalid');
+      return;
+    }
+    if (secondaryEmail && !emailRegex.test(secondaryEmail)) {
+      setError('Secondary Email is invalid');
+      return;
+    }
+
     const finalForm: IvenueUpdate = {
       ...form,
       name: form.name.trim(),
+      email: primaryEmail,
+      secondaryEmail: secondaryEmail,
       venueType: form.venueType || undefined,
       website: websiteUrl,
       country: currentCountry,
@@ -385,8 +400,10 @@ export function EditVenueDialog({
         <Help field="travelBand" />
         <TextField label="Contact Name" fullWidth value={form.contactName || ''} onChange={(e) => set('contactName', e.target.value)}
           sx={{ marginBottom: 2 }} data-testid="edit-venue-contact" />
-        <TextField label="Email" fullWidth value={form.email || ''} onChange={(e) => set('email', e.target.value)}
+        <TextField label="Primary Email" fullWidth value={form.email || ''} onChange={(e) => set('email', e.target.value)}
           sx={{ marginBottom: 2 }} data-testid="edit-venue-email" />
+        <TextField label="Secondary Email" fullWidth value={form.secondaryEmail || ''} onChange={(e) => set('secondaryEmail', e.target.value)}
+          sx={{ marginBottom: 2 }} data-testid="edit-venue-secondary-email" />
         <TextField label="Phone" fullWidth value={form.phone || ''} onChange={(e) => set('phone', e.target.value)}
           sx={{ marginBottom: 2 }} data-testid="edit-venue-phone" />
         <TextField label="Website" fullWidth value={form.website || ''} onChange={(e) => set('website', e.target.value)}
@@ -424,13 +441,7 @@ export function EditVenueDialog({
             )}
             label="Interested (worth pursuing)" />
           <Help field="interested" />
-          <FormControlLabel
-            control={(
-              <Checkbox checked={!!form.contactVerified} onChange={(e) => set('contactVerified', e.target.checked)}
-                aria-label="contact verified" data-testid="edit-venue-contactverified" />
-            )}
-            label="Contact verified" />
-          <Help field="contactVerified" />
+
         </FormGroup>
         <TextField
           label="Last Verified"

--- a/src/containers/AdminVenues/VenuesTable.tsx
+++ b/src/containers/AdminVenues/VenuesTable.tsx
@@ -140,9 +140,9 @@ export function VenuesTable({
     setCopyDialogOpen(true);
   };
 
-  // Un-vetted definition: no venueType set OR contactVerified is falsy.
+  // Un-vetted definition: no venueType set.
   // This is Josh's vetting work queue.
-  const unvettedCount = venues.filter((v) => !v.venueType || !v.contactVerified).length;
+  const unvettedCount = venues.filter((v) => !v.venueType).length;
   const vettedCount = venues.length - unvettedCount;
 
   const handleSort = (key: string) => {
@@ -180,7 +180,7 @@ export function VenuesTable({
       if (!nameMatch && !cityMatch) return false;
     }
     if (needsVettingFilter) {
-      const needsVetting = !v.venueType || !v.contactVerified;
+      const needsVetting = !v.venueType;
       if (!needsVetting) return false;
     }
     return true;
@@ -679,10 +679,10 @@ export function VenuesTable({
 
                         {/* Email */}
                         {v.email ? (
-                          <Tooltip title={`Email: ${v.email}`} arrow>
+                          <Tooltip title={`Primary Email: ${v.email}`} arrow>
                             <Box
                               component="span"
-                              onClick={() => handleOpenCopyDialog('Email Address', v.email!)}
+                              onClick={() => handleOpenCopyDialog('Primary Email Address', v.email!)}
                               data-testid={`venue-contact-email-${v._id}`}
                               sx={{
                                 fontSize: '1.1rem',
@@ -705,6 +705,28 @@ export function VenuesTable({
                             ✉
                           </Typography>
                         )}
+
+                        {/* Secondary Email */}
+                        {v.secondaryEmail ? (
+                          <Tooltip title={`Secondary Email: ${v.secondaryEmail}`} arrow>
+                            <Box
+                              component="span"
+                              onClick={() => handleOpenCopyDialog('Secondary Email Address', v.secondaryEmail!)}
+                              data-testid={`venue-contact-secondary-email-${v._id}`}
+                              sx={{
+                                fontSize: '1.1rem',
+                                cursor: 'pointer',
+                                textDecoration: 'none',
+                                color: 'info.light',
+                                display: 'inline-flex',
+                                ml: 0.5,
+                                '&:hover': { opacity: 0.8 },
+                              }}
+                            >
+                              ✉₂
+                            </Box>
+                          </Tooltip>
+                        ) : null}
 
                         {/* Phone */}
                         {v.phone ? (

--- a/src/containers/AdminVenues/admin-venues.utils.ts
+++ b/src/containers/AdminVenues/admin-venues.utils.ts
@@ -14,6 +14,7 @@ export interface Ivenue {
   venueType?: string;
   contactName?: string;
   email?: string;
+  secondaryEmail?: string;
   phone?: string;
   website?: string;
   status?: string;
@@ -22,7 +23,6 @@ export interface Ivenue {
   bookingStatus?: string;
   interested?: boolean;
   payTier?: string;
-  contactVerified?: boolean;
   notes?: string;
   relationshipStage?: string;
   templateOverride?: string;
@@ -47,6 +47,7 @@ export interface IvenueUpdate {
   venueType?: string;
   contactName?: string;
   email?: string;
+  secondaryEmail?: string;
   phone?: string;
   website?: string;
   outreachEligible?: boolean;
@@ -54,7 +55,6 @@ export interface IvenueUpdate {
   bookingStatus?: string;
   interested?: boolean;
   payTier?: string;
-  contactVerified?: boolean;
   notes?: string;
   relationshipStage?: string;
   templateOverride?: string;
@@ -143,7 +143,6 @@ export const FIELD_HELP: Record<string, string> = {
   outreachEligible: 'MASTER SAFETY GATE. ON = the auto-cron + batch MAY send a pitch email here. OFF = never emailed, period. '
     + 'Only turn ON once vetted: in scope + has a Type + still booking + contact verified.',
   payTier: 'Relative pay (e.g. $/$$/$$$); ranks better-paying venues higher in the default sort. No send effect.',
-  contactVerified: 'Is the email/contact confirmed good? Should be true before Eligible.',
   lastVerified: 'The date this venue\'s details or contact info were last verified.',
   relationshipStage: 'cold (never played) vs returning (played before) — picks the cold vs warm template. Auto = inferred from history.',
   templateOverride: 'Force a specific template regardless of Type. Leave blank normally.',
@@ -167,7 +166,7 @@ export function prospectScore(v: Ivenue): number {
   const fit = { none: 0, some: 3, loves: 6 }[v.originalsFit || 'none'] ?? 0;
   const travel = { local: 0, regional: 1, far: 2 }[v.travelBand || 'local'] ?? 0;
   const value = payTierValue(v.payTier) - travel;
-  const warmth = (v.interested ? 2 : 0) + (v.relationshipStage === 'returning' ? 1 : 0) + (v.contactVerified ? 1 : 0);
+  const warmth = (v.interested ? 2 : 0) + (v.relationshipStage === 'returning' ? 1 : 0);
   return fit + value + warmth + (v.priority || 0);
 }
 
@@ -180,6 +179,7 @@ export async function exportVenuesToExcel(venues: Ivenue[]): Promise<void> {
     { header: 'Name', key: 'name', width: 25 },
     { header: 'Contact Name', key: 'contactName', width: 20 },
     { header: 'Email', key: 'email', width: 25 },
+    { header: 'Secondary Email', key: 'secondaryEmail', width: 25 },
     { header: 'Phone', key: 'phone', width: 15 },
     { header: 'City', key: 'city', width: 15 },
     { header: 'State', key: 'usState', width: 10 },
@@ -189,7 +189,6 @@ export async function exportVenuesToExcel(venues: Ivenue[]): Promise<void> {
     { header: 'Booking Status', key: 'bookingStatus', width: 15 },
     { header: 'Interested', key: 'interested', width: 12 },
     { header: 'Pay Tier', key: 'payTier', width: 12 },
-    { header: 'Contact Verified', key: 'contactVerified', width: 18 },
     { header: 'Originals Fit', key: 'originalsFit', width: 15 },
     { header: 'Travel Band', key: 'travelBand', width: 12 },
     { header: 'Priority', key: 'priority', width: 10 },
@@ -220,6 +219,7 @@ export async function exportVenuesToExcel(venues: Ivenue[]): Promise<void> {
       name: v.name || '',
       contactName: v.contactName || '',
       email: v.email || '',
+      secondaryEmail: v.secondaryEmail || '',
       phone: v.phone || '',
       city: v.city || '',
       usState: v.usState || '',
@@ -229,7 +229,6 @@ export async function exportVenuesToExcel(venues: Ivenue[]): Promise<void> {
       bookingStatus: v.bookingStatus || '',
       interested: v.interested !== false ? 'Yes' : 'No',
       payTier: v.payTier || '',
-      contactVerified: v.contactVerified ? 'Yes' : 'No',
       originalsFit: v.originalsFit || '',
       travelBand: v.travelBand || '',
       priority: v.priority !== undefined ? v.priority : '',
@@ -250,6 +249,16 @@ export async function exportVenuesToExcel(venues: Ivenue[]): Promise<void> {
       if (emailStr.includes('@')) {
         emailCell.value = { text: emailStr, hyperlink: `mailto:${emailStr}` };
         emailCell.font = { color: { argb: 'FF0563C1' }, underline: true };
+      }
+    }
+
+    // Apply hyperlink formatting to Secondary Email cell if secondaryEmail exists
+    if (v.secondaryEmail && v.secondaryEmail.trim()) {
+      const secEmailCell = row.getCell('secondaryEmail');
+      const emailStr = v.secondaryEmail.trim();
+      if (emailStr.includes('@')) {
+        secEmailCell.value = { text: emailStr, hyperlink: `mailto:${emailStr}` };
+        secEmailCell.font = { color: { argb: 'FF0563C1' }, underline: true };
       }
     }
 

--- a/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
+++ b/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
@@ -136,7 +136,7 @@ exports[`AppTemplate > renders the component 1`] = `
             <strong>
               Version
                
-              2.16.0
+              2.17.0
             </strong>
           </div>
           <p

--- a/test/containers/AdminVenues/EditVenueDialog.spec.tsx
+++ b/test/containers/AdminVenues/EditVenueDialog.spec.tsx
@@ -61,6 +61,7 @@ describe('EditVenueDialog', () => {
       change('edit-venue-type', 'Originals');
       change('edit-venue-contact', 'Pat');
       change('edit-venue-email', 'pat@v.com');
+      change('edit-venue-secondary-email', 'sec@v.com');
       change('edit-venue-phone', '540-555-1212');
       change('edit-venue-website', 'https://v.com');
       change('edit-venue-pay', '$$$');
@@ -68,13 +69,38 @@ describe('EditVenueDialog', () => {
       change('edit-venue-notes', 'great room');
     });
     await act(async () => { fireEvent.click(screen.getByTestId('edit-venue-interested')); });
-    await act(async () => { fireEvent.click(screen.getByTestId('edit-venue-contactverified')); });
     await act(async () => { fireEvent.click(screen.getByTestId('edit-venue-save')); });
     expect(adminVenuesUtils.updateVenue).toHaveBeenCalledWith('tk', 'v1', expect.objectContaining({
       city: 'Roanoke', usState: 'VA', venueType: 'Originals', contactName: 'Pat',
-      email: 'pat@v.com', phone: '540-555-1212', website: 'https://v.com', payTier: '$$$', notes: 'great room',
+      email: 'pat@v.com', secondaryEmail: 'sec@v.com', phone: '540-555-1212', website: 'https://v.com', payTier: '$$$', notes: 'great room',
       lastVerified: '2026-07-16',
     }));
+  });
+
+  it('rejects invalid primary email address', async () => {
+    await act(async () => {
+      render(<EditVenueDialog open venue={venue} token="tk" onClose={vi.fn()} onSaved={vi.fn()} />);
+    });
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('edit-venue-email'), { target: { value: 'not-an-email' } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('edit-venue-save'));
+    });
+    expect(screen.getByTestId('edit-venue-error').innerHTML).toBe('Primary Email is invalid');
+  });
+
+  it('rejects invalid secondary email address', async () => {
+    await act(async () => {
+      render(<EditVenueDialog open venue={venue} token="tk" onClose={vi.fn()} onSaved={vi.fn()} />);
+    });
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('edit-venue-secondary-email'), { target: { value: 'not-an-email' } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('edit-venue-save'));
+    });
+    expect(screen.getByTestId('edit-venue-error').innerHTML).toBe('Secondary Email is invalid');
   });
 
   it('clears priority back to undefined when emptied', async () => {

--- a/test/containers/AdminVenues/VenuesTable.spec.tsx
+++ b/test/containers/AdminVenues/VenuesTable.spec.tsx
@@ -167,9 +167,9 @@ describe('VenuesTable', () => {
 
   it('filters un-vetted venues and displays progress stats', () => {
     const list: Ivenue[] = [
-      { _id: 'v1', name: 'Vetted 1', venueType: 'MidRangeCafeBar', contactVerified: true },
-      { _id: 'v2', name: 'Unvetted 1', venueType: undefined, contactVerified: true }, // needs vetting
-      { _id: 'v3', name: 'Unvetted 2', venueType: 'MidRangeCafeBar', contactVerified: undefined }, // needs vetting
+      { _id: 'v1', name: 'Vetted 1', venueType: 'MidRangeCafeBar' },
+      { _id: 'v2', name: 'Unvetted 1', venueType: undefined }, // needs vetting
+      { _id: 'v3', name: 'Unvetted 2', venueType: undefined }, // needs vetting
     ];
     render(<VenuesTable venues={list} onEdit={vi.fn()} />);
     
@@ -182,6 +182,30 @@ describe('VenuesTable', () => {
 
     // Now only the unvetted rows should be shown
     expect(rowIds()).toEqual(['venue-row-v2', 'venue-row-v3']);
+  });
+
+  it('opens CopyDialog when clicking primary and secondary email icons', async () => {
+    const list: Ivenue[] = [
+      {
+        _id: 'v-emails',
+        name: 'Two Email Venue',
+        email: 'pri@example.com',
+        secondaryEmail: 'sec@example.com',
+      },
+    ];
+    render(<VenuesTable venues={list} onEdit={vi.fn()} />);
+
+    // Click Primary Email icon
+    fireEvent.click(screen.getByTestId('venue-contact-email-v-emails'));
+    expect(screen.getByTestId('copy-dialog-title').textContent).toBe('Primary Email Address');
+    expect(screen.getByTestId('copy-dialog-content')).toHaveValue('pri@example.com');
+    fireEvent.click(screen.getByTestId('copy-dialog-close'));
+
+    // Click Secondary Email icon
+    fireEvent.click(screen.getByTestId('venue-contact-secondary-email-v-emails'));
+    expect(screen.getByTestId('copy-dialog-title').textContent).toBe('Secondary Email Address');
+    expect(screen.getByTestId('copy-dialog-content')).toHaveValue('sec@example.com');
+    fireEvent.click(screen.getByTestId('copy-dialog-close'));
   });
 
   it('renders inputs container with responsive wrap and non-shrinking inputs', () => {

--- a/test/containers/AdminVenues/admin-venues.utils.spec.tsx
+++ b/test/containers/AdminVenues/admin-venues.utils.spec.tsx
@@ -138,11 +138,10 @@ describe('AdminVenues utils', () => {
         payTier: '$$$', // +3
         travelBand: 'far', // −2 → value = 1
         interested: true, // +2
-        relationshipStage: 'returning', // +1
-        contactVerified: true, // +1 → warmth = 4
+        relationshipStage: 'returning', // +1 → warmth = 3
         priority: 5, // +5
       };
-      expect(prospectScore(v)).toBe(6 + 1 + 4 + 5);
+      expect(prospectScore(v)).toBe(6 + 1 + 3 + 5);
     });
 
     it('treats unset fit/travel/pay as zero and counts $ signs for pay', () => {
@@ -197,6 +196,7 @@ describe('AdminVenues utils', () => {
           venueType: 'Originals',
           contactName: 'John',
           email: 'john@thespot.com',
+          secondaryEmail: 'john.sec@thespot.com',
           phone: '123-456-7890',
           website: 'www.thespot.com',
           outreachEligible: true,
@@ -204,7 +204,6 @@ describe('AdminVenues utils', () => {
           bookingStatus: 'booking',
           interested: true,
           payTier: '$$',
-          contactVerified: true,
           originalsFit: 'loves',
           travelBand: 'local',
           priority: 3,


### PR DESCRIPTION
## Summary
## AdminVenues Form: Primary & Secondary Email Support + Drop contactVerified

This PR introduces primary and secondary email support in the AdminVenues form and drops the obsolete `contactVerified` field across the frontend to align with the backend database updates in web-jam-back#974.

### Key Changes
1. **Types and Utilities (`admin-venues.utils.ts`):**
   - Added `secondaryEmail?: string` and removed `contactVerified?: boolean` from `Ivenue` and `IvenueUpdate` interfaces.
   - Removed `contactVerified` help text from `FIELD_HELP`.
   - Adjusted `prospectScore` calculation to omit `contactVerified` (no longer adding `1` to warmth).
   - Updated Excel export columns to include `Secondary Email` and format its links correctly, while removing `Contact Verified` from columns.
2. **Edit Dialog (`EditVenueDialog.tsx`):**
   - Replaced the single `Email` text input with **Primary Email** and **Secondary Email (optional)** text inputs.
   - Removed the `Contact verified` checkbox and help icon.
   - Implemented validation for both email inputs on save, displaying distinct and clear error messages (`Primary Email is invalid` or `Secondary Email is invalid`) if any entered string is malformed.
3. **Venues Table (`VenuesTable.tsx`):**
   - Updated the contacts cell to render two separate clickable envelopes for primary and secondary emails if both exist.
   - Styled the secondary email icon with a distinctive subscript "✉₂" to keep it highly readable and visually distinct.
   - Enabled clipboard copy dialog triggers for both emails with respective titles ("Primary Email Address" and "Secondary Email Address").
   - Removed `contactVerified` from the vetting count computation and needs-vetting active filter queue (vetting queue is now determined solely by whether the venue has an assigned `venueType`).

Closes #1225

## How to test locally
## Pull Request Test Plan

### Unit Test Enhancements
1. **Utility Tests (`admin-venues.utils.spec.tsx`):**
   - Adjusted `prospectScore` test expectation to verify the updated scoring value without `contactVerified`.
   - Updated the Excel export test array to verify outputting of the new `secondaryEmail` property.
2. **Dialog Tests (`EditVenueDialog.spec.tsx`):**
   - Removed verification logic targeting `contactVerified`.
   - Added specific validations for `secondaryEmail` inputs during manual/create text updates.
   - Added automated tests verifying that invalid primary or secondary email strings trigger appropriate error messages.
3. **Table Tests (`VenuesTable.spec.tsx`):**
   - Updated vetting queue test mock data to verify that only venues without `venueType` are counted as "needs vetting".
   - Added automated tests verifying that clicking the primary and secondary email icons opens the copy dialog correctly with correct titles and inputs.

### Verification Execution
Execute the entire frontend test suite locally to verify compliance:
```bash
npm run test:unit
npm run test:lint
```
All tests should pass cleanly.

## Test evidence
## Pull Request Test Evidence

### Unit Tests
```
> jammusic@2.17.0 test:unit
> TZ=UTC vitest run --coverage -u


 RUN  v4.1.7 /home/joshua/WebJamApps/JaMmusic
      Coverage enabled with v8

Not implemented: navigation to another Document
Not implemented: navigation to another Document

  Snapshots  1 updated 
 Test Files  69 passed (69)
      Tests  520 passed (520)
   Start at  11:21:02
   Duration  34.03s (transform 4.58s, setup 5.85s, import 132.60s, tests 65.47s, environment 96.52s)

 % Coverage report from v8
-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------|---------|----------|---------|---------|-------------------
All files          |   90.94 |    80.57 |   88.46 |   92.69 |                   
 src               |       0 |      100 |     100 |       0 |                   
  polyfills.ts     |       0 |      100 |     100 |       0 | 4-5               
 ...pp/AppTemplate |   95.78 |    95.23 |   87.87 |   96.47 |                   
  ...erSection.tsx |     100 |       50 |     100 |     100 | 15                
  index.tsx        |   85.18 |    66.66 |   69.23 |   86.95 | 25,38,46          
 .../GoogleButtons |      90 |       60 |     100 |   91.66 |                   
  utils.tsx        |   84.61 |       50 |     100 |      88 | 30-31,60          
 src/components    |     100 |    91.66 |     100 |     100 |                   
  YearField.tsx    |     100 |       50 |     100 |     100 | 18                
 .../AdminOutreach |   90.67 |    79.61 |   96.73 |   93.33 |                   
  index.tsx        |   88.95 |     74.8 |   96.05 |   92.28 | ...22,429,434,491 
 ...AdminTemplates |   89.21 |    79.14 |      84 |      90 |                   
  ...ates.utils.ts |   98.91 |    92.42 |     100 |     100 | 27-29,152         
  index.tsx        |   85.04 |     73.1 |   78.94 |   86.27 | ...64,515-651,732 
 ...ers/AdminUsers |   85.18 |    71.22 |   84.37 |   87.15 |                   
  ...eUserForm.tsx |   80.76 |     61.9 |   82.35 |   84.21 | 77-80,93,142      
  ...serDialog.tsx |   88.46 |    81.39 |   88.88 |   93.18 | 62-63,110         
  UsersTable.tsx   |   80.76 |       54 |     100 |   80.43 | ...27-29,57,68,83 
  index.tsx        |      80 |    93.33 |    37.5 |   81.48 | 58-72             
 ...rs/AdminVenues |   92.05 |    81.54 |   85.84 |   93.18 |                   
  ...nueDialog.tsx |   96.96 |    89.47 |   94.87 |   96.77 | 281-282,360       
  VenuesTable.tsx  |   91.44 |    84.65 |   83.67 |   91.24 | ...36,824-825,892 
  ...nues.utils.ts |   94.73 |    67.28 |    90.9 |   96.55 | 120-124           
  index.tsx        |    80.7 |       70 |   64.28 |      86 | ...27,153,186-199 
 ...iners/Homepage |   92.72 |    88.67 |   91.42 |      94 |                   
  FacebookFeed.tsx |   96.42 |    89.47 |     100 |     100 | 29,46             
  ...bookPosts.tsx |     100 |    85.71 |     100 |     100 | 36,54             
  ...tFacebook.tsx |      60 |       50 |   66.66 |   55.55 | 14-18             
  ...ook.utils.tsx |    92.1 |    94.44 |      75 |   94.28 | 19,37             
 ...mepage/Inquiry |     100 |    97.14 |     100 |     100 |                   
  utils.tsx        |     100 |    95.65 |     100 |     100 | 22                
 ...ntainers/Music |     100 |    81.08 |     100 |     100 |                   
  index.tsx        |     100 |       80 |     100 |     100 | 81,96,116-150     
  joshBio.tsx      |     100 |       50 |     100 |     100 | 30                
  mariaBio.tsx     |     100 |       50 |     100 |     100 | 31                
 ...ers/Music/Gigs |   89.55 |    78.94 |   83.13 |   92.78 |                   
  ...GigDialog.tsx |   78.68 |    80.48 |   71.42 |   86.79 | ...31,249,266-274 
  ...GigDialog.tsx |   80.72 |       80 |   70.83 |   85.13 | ...68,176,298-320 
  gigs.utils.tsx   |   95.04 |    81.31 |   94.73 |   97.14 | 58,101,125        
  index.tsx        |     100 |       72 |     100 |     100 | ...35,40-49,54-55 
 ...Music/Pictures |   96.66 |    85.71 |      88 |   96.55 |                   
  ...PicDialog.tsx |   93.33 |      100 |   83.33 |   92.85 | 27                
  ...PicDialog.tsx |   93.75 |    83.33 |    87.5 |   93.75 | 31                
  EditPicTable.tsx |    90.9 |      100 |      75 |      90 | 56                
  ...res.utils.tsx |     100 |       75 |     100 |     100 | 101               
 ...ntainers/Songs |    95.2 |    91.17 |   84.61 |   94.82 |                   
  ...ongDialog.tsx |   93.33 |       75 |   83.33 |    93.1 | 44,129            
  ...ongDialog.tsx |   91.89 |       90 |      80 |   91.42 | 54,148-156        
  index.tsx        |   94.73 |      100 |   85.71 |   94.44 | 51                
  songs.utils.tsx  |     100 |    92.85 |     100 |     100 | 34                
 ...gs/MusicPlayer |   76.68 |    71.53 |    65.3 |   80.89 |                   
  index.tsx        |    63.7 |    61.11 |   54.05 |   69.69 | ...89,301,311-322 
  utils.tsx        |     100 |       95 |     100 |     100 | 8-13              
 ...tainers/Tipjar |     100 |       50 |     100 |     100 |                   
  index.tsx        |     100 |       50 |     100 |     100 | 9-17              
 src/lib           |   99.05 |    96.15 |     100 |   98.82 |                   
  tokenExpiry.ts   |   94.11 |      100 |     100 |   92.85 | 15                
  venueTimezone.ts |     100 |    88.88 |     100 |     100 | 155,176           
 src/providers     |   92.85 |    68.57 |   97.82 |   95.23 |                   
  ....provider.tsx |   83.63 |       50 |     100 |   86.95 | 54-61,93          
  ....provider.tsx |   96.29 |      100 |    92.3 |     100 |                   
  ....provider.tsx |   94.73 |       75 |     100 |     100 | 14,41             
  fetchSongs.tsx   |     100 |    83.33 |     100 |     100 | 7                 
-------------------|---------|----------|---------|---------|-------------------

=============================== Coverage summary ===============================
Statements   : 90.94% ( 2572/2828 )
Branches     : 80.57% ( 1551/1925 )
Functions    : 88.46% ( 652/737 )
Lines        : 92.69% ( 2310/2492 )
================================================================================
```

### Lint Checks
```
> jammusic@2.17.0 test:lint
> npm run lint:eslint && npm run lint:stylelint

...
✖ 910 problems (0 errors, 910 warnings)
```
No lint errors.

🤖 Work by agy — Gemini 3.5 Flash (Medium)