### PR TITLE
cannot send batch outreach error!

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/AdminOutreach/index.tsx
+++ b/src/containers/AdminOutreach/index.tsx
@@ -356,11 +356,26 @@ export function AdminOutreach() {
   };
 
   const send = async () => {
+    if (!structuredDate) {
+      setError('Select a weekend date first');
+      return;
+    }
     setSending(true);
     setError('');
     try {
+      const startDate = new Date(`${structuredDate}T00:00:00`);
+      const endDate = new Date(startDate);
+      endDate.setDate(startDate.getDate() + 2);
+      const year = endDate.getFullYear();
+      const month = String(endDate.getMonth() + 1).padStart(2, '0');
+      const day = String(endDate.getDate()).padStart(2, '0');
+      const end = `${year}-${month}-${day}`;
+
       const res = await outreachUtils.sendBatch(auth.token, {
-        venueIds: [...selected], targetDates: targetDates.trim(), bookingPeriod: bookingPeriod.trim() || undefined,
+        venueIds: [...selected],
+        targetDates: targetDates.trim(),
+        bookingPeriod: bookingPeriod.trim() || undefined,
+        targetWeekend: { start: structuredDate, end },
       });
       setResult(res);
       setCandidates([]);

--- a/src/containers/AdminOutreach/outreach.utils.ts
+++ b/src/containers/AdminOutreach/outreach.utils.ts
@@ -75,7 +75,12 @@ async function getCandidates(token: string, targetDates?: string, eligibleFor?: 
 
 async function sendBatch(
   token: string,
-  payload: { venueIds: string[]; targetDates: string; bookingPeriod?: string },
+  payload: {
+    venueIds: string[];
+    targetDates: string;
+    bookingPeriod?: string;
+    targetWeekend: { start: string; end: string };
+  },
 ): Promise<IbatchResult> {
   const res = await fetch(`${outreachUrl}/batch`, {
     method: 'POST', headers: headers(token, true), body: JSON.stringify(payload),

--- a/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
+++ b/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
@@ -136,7 +136,7 @@ exports[`AppTemplate > renders the component 1`] = `
             <strong>
               Version
                
-              2.18.0
+              2.18.1
             </strong>
           </div>
           <p

--- a/test/containers/AdminOutreach/index.spec.tsx
+++ b/test/containers/AdminOutreach/index.spec.tsx
@@ -105,7 +105,10 @@ describe('AdminOutreach', () => {
     await act(async () => { fireEvent.click(screen.getByTestId('outreach-open-dialog')); });
     await act(async () => { fireEvent.click(screen.getByTestId('outreach-dialog-send')); });
     expect(outreachUtils.sendBatch).toHaveBeenCalledWith('tk', expect.objectContaining({
-      venueIds: ['c1', 'c2'], targetDates: 'Aug 15-17', bookingPeriod: 'summer 2026',
+      venueIds: ['c1', 'c2'],
+      targetDates: 'Aug 15-17',
+      bookingPeriod: 'summer 2026',
+      targetWeekend: { start: '2026-08-15', end: '2026-08-17' },
     }));
     expect(screen.getByTestId('outreach-result').textContent).toContain('Sent 2 of 2');
   });

--- a/test/containers/AdminOutreach/outreach.utils.spec.tsx
+++ b/test/containers/AdminOutreach/outreach.utils.spec.tsx
@@ -22,11 +22,20 @@ describe('Outreach utils', () => {
 
   it('sendBatch POSTs the venueIds + dates', async () => {
     fetchMock.mockReturnValue(okJson({ requested: 2, sent: 2, skipped: [], records: [] }));
-    const res = await outreachUtils.sendBatch('tok', { venueIds: ['a', 'b'], targetDates: 'Aug 14-16', bookingPeriod: 'August' });
+    const res = await outreachUtils.sendBatch('tok', {
+      venueIds: ['a', 'b'],
+      targetDates: 'Aug 14-16',
+      bookingPeriod: 'August',
+      targetWeekend: { start: '2026-08-14', end: '2026-08-16' },
+    });
     expect(res.sent).toBe(2);
     const opts = fetchMock.mock.calls[0][1] as RequestInit;
     expect(opts.method).toBe('POST');
-    expect(JSON.parse(opts.body as string)).toMatchObject({ venueIds: ['a', 'b'], targetDates: 'Aug 14-16' });
+    expect(JSON.parse(opts.body as string)).toMatchObject({
+      venueIds: ['a', 'b'],
+      targetDates: 'Aug 14-16',
+      targetWeekend: { start: '2026-08-14', end: '2026-08-16' },
+    });
   });
 
   it('getConfig GETs /outreach/config', async () => {
@@ -102,7 +111,7 @@ describe('Outreach utils', () => {
 
   it.each([
     ['getCandidates', () => outreachUtils.getCandidates('t', 'd')],
-    ['sendBatch', () => outreachUtils.sendBatch('t', { venueIds: ['a'], targetDates: 'd' })],
+    ['sendBatch', () => outreachUtils.sendBatch('t', { venueIds: ['a'], targetDates: 'd', targetWeekend: { start: 's', end: 'e' } })],
     ['getConfig', () => outreachUtils.getConfig('t')],
     ['setConfig', () => outreachUtils.setConfig('t', true)],
     ['getPreview', () => outreachUtils.getPreview('t', ['a'], 'd')],


### PR DESCRIPTION
## Summary
### Summary
This PR resolves the issue where sending a batch outreach campaign fails with a `targetWeekend {start, end} is required` error.

### Changes
- **Backend-compatible Batch payload**: Updated `outreachUtils.sendBatch` signature in `outreach.utils.ts` to include `targetWeekend: { start: string; end: string }` and pass it through to the backend body.
- **Derived Weekend Dates**: Modified `send()` in `index.tsx` to compute the target weekend date range starting at `structuredDate` and ending 2 days later (`structuredDate + 2 days`).
- **Defensive Guard**: Added a defensive check to ensure `structuredDate` is set before sending. If not, sets an error message and bails.
- **Version Bump**: Incremented the package.json version to `2.18.1` as the first commit.
- **Unit Tests Updated**: Enhanced unit tests in `index.spec.tsx` and `outreach.utils.spec.tsx` to assert that `targetWeekend` is correctly structured and sent, and updated the version snapshot in `index.spec.tsx.snap`.

Closes #1246

## How to test locally
### Test Plan

#### 1. Unit Tests
- Execute unit tests to verify outreach module logic:
  - Command: `npm run test:unit`
  - Expected: All 525 unit tests pass, and snapshot tests match the new version `2.18.1`.

#### 2. Full Verification Suite
- Execute full linting and static checks to ensure code health and consistency:
  - Command: `npm test`
  - Expected: Stylelint, ESLint, TypeScript compilation (`tsc --noEmit`), and JSCPD duplicate detector all pass successfully.

## Test evidence
### Test Evidence

The entire validation suite has passed successfully.

#### Unit Test Output excerpt:
```
Test Files  69 passed (69)
     Tests  525 passed (525)
  Snapshots  1 updated
```

#### Full Test Suite execution results (`npm test`):
```
> jammusic@2.18.1 test
> npm run test:lint && npm run typecheck && npm run jscpd && npm run test:unit

...
Found 31 clones.
time: 14.176ms

Test Files  69 passed (69)
     Tests  525 passed (525)
```

🤖 Work by agy — Gemini 3.5 Flash (Medium)