### PR TITLE
AdminVenues: gigInterval + resumeBooking inputs; bookingStatus becomes read-only badge; drop manual booking/doNotContact controls

### DIFF
--- a/src/containers/AdminVenues/EditVenueDialog.tsx
+++ b/src/containers/AdminVenues/EditVenueDialog.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import {
   Dialog, DialogTitle, DialogContent, DialogActions,
   Button, Typography, FormGroup, FormControlLabel, Checkbox, FormControl, InputLabel, Select, MenuItem, TextField,
-  Autocomplete, CircularProgress,
+  Autocomplete, CircularProgress, Box, Chip,
 } from '@mui/material';
 import adminVenuesUtils, {
   VENUE_TYPES, BOOKING_STATUSES, RELATIONSHIP_STAGES, ORIGINALS_FITS, TRAVEL_BANDS, FIELD_HELP,
@@ -241,6 +241,8 @@ export function EditVenueDialog({
           originalsFit: venue.originalsFit || '',
           travelBand: venue.travelBand || '',
           priority: venue.priority ?? undefined,
+          gigInterval: venue.gigInterval ?? 0,
+          resumeBooking: venue.resumeBooking ? venue.resumeBooking.substring(0, 10) : '',
         });
       } else {
         // Safe defaults for hand-added venues
@@ -268,6 +270,8 @@ export function EditVenueDialog({
           originalsFit: '',
           travelBand: '',
           priority: undefined,
+          gigInterval: 0,
+          resumeBooking: '',
         });
       }
       setError('');
@@ -341,7 +345,10 @@ export function EditVenueDialog({
       venueType: form.venueType || undefined,
       website: websiteUrl,
       country: currentCountry,
+      gigInterval: typeof form.gigInterval === 'number' ? form.gigInterval : 0,
+      resumeBooking: form.resumeBooking || null,
     };
+    delete finalForm.bookingStatus;
     if (currentCountry === 'US') {
       finalForm.region = '';
     } else {
@@ -558,14 +565,47 @@ export function EditVenueDialog({
           </Select>
         </FormControl>
         <Help field="venueType" />
-        <FormControl fullWidth sx={{ marginBottom: 2 }}>
-          <InputLabel id="edit-venue-booking-label">Booking Status</InputLabel>
-          <Select labelId="edit-venue-booking-label" label="Booking Status" value={form.bookingStatus || 'booking'}
-            onChange={(e) => set('bookingStatus', e.target.value)} data-testid="edit-venue-booking">
-            {BOOKING_STATUSES.map((s) => (<MenuItem key={s} value={s}>{s}</MenuItem>))}
-          </Select>
-        </FormControl>
+        <Box sx={{ marginBottom: 2, display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+          <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 'bold' }}>
+            Booking Status (Read-Only)
+          </Typography>
+          <Box>
+            <Chip
+              label={form.bookingStatus || 'booking'}
+              color={
+                form.bookingStatus === 'booked' ? 'success' :
+                form.bookingStatus === 'not-booking' ? 'error' : 'default'
+              }
+              variant="outlined"
+              data-testid="edit-venue-booking-readonly"
+            />
+          </Box>
+        </Box>
         <Help field="bookingStatus" />
+
+        <TextField
+          label="Gig Interval (months)"
+          type="number"
+          fullWidth
+          slotProps={{ htmlInput: { min: 0 } }}
+          value={form.gigInterval ?? 0}
+          onChange={(e) => set('gigInterval', e.target.value === '' ? 0 : Number(e.target.value))}
+          sx={{ marginBottom: 2 }}
+          data-testid="edit-venue-giginterval"
+        />
+        <Help field="gigInterval" />
+
+        <TextField
+          label="Resume Booking Date"
+          type="date"
+          fullWidth
+          slotProps={{ inputLabel: { shrink: true } }}
+          value={form.resumeBooking || ''}
+          onChange={(e) => set('resumeBooking', e.target.value || null)}
+          sx={{ marginBottom: 2 }}
+          data-testid="edit-venue-resumebooking"
+        />
+        <Help field="resumeBooking" />
         <FormControl fullWidth sx={{ marginBottom: 2 }}>
           <InputLabel id="edit-venue-stage-label">Relationship Stage</InputLabel>
           <Select labelId="edit-venue-stage-label" label="Relationship Stage" value={form.relationshipStage || ''}

--- a/src/containers/AdminVenues/admin-venues.utils.ts
+++ b/src/containers/AdminVenues/admin-venues.utils.ts
@@ -37,6 +37,8 @@ export interface Ivenue {
   originalsFit?: string;
   travelBand?: string;
   priority?: number;
+  gigInterval?: number;
+  resumeBooking?: string | null;
 }
 
 export interface IvenueUpdate {
@@ -66,6 +68,8 @@ export interface IvenueUpdate {
   status?: string;
   lastContacted?: string;
   lastVerified?: string;
+  gigInterval?: number;
+  resumeBooking?: string | null;
 }
 
 const venueUrl = `${process.env.BackendUrl}/venue`;
@@ -151,6 +155,9 @@ export const FIELD_HELP: Record<string, string> = {
   originalsFit: 'How much the venue welcomes ORIGINAL music — the heaviest factor in the default Prospect sort (loves > some > none).',
   travelBand: 'Coarse distance from Salem, VA. Farther venues are discounted in the Prospect sort (local > regional > far).',
   priority: 'Manual 0–5 boost to nudge a venue up or down the default Prospect sort, regardless of the other factors.',
+  gigInterval: 'Minimum gap between gigs at this venue in months (default 0). '
+    + 'Ensures outreach is paused if a gig is already scheduled too close to the target window.',
+  resumeBooking: 'Cooldown date: outreach is paused/cooldown is active until this date passes (null/unset = no cooldown).',
 };
 
 // Map a free-text pay note to a 0–3 value for the Prospect Score: count the

--- a/test/containers/AdminVenues/EditVenueDialog.spec.tsx
+++ b/test/containers/AdminVenues/EditVenueDialog.spec.tsx
@@ -65,9 +65,19 @@ describe('EditVenueDialog', () => {
     await act(async () => { render(<EditVenueDialog open venue={venue} token="tk" onClose={vi.fn()} onSaved={onSaved} />); });
     await act(async () => { fireEvent.click(screen.getByTestId('edit-venue-save')); });
     expect(adminVenuesUtils.updateVenue).toHaveBeenCalledWith('tk', 'v1', expect.objectContaining({
-      name: 'Mac n Bob', bookingStatus: 'booking',
+      name: 'Mac n Bob',
     }));
     expect(onSaved).toHaveBeenCalled();
+  });
+
+  it('saves gigInterval and resumeBooking inputs', async () => {
+    await act(async () => { render(<EditVenueDialog open venue={venue} token="tk" onClose={vi.fn()} onSaved={vi.fn()} />); });
+    await act(async () => { fireEvent.change(screen.getByTestId('edit-venue-giginterval'), { target: { value: '3' } }); });
+    await act(async () => { fireEvent.change(screen.getByTestId('edit-venue-resumebooking'), { target: { value: '2026-11-20' } }); });
+    await act(async () => { fireEvent.click(screen.getByTestId('edit-venue-save')); });
+    expect(adminVenuesUtils.updateVenue).toHaveBeenCalledWith('tk', 'v1', expect.objectContaining({
+      gigInterval: 3, resumeBooking: '2026-11-20',
+    }));
   });
 
   it('saves the relationshipStage + templateOverride selections (#1136)', async () => {


### PR DESCRIPTION
## Summary
- Replace bookingStatus select dropdown in EditVenueDialog with a read-only visual badge display.
- Add gigInterval input (numeric, non-negative) to edit/create forms.
- Add resumeBooking input (date format) to edit/create forms.
- Map gigInterval and resumeBooking correctly into payload formatting on save.
- Add tooltips/help text explaining gigInterval and resumeBooking fields.

Closes #1237

## How to test locally
Verify component initialization and payload formatting on save. Assert inputs are validated and correctly bound to properties. Execute vitest unit tests.

## Test evidence
```
✓ test/containers/AdminVenues/EditVenueDialog.spec.tsx (24 tests)
✓ test/containers/AdminVenues/VenuesTable.spec.tsx (20 tests)
✓ test/containers/AdminVenues/index.spec.tsx (13 tests)

 Test Files  4 passed (4)
      Tests  70 passed (70)
```

🤖 Work by agy — Gemini 3.5 Flash (Medium)