### PR TITLE
Displays errors from tour CRUD

### DIFF
--- a/src/containers/Music/Gigs/CreateGigDialog.tsx
+++ b/src/containers/Music/Gigs/CreateGigDialog.tsx
@@ -62,7 +62,7 @@ export function CreateGigDialog({
         finalVenueId = newVenue._id;
       }
 
-      await utils.createGig(
+      const success = await utils.createGig(
         getGigs,
         setShowDialog,
         dateTime,
@@ -75,13 +75,15 @@ export function CreateGigDialog({
         promoImageUrl,
         finalVenueId,
       );
-      // Reset form states
-      setVenue('');
-      setSelectedVenue(null);
-      setInlineName('');
-      setInlineCity('');
-      setInlineState('Virginia');
-      setPath('existing');
+      if (success) {
+        // Reset form states
+        setVenue('');
+        setSelectedVenue(null);
+        setInlineName('');
+        setInlineCity('');
+        setInlineState('Virginia');
+        setPath('existing');
+      }
     } catch (err) {
       console.error('Failed to create gig:', err);
     }

--- a/src/containers/Music/Gigs/EditGigDialog.tsx
+++ b/src/containers/Music/Gigs/EditGigDialog.tsx
@@ -106,8 +106,10 @@ export function EditGigDialog(props: IeditGigDialogProps) {
         usState: '',
       };
 
-      await utils.updateGig(getGigs, setEditGig, setEditChanged, updatedGig, auth.token);
-      setShowDialog(false);
+      const success = await utils.updateGig(getGigs, setEditGig, setEditChanged, updatedGig, auth.token);
+      if (success) {
+        setShowDialog(false);
+      }
     } catch (err) {
       console.error('Failed to update gig:', err);
     }

--- a/src/containers/Music/Gigs/gigs.utils.tsx
+++ b/src/containers/Music/Gigs/gigs.utils.tsx
@@ -22,7 +22,7 @@ const createGig = async (
   duration: number,
   promoImageUrl: string,
   venueId?: string | null,
-) => {
+): Promise<boolean> => {
   try {
     const { token } = auth;
     const gig = {
@@ -35,10 +35,26 @@ const createGig = async (
       secure: process.env.SOCKETCLUSTER_SECURE !== 'false',
     });
     socket.transmit('newGig', { gig, token });
+    const waitForError = async (): Promise<string | undefined> => {
+      const { value } = await socket.receiver('socketError').createConsumer().next();
+      return (value as { newGig?: string } | undefined)?.newGig;
+    };
+    const errorMessage = await Promise.race<string | undefined>([
+      waitForError(),
+      commonUtils.delay(2) as Promise<string | undefined>,
+    ]);
+    socket.disconnect();
+    if (errorMessage) {
+      commonUtils.notify('Error creating gig', errorMessage, 'danger');
+      return false;
+    }
     setShowDialog(false);
-    await commonUtils.delay(2);
     getGigs();
-  } catch (err) { console.log((err as Error).message); }
+    return true;
+  } catch (err) {
+    commonUtils.notify('Error creating gig', (err as Error).message, 'danger');
+    return false;
+  }
 };
 
 const updateGig = async (
@@ -47,7 +63,7 @@ const updateGig = async (
   setEditChanged: (arg0: boolean) => void,
   editGig: typeof defaultGig,
   token: string,
-) => {
+): Promise<boolean> => {
   try {
     const gig: Igig = { ...editGig, artist: 'josh' };
     delete gig.date;
@@ -64,11 +80,27 @@ const updateGig = async (
       secure: process.env.SOCKETCLUSTER_SECURE !== 'false',
     });
     socket.transmit('editGig', { gigId: editGig._id, gig, token });
+    const waitForError = async (): Promise<string | undefined> => {
+      const { value } = await socket.receiver('socketError').createConsumer().next();
+      return (value as { editGig?: string } | undefined)?.editGig;
+    };
+    const errorMessage = await Promise.race<string | undefined>([
+      waitForError(),
+      commonUtils.delay(2) as Promise<string | undefined>,
+    ]);
+    socket.disconnect();
+    if (errorMessage) {
+      commonUtils.notify('Error updating gig', errorMessage, 'danger');
+      return false;
+    }
     setEditGig(defaultGig);
     setEditChanged(false);
-    await commonUtils.delay(2);
     getGigs();
-  } catch (err) { console.log((err as Error).message); }
+    return true;
+  } catch (err) {
+    commonUtils.notify('Error updating gig', (err as Error).message, 'danger');
+    return false;
+  }
 };
 
 const clickToEdit = (
@@ -143,12 +175,27 @@ async function deleteGig(
       });
       const gig = { gigId };
       socket.transmit('deleteGig', { gig, token });
-      await commonUtils.delay(2);
+      const waitForError = async (): Promise<string | undefined> => {
+        const { value } = await socket.receiver('socketError').createConsumer().next();
+        return (value as { deleteGig?: string } | undefined)?.deleteGig;
+      };
+      const errorMessage = await Promise.race<string | undefined>([
+        waitForError(),
+        commonUtils.delay(2) as Promise<string | undefined>,
+      ]);
+      socket.disconnect();
+      if (errorMessage) {
+        commonUtils.notify('Error deleting gig', errorMessage, 'danger');
+        return false;
+      }
       setEditGig(defaultGig);
       setEditChanged(false);
       getGigs();
       return true;
-    } catch (err) { console.log((err as Error)); return false; }
+    } catch (err) {
+      commonUtils.notify('Error deleting gig', (err as Error).message, 'danger');
+      return false;
+    }
   } return false;
 }
 

--- a/test/containers/Music/Gigs/CreateGigDialog.spec.tsx
+++ b/test/containers/Music/Gigs/CreateGigDialog.spec.tsx
@@ -49,7 +49,7 @@ describe('CreateGigDialog', () => {
       { _id: 'v2', name: 'Venue 2 NoWebsite', city: 'Raleigh', usState: 'North Carolina', status: 'active' },
       { _id: 'v3', name: 'Archived Venue', status: 'archived' },
     ]);
-    const createGigSpy = vi.spyOn(utils, 'createGig').mockResolvedValue();
+    const createGigSpy = vi.spyOn(utils, 'createGig').mockResolvedValue(true);
     const setShowDialog = vi.fn();
 
     render(
@@ -97,7 +97,7 @@ describe('CreateGigDialog', () => {
   it('handles new venue path (creation)', async () => {
     vi.spyOn(adminVenuesUtils, 'listVenues').mockResolvedValue([]);
     const createVenueSpy = vi.spyOn(adminVenuesUtils, 'createVenue').mockResolvedValue({ _id: 'new-venue-123' } as any);
-    const createGigSpy = vi.spyOn(utils, 'createGig').mockResolvedValue();
+    const createGigSpy = vi.spyOn(utils, 'createGig').mockResolvedValue(true);
     const setShowDialog = vi.fn();
 
     render(
@@ -144,7 +144,7 @@ describe('CreateGigDialog', () => {
 
   it('handles no venue path (one-off)', async () => {
     vi.spyOn(adminVenuesUtils, 'listVenues').mockResolvedValue([]);
-    const createGigSpy = vi.spyOn(utils, 'createGig').mockResolvedValue();
+    const createGigSpy = vi.spyOn(utils, 'createGig').mockResolvedValue(true);
     const setShowDialog = vi.fn();
 
     render(

--- a/test/containers/Music/Gigs/EditGigDialog.spec.tsx
+++ b/test/containers/Music/Gigs/EditGigDialog.spec.tsx
@@ -59,7 +59,7 @@ describe('EditGigDialog', () => {
 
   it('handles existing venue path (initial match, website rendering, update)', async () => {
     const listVenuesSpy = vi.spyOn(adminVenuesUtils, 'listVenues').mockResolvedValue(activeVenues);
-    const updateSpy = vi.spyOn(utils, 'updateGig').mockResolvedValue();
+    const updateSpy = vi.spyOn(utils, 'updateGig').mockResolvedValue(true);
     const setEditGig = vi.fn();
     const setShowDialog = vi.fn();
 
@@ -115,7 +115,7 @@ describe('EditGigDialog', () => {
   it('handles new inline venue path (creation and update)', async () => {
     vi.spyOn(adminVenuesUtils, 'listVenues').mockResolvedValue(activeVenues);
     const createVenueSpy = vi.spyOn(adminVenuesUtils, 'createVenue').mockResolvedValue({ _id: 'new-venue-123' } as any);
-    const updateSpy = vi.spyOn(utils, 'updateGig').mockResolvedValue();
+    const updateSpy = vi.spyOn(utils, 'updateGig').mockResolvedValue(true);
 
     const editGig = {
       _id: 'gig123',
@@ -171,7 +171,7 @@ describe('EditGigDialog', () => {
 
   it('handles no venue path (one-off selection & clear selected venue)', async () => {
     vi.spyOn(adminVenuesUtils, 'listVenues').mockResolvedValue(activeVenues);
-    const updateSpy = vi.spyOn(utils, 'updateGig').mockResolvedValue();
+    const updateSpy = vi.spyOn(utils, 'updateGig').mockResolvedValue(true);
 
     const editGig = {
       _id: 'gig123',

--- a/test/containers/Music/Gigs/gigs.utils.spec.tsx
+++ b/test/containers/Music/Gigs/gigs.utils.spec.tsx
@@ -1,3 +1,4 @@
+import scc from 'socketcluster-client';
 import utils from 'src/containers/Music/Gigs/gigs.utils';
 import commonUtils from 'src/lib/utils';
 import type { Iauth } from 'src/providers/Auth.provider';
@@ -59,10 +60,34 @@ describe('gigs.utils', () => {
   it('deleteGig successful', async () => {
     commonUtils.delay = vi.fn();
     global.confirm = vi.fn(() => true);
+    const transmit = vi.fn();
+    const disconnect = vi.fn();
+    const next = vi.fn(() => new Promise(() => { /* never resolves */ }));
+    const receiver = vi.fn(() => ({ createConsumer: () => ({ next }) }));
+    scc.create = vi.fn(() => ({ transmit, receiver, disconnect })) as any;
+
     const result = await utils.deleteGig('id', vi.fn(), vi.fn(), vi.fn(), 'token');
     expect(result).toBe(true);
+    expect(disconnect).toHaveBeenCalled();
   });
-  it('deleteGig returns false', async () => {
+  it('deleteGig surfaces a backend socketError', async () => {
+    commonUtils.delay = vi.fn(() => new Promise(() => { /* never resolves */ }));
+    commonUtils.notify = vi.fn();
+    global.confirm = vi.fn(() => true);
+    const transmit = vi.fn();
+    const disconnect = vi.fn();
+    const next = vi.fn(() => Promise.resolve({ value: { deleteGig: 'Delete failed' }, done: true }));
+    const receiver = vi.fn(() => ({ createConsumer: () => ({ next }) }));
+    scc.create = vi.fn(() => ({ transmit, receiver, disconnect })) as any;
+
+    const getGigs = vi.fn();
+    const result = await utils.deleteGig('id', getGigs, vi.fn(), vi.fn(), 'token');
+    expect(result).toBe(false);
+    expect(commonUtils.notify).toHaveBeenCalledWith('Error deleting gig', 'Delete failed', 'danger');
+    expect(getGigs).not.toHaveBeenCalled();
+    expect(disconnect).toHaveBeenCalled();
+  });
+  it('deleteGig returns false on confirm cancel', async () => {
     commonUtils.delay = vi.fn();
     global.confirm = vi.fn(() => false);
     const result = await utils.deleteGig('id', vi.fn(), vi.fn(), vi.fn(), 'token');
@@ -70,34 +95,91 @@ describe('gigs.utils', () => {
   });
   it('deleteGig catches error', async () => {
     const getGigs = vi.fn();
+    commonUtils.notify = vi.fn();
     commonUtils.delay = vi.fn(() => Promise.reject(new Error('failed')));
     global.confirm = vi.fn(() => true);
-    await utils.deleteGig('id', getGigs, vi.fn(), vi.fn(), 'token');
+    const result = await utils.deleteGig('id', getGigs, vi.fn(), vi.fn(), 'token');
+    expect(result).toBe(false);
     expect(getGigs).not.toHaveBeenCalled();
+    expect(commonUtils.notify).toHaveBeenCalledWith('Error deleting gig', 'failed', 'danger');
   });
   it('updateGig successful', async () => {
     commonUtils.delay = vi.fn();
     const getGigs = vi.fn();
-    await utils.updateGig(getGigs, vi.fn(), vi.fn(), {} as any, 'token');
+    const transmit = vi.fn();
+    const disconnect = vi.fn();
+    const next = vi.fn(() => new Promise(() => { /* never resolves */ }));
+    const receiver = vi.fn(() => ({ createConsumer: () => ({ next }) }));
+    scc.create = vi.fn(() => ({ transmit, receiver, disconnect })) as any;
+
+    const result = await utils.updateGig(getGigs, vi.fn(), vi.fn(), {} as any, 'token');
+    expect(result).toBe(true);
     expect(getGigs).toHaveBeenCalled();
+    expect(disconnect).toHaveBeenCalled();
+  });
+  it('updateGig surfaces a backend socketError', async () => {
+    commonUtils.delay = vi.fn(() => new Promise(() => { /* never resolves */ }));
+    commonUtils.notify = vi.fn();
+    const transmit = vi.fn();
+    const disconnect = vi.fn();
+    const next = vi.fn(() => Promise.resolve({ value: { editGig: 'Update failed' }, done: true }));
+    const receiver = vi.fn(() => ({ createConsumer: () => ({ next }) }));
+    scc.create = vi.fn(() => ({ transmit, receiver, disconnect })) as any;
+
+    const getGigs = vi.fn();
+    const result = await utils.updateGig(getGigs, vi.fn(), vi.fn(), {} as any, 'token');
+    expect(result).toBe(false);
+    expect(commonUtils.notify).toHaveBeenCalledWith('Error updating gig', 'Update failed', 'danger');
+    expect(getGigs).not.toHaveBeenCalled();
+    expect(disconnect).toHaveBeenCalled();
   });
   it('updateGig catches error', async () => {
     commonUtils.delay = vi.fn(() => Promise.reject(new Error('failed')));
+    commonUtils.notify = vi.fn();
     const getGigs = vi.fn();
-    await utils.updateGig(getGigs, vi.fn(), vi.fn(), {} as any, 'token');
+    const result = await utils.updateGig(getGigs, vi.fn(), vi.fn(), {} as any, 'token');
+    expect(result).toBe(false);
     expect(getGigs).not.toHaveBeenCalled();
+    expect(commonUtils.notify).toHaveBeenCalledWith('Error updating gig', 'failed', 'danger');
   });
   it('createGig successful', async () => {
     commonUtils.delay = vi.fn();
     const getGigs = vi.fn();
-    await utils.createGig(getGigs, vi.fn(), new Date(), 'item', 'item', 'item', 'item', { token: 'token' } as Iauth, 0, '');
+    const transmit = vi.fn();
+    const disconnect = vi.fn();
+    const next = vi.fn(() => new Promise(() => { /* never resolves */ }));
+    const receiver = vi.fn(() => ({ createConsumer: () => ({ next }) }));
+    scc.create = vi.fn(() => ({ transmit, receiver, disconnect })) as any;
+
+    const result = await utils.createGig(getGigs, vi.fn(), new Date(), 'item', 'item', 'item', 'item', { token: 'token' } as Iauth, 0, '');
+    expect(result).toBe(true);
     expect(getGigs).toHaveBeenCalled();
+    expect(disconnect).toHaveBeenCalled();
+  });
+  it('createGig surfaces a backend socketError', async () => {
+    commonUtils.delay = vi.fn(() => new Promise(() => { /* never resolves */ }));
+    commonUtils.notify = vi.fn();
+    const transmit = vi.fn();
+    const disconnect = vi.fn();
+    const next = vi.fn(() => Promise.resolve({ value: { newGig: 'Create failed' }, done: true }));
+    const receiver = vi.fn(() => ({ createConsumer: () => ({ next }) }));
+    scc.create = vi.fn(() => ({ transmit, receiver, disconnect })) as any;
+
+    const getGigs = vi.fn();
+    const result = await utils.createGig(getGigs, vi.fn(), new Date(), 'item', 'item', 'item', 'item', { token: 'token' } as Iauth, 0, '');
+    expect(result).toBe(false);
+    expect(commonUtils.notify).toHaveBeenCalledWith('Error creating gig', 'Create failed', 'danger');
+    expect(getGigs).not.toHaveBeenCalled();
+    expect(disconnect).toHaveBeenCalled();
   });
   it('createGig catches error', async () => {
     commonUtils.delay = vi.fn(() => Promise.reject(new Error('failed')));
+    commonUtils.notify = vi.fn();
     const getGigs = vi.fn();
-    await utils.createGig(getGigs, vi.fn(), new Date(), 'item', 'item', 'item', 'item', { token: 'token' } as Iauth, 0, '');
+    const result = await utils.createGig(getGigs, vi.fn(), new Date(), 'item', 'item', 'item', 'item', { token: 'token' } as Iauth, 0, '');
+    expect(result).toBe(false);
     expect(getGigs).not.toHaveBeenCalled();
+    expect(commonUtils.notify).toHaveBeenCalledWith('Error creating gig', 'failed', 'danger');
   });
   it('checkUpdateDisabled', () => {
     const editGig = {


### PR DESCRIPTION
## Summary
- Integrated 'socketError' event listeners using Promise.race in createGig, updateGig, and deleteGig utilities to capture real-time database and validation errors.
- Displayed captured validation and DB errors to the user via commonUtils.notify danger toasts.
- Refactored form state handling so that dialogs remain open and input values are preserved upon validation failures.
- Updated package.json and ran update-snapshots to synchronize versions.

Part of #339

## How to test locally
Updated vitest specs for create/update/delete gig functions in gigs.utils.spec.tsx to cover socketError events, and updated component spec suites to align with new boolean-success return values. Verified the entire linting and testing pipeline passes.

## Test evidence
```
Test Files  69 passed (69)
     Tests  528 passed (528)
 Snapshots  1 updated
  Start at  09:03:22
  Duration  26.51s
```

🤖 Work by agy — Gemini 3.5 Flash (High)
