### PR TITLE
Gigs CRUD result deterministically: race socketError vs the success publish (drop the 2s timeout guess)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.18.2",
+  "version": "2.18.3",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/Music/Gigs/CreateGigDialog.tsx
+++ b/src/containers/Music/Gigs/CreateGigDialog.tsx
@@ -62,7 +62,7 @@ export function CreateGigDialog({
         finalVenueId = newVenue._id;
       }
 
-      const success = await utils.createGig(
+      const result = await utils.createGig(
         getGigs,
         setShowDialog,
         dateTime,
@@ -75,7 +75,7 @@ export function CreateGigDialog({
         promoImageUrl,
         finalVenueId,
       );
-      if (success) {
+      if (result === 'success' || result === 'unconfirmed') {
         // Reset form states
         setVenue('');
         setSelectedVenue(null);

--- a/src/containers/Music/Gigs/EditGigDialog.tsx
+++ b/src/containers/Music/Gigs/EditGigDialog.tsx
@@ -106,8 +106,8 @@ export function EditGigDialog(props: IeditGigDialogProps) {
         usState: '',
       };
 
-      const success = await utils.updateGig(getGigs, setEditGig, setEditChanged, updatedGig, auth.token);
-      if (success) {
+      const result = await utils.updateGig(getGigs, setEditGig, setEditChanged, updatedGig, auth.token);
+      if (result === 'success' || result === 'unconfirmed') {
         setShowDialog(false);
       }
     } catch (err) {
@@ -345,9 +345,12 @@ export function EditGigDialog(props: IeditGigDialogProps) {
           size="small"
           className="deleteGigButton"
           sx={{ color: 'red' }}
-          onClick={() => {
+          onClick={async () => {
             setEditChanged(false);
-            utils.deleteGig(editGig._id || '', getGigs, setEditGig, setEditChanged, auth.token);
+            const result = await utils.deleteGig(editGig._id || '', getGigs, setEditGig, setEditChanged, auth.token);
+            if (result === 'success' || result === 'unconfirmed') {
+              setShowDialog(false);
+            }
           }}
         >
           Delete

--- a/src/containers/Music/Gigs/gigs.utils.tsx
+++ b/src/containers/Music/Gigs/gigs.utils.tsx
@@ -7,6 +7,8 @@ import type { Iauth } from 'src/providers/Auth.provider';
 import type { Igig } from 'src/providers/Data.provider';
 import { defaultGig } from 'src/providers/fetchGigs';
 
+export type GigOpResult = 'success' | 'error' | 'unconfirmed';
+
 // eslint-disable-next-line max-len
 const usStateOptions = ['Alabama', 'Alaska', 'American Samoa', 'Arizona', 'Arkansas', 'California', 'Colorado', 'Connecticut', 'Delaware', 'District of Columbia', 'Federated States of Micronesia', 'Florida', 'Georgia', 'Guam', 'Hawaii', 'Idaho', 'Illinois', 'Indiana', 'Iowa', 'Kansas', 'Kentucky', 'Louisiana', 'Maine', 'Marshall Islands', 'Maryland', 'Massachusetts', 'Michigan', 'Minnesota', 'Mississippi', 'Missouri', 'Montana', 'Nebraska', 'Nevada', 'New Hampshire', 'New Jersey', 'New Mexico', 'New York', 'North Carolina', 'North Dakota', 'Northern Mariana Islands', 'Ohio', 'Oklahoma', 'Oregon', 'Palau', 'Pennsylvania', 'Puerto Rico', 'Rhode Island', 'South Carolina', 'South Dakota', 'Tennessee', 'Texas', 'Utah', 'Vermont', 'Virgin Island', 'Virginia', 'Washington', 'West Virginia', 'Wisconsin', 'Wyoming'];
 
@@ -22,38 +24,70 @@ const createGig = async (
   duration: number,
   promoImageUrl: string,
   venueId?: string | null,
-): Promise<boolean> => {
+): Promise<GigOpResult> => {
+  let socket: scc.AGClientSocket | undefined;
   try {
     const { token } = auth;
     const gig = {
       datetime, venue, tickets, city, usState, duration, promoImageUrl, artist: 'josh', venueId: venueId || undefined,
     };
-    const socket = scc.create({
+    socket = scc.create({
       hostname: process.env.SCS_HOST,
       port: Number(process.env.SCS_PORT),
       autoConnect: true,
       secure: process.env.SOCKETCLUSTER_SECURE !== 'false',
     });
+
+    const errorConsumer = socket.receiver('socketError').createConsumer();
+    const successConsumer = socket.subscribe('gigCreated').createConsumer();
+
     socket.transmit('newGig', { gig, token });
-    const waitForError = async (): Promise<string | undefined> => {
-      const { value } = await socket.receiver('socketError').createConsumer().next();
-      return (value as { newGig?: string } | undefined)?.newGig;
+
+    const waitForError = async (): Promise<{ kind: 'error'; message: string }> => {
+      const { value } = await errorConsumer.next();
+      const msg = (value as { newGig?: string; message?: string } | undefined)?.newGig
+        || (value as { message?: string } | undefined)?.message;
+      return { kind: 'error', message: msg || 'Unknown error' };
     };
-    const errorMessage = await Promise.race<string | undefined>([
+
+    // Note: Success channels are broadcast and don't include an op correlation ID;
+    // the consumer treats the next broadcast as this op's result.
+    const waitForSuccess = async (): Promise<{ kind: 'success' }> => {
+      await successConsumer.next();
+      return { kind: 'success' };
+    };
+
+    const waitForTimeout = async (): Promise<{ kind: 'timeout' }> => {
+      await commonUtils.delay(5);
+      return { kind: 'timeout' };
+    };
+
+    const result = await Promise.race([
       waitForError(),
-      commonUtils.delay(2) as Promise<string | undefined>,
+      waitForSuccess(),
+      waitForTimeout(),
     ]);
-    socket.disconnect();
-    if (errorMessage) {
-      commonUtils.notify('Error creating gig', errorMessage, 'danger');
-      return false;
+
+    if (result.kind === 'error') {
+      commonUtils.notify('Error creating gig', result.message, 'danger');
+      return 'error';
     }
+
+    if (result.kind === 'success') {
+      setShowDialog(false);
+      getGigs();
+      return 'success';
+    }
+
     setShowDialog(false);
     getGigs();
-    return true;
+    commonUtils.notify('Create gig', "Couldn't confirm — list refreshed", 'info');
+    return 'unconfirmed';
   } catch (err) {
     commonUtils.notify('Error creating gig', (err as Error).message, 'danger');
-    return false;
+    return 'error';
+  } finally {
+    if (socket) socket.disconnect();
   }
 };
 
@@ -63,7 +97,8 @@ const updateGig = async (
   setEditChanged: (arg0: boolean) => void,
   editGig: typeof defaultGig,
   token: string,
-): Promise<boolean> => {
+): Promise<GigOpResult> => {
+  let socket: scc.AGClientSocket | undefined;
   try {
     const gig: Igig = { ...editGig, artist: 'josh' };
     delete gig.date;
@@ -73,33 +108,65 @@ const updateGig = async (
     if (gig.venueId && typeof gig.venueId === 'object') {
       gig.venueId = gig.venueId._id;
     }
-    const socket = scc.create({
+    socket = scc.create({
       hostname: process.env.SCS_HOST,
       port: Number(process.env.SCS_PORT),
       autoConnect: true,
       secure: process.env.SOCKETCLUSTER_SECURE !== 'false',
     });
+
+    const errorConsumer = socket.receiver('socketError').createConsumer();
+    const successConsumer = socket.subscribe('gigUpdated').createConsumer();
+
     socket.transmit('editGig', { gigId: editGig._id, gig, token });
-    const waitForError = async (): Promise<string | undefined> => {
-      const { value } = await socket.receiver('socketError').createConsumer().next();
-      return (value as { editGig?: string } | undefined)?.editGig;
+
+    const waitForError = async (): Promise<{ kind: 'error'; message: string }> => {
+      const { value } = await errorConsumer.next();
+      const msg = (value as { editGig?: string; message?: string } | undefined)?.editGig
+        || (value as { message?: string } | undefined)?.message;
+      return { kind: 'error', message: msg || 'Unknown error' };
     };
-    const errorMessage = await Promise.race<string | undefined>([
+
+    // Note: Success channels are broadcast and don't include an op correlation ID;
+    // the consumer treats the next broadcast as this op's result.
+    const waitForSuccess = async (): Promise<{ kind: 'success' }> => {
+      await successConsumer.next();
+      return { kind: 'success' };
+    };
+
+    const waitForTimeout = async (): Promise<{ kind: 'timeout' }> => {
+      await commonUtils.delay(5);
+      return { kind: 'timeout' };
+    };
+
+    const result = await Promise.race([
       waitForError(),
-      commonUtils.delay(2) as Promise<string | undefined>,
+      waitForSuccess(),
+      waitForTimeout(),
     ]);
-    socket.disconnect();
-    if (errorMessage) {
-      commonUtils.notify('Error updating gig', errorMessage, 'danger');
-      return false;
+
+    if (result.kind === 'error') {
+      commonUtils.notify('Error updating gig', result.message, 'danger');
+      return 'error';
     }
+
+    if (result.kind === 'success') {
+      setEditGig(defaultGig);
+      setEditChanged(false);
+      getGigs();
+      return 'success';
+    }
+
     setEditGig(defaultGig);
     setEditChanged(false);
     getGigs();
-    return true;
+    commonUtils.notify('Update gig', "Couldn't confirm — list refreshed", 'info');
+    return 'unconfirmed';
   } catch (err) {
     commonUtils.notify('Error updating gig', (err as Error).message, 'danger');
-    return false;
+    return 'error';
+  } finally {
+    if (socket) socket.disconnect();
   }
 };
 
@@ -163,40 +230,74 @@ async function deleteGig(
   setEditGig: (arg0: typeof defaultGig) => void,
   setEditChanged: (arg0: boolean) => void,
   token: string,
-): Promise<boolean> { // eslint-disable-next-line no-restricted-globals
+): Promise<GigOpResult> { // eslint-disable-next-line no-restricted-globals
   const result = confirm('Deleting Gig, are you sure?');// eslint-disable-line no-alert
   if (result) {
+    let socket: scc.AGClientSocket | undefined;
     try {
-      const socket = scc.create({
+      socket = scc.create({
         hostname: process.env.SCS_HOST,
         port: Number(process.env.SCS_PORT),
         autoConnect: true,
         secure: process.env.SOCKETCLUSTER_SECURE !== 'false',
       });
       const gig = { gigId };
+
+      const errorConsumer = socket.receiver('socketError').createConsumer();
+      const successConsumer = socket.subscribe('gigDeleted').createConsumer();
+
       socket.transmit('deleteGig', { gig, token });
-      const waitForError = async (): Promise<string | undefined> => {
-        const { value } = await socket.receiver('socketError').createConsumer().next();
-        return (value as { deleteGig?: string } | undefined)?.deleteGig;
+
+      const waitForError = async (): Promise<{ kind: 'error'; message: string }> => {
+        const { value } = await errorConsumer.next();
+        const msg = (value as { deleteGig?: string; message?: string } | undefined)?.deleteGig
+          || (value as { message?: string } | undefined)?.message;
+        return { kind: 'error', message: msg || 'Unknown error' };
       };
-      const errorMessage = await Promise.race<string | undefined>([
+
+      // Note: Success channels are broadcast and don't include an op correlation ID;
+      // the consumer treats the next broadcast as this op's result.
+      const waitForSuccess = async (): Promise<{ kind: 'success' }> => {
+        await successConsumer.next();
+        return { kind: 'success' };
+      };
+
+      const waitForTimeout = async (): Promise<{ kind: 'timeout' }> => {
+        await commonUtils.delay(5);
+        return { kind: 'timeout' };
+      };
+
+      const res = await Promise.race([
         waitForError(),
-        commonUtils.delay(2) as Promise<string | undefined>,
+        waitForSuccess(),
+        waitForTimeout(),
       ]);
-      socket.disconnect();
-      if (errorMessage) {
-        commonUtils.notify('Error deleting gig', errorMessage, 'danger');
-        return false;
+
+      if (res.kind === 'error') {
+        commonUtils.notify('Error deleting gig', res.message, 'danger');
+        return 'error';
       }
+
+      if (res.kind === 'success') {
+        setEditGig(defaultGig);
+        setEditChanged(false);
+        getGigs();
+        return 'success';
+      }
+
       setEditGig(defaultGig);
       setEditChanged(false);
       getGigs();
-      return true;
+      commonUtils.notify('Delete gig', "Couldn't confirm — list refreshed", 'info');
+      return 'unconfirmed';
     } catch (err) {
       commonUtils.notify('Error deleting gig', (err as Error).message, 'danger');
-      return false;
+      return 'error';
+    } finally {
+      if (socket) socket.disconnect();
     }
-  } return false;
+  }
+  return 'error';
 }
 
 export const orderGigs = (

--- a/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
+++ b/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
@@ -136,7 +136,7 @@ exports[`AppTemplate > renders the component 1`] = `
             <strong>
               Version
                
-              2.18.2
+              2.18.3
             </strong>
           </div>
           <p

--- a/test/containers/Music/Gigs/CreateGigDialog.spec.tsx
+++ b/test/containers/Music/Gigs/CreateGigDialog.spec.tsx
@@ -49,7 +49,7 @@ describe('CreateGigDialog', () => {
       { _id: 'v2', name: 'Venue 2 NoWebsite', city: 'Raleigh', usState: 'North Carolina', status: 'active' },
       { _id: 'v3', name: 'Archived Venue', status: 'archived' },
     ]);
-    const createGigSpy = vi.spyOn(utils, 'createGig').mockResolvedValue(true);
+    const createGigSpy = vi.spyOn(utils, 'createGig').mockResolvedValue('success');
     const setShowDialog = vi.fn();
 
     render(
@@ -97,7 +97,7 @@ describe('CreateGigDialog', () => {
   it('handles new venue path (creation)', async () => {
     vi.spyOn(adminVenuesUtils, 'listVenues').mockResolvedValue([]);
     const createVenueSpy = vi.spyOn(adminVenuesUtils, 'createVenue').mockResolvedValue({ _id: 'new-venue-123' } as any);
-    const createGigSpy = vi.spyOn(utils, 'createGig').mockResolvedValue(true);
+    const createGigSpy = vi.spyOn(utils, 'createGig').mockResolvedValue('success');
     const setShowDialog = vi.fn();
 
     render(
@@ -144,7 +144,7 @@ describe('CreateGigDialog', () => {
 
   it('handles no venue path (one-off)', async () => {
     vi.spyOn(adminVenuesUtils, 'listVenues').mockResolvedValue([]);
-    const createGigSpy = vi.spyOn(utils, 'createGig').mockResolvedValue(true);
+    const createGigSpy = vi.spyOn(utils, 'createGig').mockResolvedValue('success');
     const setShowDialog = vi.fn();
 
     render(

--- a/test/containers/Music/Gigs/EditGigDialog.spec.tsx
+++ b/test/containers/Music/Gigs/EditGigDialog.spec.tsx
@@ -59,7 +59,7 @@ describe('EditGigDialog', () => {
 
   it('handles existing venue path (initial match, website rendering, update)', async () => {
     const listVenuesSpy = vi.spyOn(adminVenuesUtils, 'listVenues').mockResolvedValue(activeVenues);
-    const updateSpy = vi.spyOn(utils, 'updateGig').mockResolvedValue(true);
+    const updateSpy = vi.spyOn(utils, 'updateGig').mockResolvedValue('success');
     const setEditGig = vi.fn();
     const setShowDialog = vi.fn();
 
@@ -115,7 +115,7 @@ describe('EditGigDialog', () => {
   it('handles new inline venue path (creation and update)', async () => {
     vi.spyOn(adminVenuesUtils, 'listVenues').mockResolvedValue(activeVenues);
     const createVenueSpy = vi.spyOn(adminVenuesUtils, 'createVenue').mockResolvedValue({ _id: 'new-venue-123' } as any);
-    const updateSpy = vi.spyOn(utils, 'updateGig').mockResolvedValue(true);
+    const updateSpy = vi.spyOn(utils, 'updateGig').mockResolvedValue('success');
 
     const editGig = {
       _id: 'gig123',
@@ -171,7 +171,7 @@ describe('EditGigDialog', () => {
 
   it('handles no venue path (one-off selection & clear selected venue)', async () => {
     vi.spyOn(adminVenuesUtils, 'listVenues').mockResolvedValue(activeVenues);
-    const updateSpy = vi.spyOn(utils, 'updateGig').mockResolvedValue(true);
+    const updateSpy = vi.spyOn(utils, 'updateGig').mockResolvedValue('success');
 
     const editGig = {
       _id: 'gig123',
@@ -213,7 +213,7 @@ describe('EditGigDialog', () => {
 
   it('handles delete and cancel clicks', async () => {
     vi.spyOn(adminVenuesUtils, 'listVenues').mockResolvedValue([]);
-    const deleteSpy = vi.spyOn(utils, 'deleteGig').mockResolvedValue(true);
+    const deleteSpy = vi.spyOn(utils, 'deleteGig').mockResolvedValue('success');
     const setEditGig = vi.fn();
     const setShowDialog = vi.fn();
 

--- a/test/containers/Music/Gigs/gigs.utils.spec.tsx
+++ b/test/containers/Music/Gigs/gigs.utils.spec.tsx
@@ -57,138 +57,295 @@ describe('gigs.utils', () => {
     const result = venue.renderCell({ value: 'value' });
     expect(result.type).toBe('div');
   });
-  it('deleteGig successful', async () => {
-    commonUtils.delay = vi.fn();
-    global.confirm = vi.fn(() => true);
-    const transmit = vi.fn();
-    const disconnect = vi.fn();
-    const next = vi.fn(() => new Promise(() => { /* never resolves */ }));
-    const receiver = vi.fn(() => ({ createConsumer: () => ({ next }) }));
-    scc.create = vi.fn(() => ({ transmit, receiver, disconnect })) as any;
+  describe('deleteGig', () => {
+    it('deleteGig successful via gigDeleted subscribe channel', async () => {
+      commonUtils.delay = vi.fn(() => new Promise(() => { /* never resolves */ }));
+      global.confirm = vi.fn(() => true);
+      const transmit = vi.fn();
+      const disconnect = vi.fn();
+      const receiverNext = vi.fn(() => new Promise(() => { /* never resolves */ }));
+      const subscribeNext = vi.fn(() => Promise.resolve({ value: {}, done: false }));
+      const receiver = vi.fn(() => ({ createConsumer: () => ({ next: receiverNext }) }));
+      const subscribe = vi.fn(() => ({ createConsumer: () => ({ next: subscribeNext }) }));
+      scc.create = vi.fn(() => ({ transmit, receiver, subscribe, disconnect })) as any;
 
-    const result = await utils.deleteGig('id', vi.fn(), vi.fn(), vi.fn(), 'token');
-    expect(result).toBe(true);
-    expect(disconnect).toHaveBeenCalled();
-  });
-  it('deleteGig surfaces a backend socketError', async () => {
-    commonUtils.delay = vi.fn(() => new Promise(() => { /* never resolves */ }));
-    commonUtils.notify = vi.fn();
-    global.confirm = vi.fn(() => true);
-    const transmit = vi.fn();
-    const disconnect = vi.fn();
-    const next = vi.fn(() => Promise.resolve({ value: { deleteGig: 'Delete failed' }, done: true }));
-    const receiver = vi.fn(() => ({ createConsumer: () => ({ next }) }));
-    scc.create = vi.fn(() => ({ transmit, receiver, disconnect })) as any;
+      const getGigs = vi.fn();
+      const setEditGig = vi.fn();
+      const setEditChanged = vi.fn();
+      const result = await utils.deleteGig('id', getGigs, setEditGig, setEditChanged, 'token');
+      expect(result).toBe('success');
+      expect(subscribe).toHaveBeenCalledWith('gigDeleted');
+      expect(getGigs).toHaveBeenCalled();
+      expect(setEditGig).toHaveBeenCalled();
+      expect(setEditChanged).toHaveBeenCalledWith(false);
+      expect(disconnect).toHaveBeenCalled();
+    });
 
-    const getGigs = vi.fn();
-    const result = await utils.deleteGig('id', getGigs, vi.fn(), vi.fn(), 'token');
-    expect(result).toBe(false);
-    expect(commonUtils.notify).toHaveBeenCalledWith('Error deleting gig', 'Delete failed', 'danger');
-    expect(getGigs).not.toHaveBeenCalled();
-    expect(disconnect).toHaveBeenCalled();
-  });
-  it('deleteGig returns false on confirm cancel', async () => {
-    commonUtils.delay = vi.fn();
-    global.confirm = vi.fn(() => false);
-    const result = await utils.deleteGig('id', vi.fn(), vi.fn(), vi.fn(), 'token');
-    expect(result).toBe(false);
-  });
-  it('deleteGig catches error', async () => {
-    const getGigs = vi.fn();
-    commonUtils.notify = vi.fn();
-    commonUtils.delay = vi.fn(() => Promise.reject(new Error('failed')));
-    global.confirm = vi.fn(() => true);
-    const result = await utils.deleteGig('id', getGigs, vi.fn(), vi.fn(), 'token');
-    expect(result).toBe(false);
-    expect(getGigs).not.toHaveBeenCalled();
-    expect(commonUtils.notify).toHaveBeenCalledWith('Error deleting gig', 'failed', 'danger');
-  });
-  it('updateGig successful', async () => {
-    commonUtils.delay = vi.fn();
-    const getGigs = vi.fn();
-    const transmit = vi.fn();
-    const disconnect = vi.fn();
-    const next = vi.fn(() => new Promise(() => { /* never resolves */ }));
-    const receiver = vi.fn(() => ({ createConsumer: () => ({ next }) }));
-    scc.create = vi.fn(() => ({ transmit, receiver, disconnect })) as any;
+    it('deleteGig surfaces a backend socketError', async () => {
+      commonUtils.delay = vi.fn(() => new Promise(() => { /* never resolves */ }));
+      commonUtils.notify = vi.fn();
+      global.confirm = vi.fn(() => true);
+      const transmit = vi.fn();
+      const disconnect = vi.fn();
+      const receiverNext = vi.fn(() => Promise.resolve({ value: { deleteGig: 'Delete failed' }, done: false }));
+      const subscribeNext = vi.fn(() => new Promise(() => { /* never resolves */ }));
+      const receiver = vi.fn(() => ({ createConsumer: () => ({ next: receiverNext }) }));
+      const subscribe = vi.fn(() => ({ createConsumer: () => ({ next: subscribeNext }) }));
+      scc.create = vi.fn(() => ({ transmit, receiver, subscribe, disconnect })) as any;
 
-    const result = await utils.updateGig(getGigs, vi.fn(), vi.fn(), {} as any, 'token');
-    expect(result).toBe(true);
-    expect(getGigs).toHaveBeenCalled();
-    expect(disconnect).toHaveBeenCalled();
-  });
-  it('updateGig surfaces a backend socketError', async () => {
-    commonUtils.delay = vi.fn(() => new Promise(() => { /* never resolves */ }));
-    commonUtils.notify = vi.fn();
-    const transmit = vi.fn();
-    const disconnect = vi.fn();
-    const next = vi.fn(() => Promise.resolve({ value: { editGig: 'Update failed' }, done: true }));
-    const receiver = vi.fn(() => ({ createConsumer: () => ({ next }) }));
-    scc.create = vi.fn(() => ({ transmit, receiver, disconnect })) as any;
+      const getGigs = vi.fn();
+      const result = await utils.deleteGig('id', getGigs, vi.fn(), vi.fn(), 'token');
+      expect(result).toBe('error');
+      expect(commonUtils.notify).toHaveBeenCalledWith('Error deleting gig', 'Delete failed', 'danger');
+      expect(getGigs).not.toHaveBeenCalled();
+      expect(disconnect).toHaveBeenCalled();
+    });
 
-    const getGigs = vi.fn();
-    const result = await utils.updateGig(getGigs, vi.fn(), vi.fn(), {} as any, 'token');
-    expect(result).toBe(false);
-    expect(commonUtils.notify).toHaveBeenCalledWith('Error updating gig', 'Update failed', 'danger');
-    expect(getGigs).not.toHaveBeenCalled();
-    expect(disconnect).toHaveBeenCalled();
-  });
-  it('updateGig catches error', async () => {
-    commonUtils.delay = vi.fn(() => Promise.reject(new Error('failed')));
-    commonUtils.notify = vi.fn();
-    const getGigs = vi.fn();
-    const result = await utils.updateGig(getGigs, vi.fn(), vi.fn(), {} as any, 'token');
-    expect(result).toBe(false);
-    expect(getGigs).not.toHaveBeenCalled();
-    expect(commonUtils.notify).toHaveBeenCalledWith('Error updating gig', 'failed', 'danger');
-  });
-  it('createGig successful', async () => {
-    commonUtils.delay = vi.fn();
-    const getGigs = vi.fn();
-    const transmit = vi.fn();
-    const disconnect = vi.fn();
-    const next = vi.fn(() => new Promise(() => { /* never resolves */ }));
-    const receiver = vi.fn(() => ({ createConsumer: () => ({ next }) }));
-    scc.create = vi.fn(() => ({ transmit, receiver, disconnect })) as any;
+    it('deleteGig unconfirmed on timeout', async () => {
+      commonUtils.delay = vi.fn(() => Promise.resolve());
+      commonUtils.notify = vi.fn();
+      global.confirm = vi.fn(() => true);
+      const transmit = vi.fn();
+      const disconnect = vi.fn();
+      const receiverNext = vi.fn(() => new Promise(() => { /* never resolves */ }));
+      const subscribeNext = vi.fn(() => new Promise(() => { /* never resolves */ }));
+      const receiver = vi.fn(() => ({ createConsumer: () => ({ next: receiverNext }) }));
+      const subscribe = vi.fn(() => ({ createConsumer: () => ({ next: subscribeNext }) }));
+      scc.create = vi.fn(() => ({ transmit, receiver, subscribe, disconnect })) as any;
 
-    const result = await utils.createGig(getGigs, vi.fn(), new Date(), 'item', 'item', 'item', 'item', { token: 'token' } as Iauth, 0, '');
-    expect(result).toBe(true);
-    expect(getGigs).toHaveBeenCalled();
-    expect(disconnect).toHaveBeenCalled();
-  });
-  it('createGig surfaces a backend socketError', async () => {
-    commonUtils.delay = vi.fn(() => new Promise(() => { /* never resolves */ }));
-    commonUtils.notify = vi.fn();
-    const transmit = vi.fn();
-    const disconnect = vi.fn();
-    const next = vi.fn(() => Promise.resolve({ value: { newGig: 'Create failed' }, done: true }));
-    const receiver = vi.fn(() => ({ createConsumer: () => ({ next }) }));
-    scc.create = vi.fn(() => ({ transmit, receiver, disconnect })) as any;
+      const getGigs = vi.fn();
+      const setEditGig = vi.fn();
+      const setEditChanged = vi.fn();
+      const result = await utils.deleteGig('id', getGigs, setEditGig, setEditChanged, 'token');
+      expect(result).toBe('unconfirmed');
+      expect(commonUtils.notify).toHaveBeenCalledWith('Delete gig', "Couldn't confirm — list refreshed", 'info');
+      expect(commonUtils.notify).not.toHaveBeenCalledWith(expect.anything(), expect.anything(), 'danger');
+      expect(getGigs).toHaveBeenCalled();
+      expect(setEditGig).toHaveBeenCalled();
+      expect(setEditChanged).toHaveBeenCalledWith(false);
+      expect(disconnect).toHaveBeenCalled();
+    });
 
-    const getGigs = vi.fn();
-    const result = await utils.createGig(getGigs, vi.fn(), new Date(), 'item', 'item', 'item', 'item', { token: 'token' } as Iauth, 0, '');
-    expect(result).toBe(false);
-    expect(commonUtils.notify).toHaveBeenCalledWith('Error creating gig', 'Create failed', 'danger');
-    expect(getGigs).not.toHaveBeenCalled();
-    expect(disconnect).toHaveBeenCalled();
+    it('deleteGig returns error on confirm cancel', async () => {
+      commonUtils.delay = vi.fn();
+      global.confirm = vi.fn(() => false);
+      const result = await utils.deleteGig('id', vi.fn(), vi.fn(), vi.fn(), 'token');
+      expect(result).toBe('error');
+    });
+
+    it('deleteGig catches error', async () => {
+      const getGigs = vi.fn();
+      commonUtils.notify = vi.fn();
+      commonUtils.delay = vi.fn(() => Promise.reject(new Error('failed')));
+      global.confirm = vi.fn(() => true);
+      const transmit = vi.fn();
+      const disconnect = vi.fn();
+      const receiverNext = vi.fn(() => new Promise(() => { /* never resolves */ }));
+      const subscribeNext = vi.fn(() => new Promise(() => { /* never resolves */ }));
+      const receiver = vi.fn(() => ({ createConsumer: () => ({ next: receiverNext }) }));
+      const subscribe = vi.fn(() => ({ createConsumer: () => ({ next: subscribeNext }) }));
+      scc.create = vi.fn(() => ({ transmit, receiver, subscribe, disconnect })) as any;
+
+      const result = await utils.deleteGig('id', getGigs, vi.fn(), vi.fn(), 'token');
+      expect(result).toBe('error');
+      expect(getGigs).not.toHaveBeenCalled();
+      expect(commonUtils.notify).toHaveBeenCalledWith('Error deleting gig', 'failed', 'danger');
+      expect(disconnect).toHaveBeenCalled();
+    });
   });
-  it('createGig catches error', async () => {
-    commonUtils.delay = vi.fn(() => Promise.reject(new Error('failed')));
-    commonUtils.notify = vi.fn();
-    const getGigs = vi.fn();
-    const result = await utils.createGig(getGigs, vi.fn(), new Date(), 'item', 'item', 'item', 'item', { token: 'token' } as Iauth, 0, '');
-    expect(result).toBe(false);
-    expect(getGigs).not.toHaveBeenCalled();
-    expect(commonUtils.notify).toHaveBeenCalledWith('Error creating gig', 'failed', 'danger');
+
+  describe('updateGig', () => {
+    it('updateGig successful via gigUpdated subscribe channel', async () => {
+      commonUtils.delay = vi.fn(() => new Promise(() => { /* never resolves */ }));
+      const getGigs = vi.fn();
+      const setEditGig = vi.fn();
+      const setEditChanged = vi.fn();
+      const transmit = vi.fn();
+      const disconnect = vi.fn();
+      const receiverNext = vi.fn(() => new Promise(() => { /* never resolves */ }));
+      const subscribeNext = vi.fn(() => Promise.resolve({ value: {}, done: false }));
+      const receiver = vi.fn(() => ({ createConsumer: () => ({ next: receiverNext }) }));
+      const subscribe = vi.fn(() => ({ createConsumer: () => ({ next: subscribeNext }) }));
+      scc.create = vi.fn(() => ({ transmit, receiver, subscribe, disconnect })) as any;
+
+      const result = await utils.updateGig(getGigs, setEditGig, setEditChanged, {} as any, 'token');
+      expect(result).toBe('success');
+      expect(subscribe).toHaveBeenCalledWith('gigUpdated');
+      expect(getGigs).toHaveBeenCalled();
+      expect(setEditGig).toHaveBeenCalled();
+      expect(setEditChanged).toHaveBeenCalledWith(false);
+      expect(disconnect).toHaveBeenCalled();
+    });
+
+    it('updateGig surfaces a backend socketError', async () => {
+      commonUtils.delay = vi.fn(() => new Promise(() => { /* never resolves */ }));
+      commonUtils.notify = vi.fn();
+      const transmit = vi.fn();
+      const disconnect = vi.fn();
+      const receiverNext = vi.fn(() => Promise.resolve({ value: { editGig: 'Update failed' }, done: false }));
+      const subscribeNext = vi.fn(() => new Promise(() => { /* never resolves */ }));
+      const receiver = vi.fn(() => ({ createConsumer: () => ({ next: receiverNext }) }));
+      const subscribe = vi.fn(() => ({ createConsumer: () => ({ next: subscribeNext }) }));
+      scc.create = vi.fn(() => ({ transmit, receiver, subscribe, disconnect })) as any;
+
+      const getGigs = vi.fn();
+      const result = await utils.updateGig(getGigs, vi.fn(), vi.fn(), {} as any, 'token');
+      expect(result).toBe('error');
+      expect(commonUtils.notify).toHaveBeenCalledWith('Error updating gig', 'Update failed', 'danger');
+      expect(getGigs).not.toHaveBeenCalled();
+      expect(disconnect).toHaveBeenCalled();
+    });
+
+    it('updateGig unconfirmed on timeout', async () => {
+      commonUtils.delay = vi.fn(() => Promise.resolve());
+      commonUtils.notify = vi.fn();
+      const getGigs = vi.fn();
+      const setEditGig = vi.fn();
+      const setEditChanged = vi.fn();
+      const transmit = vi.fn();
+      const disconnect = vi.fn();
+      const receiverNext = vi.fn(() => new Promise(() => { /* never resolves */ }));
+      const subscribeNext = vi.fn(() => new Promise(() => { /* never resolves */ }));
+      const receiver = vi.fn(() => ({ createConsumer: () => ({ next: receiverNext }) }));
+      const subscribe = vi.fn(() => ({ createConsumer: () => ({ next: subscribeNext }) }));
+      scc.create = vi.fn(() => ({ transmit, receiver, subscribe, disconnect })) as any;
+
+      const result = await utils.updateGig(getGigs, setEditGig, setEditChanged, {} as any, 'token');
+      expect(result).toBe('unconfirmed');
+      expect(commonUtils.notify).toHaveBeenCalledWith('Update gig', "Couldn't confirm — list refreshed", 'info');
+      expect(commonUtils.notify).not.toHaveBeenCalledWith(expect.anything(), expect.anything(), 'danger');
+      expect(getGigs).toHaveBeenCalled();
+      expect(setEditGig).toHaveBeenCalled();
+      expect(setEditChanged).toHaveBeenCalledWith(false);
+      expect(disconnect).toHaveBeenCalled();
+    });
+
+    it('updateGig catches error', async () => {
+      commonUtils.delay = vi.fn(() => Promise.reject(new Error('failed')));
+      commonUtils.notify = vi.fn();
+      const getGigs = vi.fn();
+      const transmit = vi.fn();
+      const disconnect = vi.fn();
+      const receiverNext = vi.fn(() => new Promise(() => { /* never resolves */ }));
+      const subscribeNext = vi.fn(() => new Promise(() => { /* never resolves */ }));
+      const receiver = vi.fn(() => ({ createConsumer: () => ({ next: receiverNext }) }));
+      const subscribe = vi.fn(() => ({ createConsumer: () => ({ next: subscribeNext }) }));
+      scc.create = vi.fn(() => ({ transmit, receiver, subscribe, disconnect })) as any;
+
+      const result = await utils.updateGig(getGigs, vi.fn(), vi.fn(), {} as any, 'token');
+      expect(result).toBe('error');
+      expect(getGigs).not.toHaveBeenCalled();
+      expect(commonUtils.notify).toHaveBeenCalledWith('Error updating gig', 'failed', 'danger');
+      expect(disconnect).toHaveBeenCalled();
+    });
   });
-  it('checkUpdateDisabled', () => {
-    const editGig = {
-      venue: 'venue', city: 'city', datetime: 'datetime', usState: 'usState',
-    };
-    expect(utils.checkUpdateDisabled(editGig, true, 'existing', 'venueId', 'venue', '', '', '')).toBe(false);
+
+  describe('createGig', () => {
+    it('createGig successful via gigCreated subscribe channel', async () => {
+      commonUtils.delay = vi.fn(() => new Promise(() => { /* never resolves */ }));
+      const getGigs = vi.fn();
+      const setShowDialog = vi.fn();
+      const transmit = vi.fn();
+      const disconnect = vi.fn();
+      const receiverNext = vi.fn(() => new Promise(() => { /* never resolves */ }));
+      const subscribeNext = vi.fn(() => Promise.resolve({ value: {}, done: false }));
+      const receiver = vi.fn(() => ({ createConsumer: () => ({ next: receiverNext }) }));
+      const subscribe = vi.fn(() => ({ createConsumer: () => ({ next: subscribeNext }) }));
+      scc.create = vi.fn(() => ({ transmit, receiver, subscribe, disconnect })) as any;
+
+      const result = await utils.createGig(getGigs, setShowDialog, new Date(), 'item', 'item', 'item', 'item', { token: 'token' } as Iauth, 0, '');
+      expect(result).toBe('success');
+      expect(subscribe).toHaveBeenCalledWith('gigCreated');
+      expect(getGigs).toHaveBeenCalled();
+      expect(setShowDialog).toHaveBeenCalledWith(false);
+      expect(disconnect).toHaveBeenCalled();
+    });
+
+    it('createGig surfaces a backend socketError', async () => {
+      commonUtils.delay = vi.fn(() => new Promise(() => { /* never resolves */ }));
+      commonUtils.notify = vi.fn();
+      const transmit = vi.fn();
+      const disconnect = vi.fn();
+      const receiverNext = vi.fn(() => Promise.resolve({ value: { newGig: 'Create failed' }, done: false }));
+      const subscribeNext = vi.fn(() => new Promise(() => { /* never resolves */ }));
+      const receiver = vi.fn(() => ({ createConsumer: () => ({ next: receiverNext }) }));
+      const subscribe = vi.fn(() => ({ createConsumer: () => ({ next: subscribeNext }) }));
+      scc.create = vi.fn(() => ({ transmit, receiver, subscribe, disconnect })) as any;
+
+      const getGigs = vi.fn();
+      const setShowDialog = vi.fn();
+      const result = await utils.createGig(getGigs, setShowDialog, new Date(), 'item', 'item', 'item', 'item', { token: 'token' } as Iauth, 0, '');
+      expect(result).toBe('error');
+      expect(commonUtils.notify).toHaveBeenCalledWith('Error creating gig', 'Create failed', 'danger');
+      expect(getGigs).not.toHaveBeenCalled();
+      expect(setShowDialog).not.toHaveBeenCalled();
+      expect(disconnect).toHaveBeenCalled();
+    });
+
+    it('createGig unconfirmed on timeout', async () => {
+      commonUtils.delay = vi.fn(() => Promise.resolve());
+      commonUtils.notify = vi.fn();
+      const getGigs = vi.fn();
+      const setShowDialog = vi.fn();
+      const transmit = vi.fn();
+      const disconnect = vi.fn();
+      const receiverNext = vi.fn(() => new Promise(() => { /* never resolves */ }));
+      const subscribeNext = vi.fn(() => new Promise(() => { /* never resolves */ }));
+      const receiver = vi.fn(() => ({ createConsumer: () => ({ next: receiverNext }) }));
+      const subscribe = vi.fn(() => ({ createConsumer: () => ({ next: subscribeNext }) }));
+      scc.create = vi.fn(() => ({ transmit, receiver, subscribe, disconnect })) as any;
+
+      const result = await utils.createGig(getGigs, setShowDialog, new Date(), 'item', 'item', 'item', 'item', { token: 'token' } as Iauth, 0, '');
+      expect(result).toBe('unconfirmed');
+      expect(commonUtils.notify).toHaveBeenCalledWith('Create gig', "Couldn't confirm — list refreshed", 'info');
+      expect(commonUtils.notify).not.toHaveBeenCalledWith(expect.anything(), expect.anything(), 'danger');
+      expect(getGigs).toHaveBeenCalled();
+      expect(setShowDialog).toHaveBeenCalledWith(false);
+      expect(disconnect).toHaveBeenCalled();
+    });
+
+    it('createGig catches error', async () => {
+      commonUtils.delay = vi.fn(() => Promise.reject(new Error('failed')));
+      commonUtils.notify = vi.fn();
+      const getGigs = vi.fn();
+      const transmit = vi.fn();
+      const disconnect = vi.fn();
+      const receiverNext = vi.fn(() => new Promise(() => { /* never resolves */ }));
+      const subscribeNext = vi.fn(() => new Promise(() => { /* never resolves */ }));
+      const receiver = vi.fn(() => ({ createConsumer: () => ({ next: receiverNext }) }));
+      const subscribe = vi.fn(() => ({ createConsumer: () => ({ next: subscribeNext }) }));
+      scc.create = vi.fn(() => ({ transmit, receiver, subscribe, disconnect })) as any;
+
+      const result = await utils.createGig(getGigs, vi.fn(), new Date(), 'item', 'item', 'item', 'item', { token: 'token' } as Iauth, 0, '');
+      expect(result).toBe('error');
+      expect(getGigs).not.toHaveBeenCalled();
+      expect(commonUtils.notify).toHaveBeenCalledWith('Error creating gig', 'failed', 'danger');
+      expect(disconnect).toHaveBeenCalled();
+    });
   });
-  it('checkNewDisabled', () => {
+  it('checkUpdateDisabled branches', () => {
+    const validGig = { datetime: new Date() };
+    expect(utils.checkUpdateDisabled({}, false, 'existing', 'venueId', 'venue', '', '', '')).toBe(true);
+    expect(utils.checkUpdateDisabled({}, true, 'existing', 'venueId', 'venue', '', '', '')).toBe(true);
+    expect(utils.checkUpdateDisabled(validGig, true, 'existing', null, 'venue', '', '', '')).toBe(true);
+    expect(utils.checkUpdateDisabled(validGig, true, 'existing', 'venueId', 'venue', '', '', '')).toBe(false);
+    expect(utils.checkUpdateDisabled(validGig, true, 'new', 'venueId', 'venue', '', 'city', 'state')).toBe(true);
+    expect(utils.checkUpdateDisabled(validGig, true, 'new', 'venueId', 'venue', 'name', 'city', 'state')).toBe(false);
+    expect(utils.checkUpdateDisabled(validGig, true, 'none', 'venueId', '', '', '', '')).toBe(true);
+    expect(utils.checkUpdateDisabled(validGig, true, 'none', 'venueId', '<p></p>', '', '', '')).toBe(true);
+    expect(utils.checkUpdateDisabled(validGig, true, 'none', 'venueId', 'valid venue', '', '', '')).toBe(false);
+    expect(utils.checkUpdateDisabled(validGig, true, 'invalid' as any, 'venueId', 'venue', '', '', '')).toBe(true);
+  });
+  it('checkNewDisabled branches', () => {
+    expect(utils.checkNewDisabled(null, 'existing', 'venueId', 'venue', '', '', '')).toBe(true);
+    expect(utils.checkNewDisabled(new Date(), 'existing', null, 'venue', '', '', '')).toBe(true);
     expect(utils.checkNewDisabled(new Date(), 'existing', 'venueId', 'venue', '', '', '')).toBe(false);
+    expect(utils.checkNewDisabled(new Date(), 'new', 'venueId', 'venue', '', 'city', 'state')).toBe(true);
+    expect(utils.checkNewDisabled(new Date(), 'new', 'venueId', 'venue', 'name', 'city', 'state')).toBe(false);
+    expect(utils.checkNewDisabled(new Date(), 'none', 'venueId', '', '', '', '')).toBe(true);
+    expect(utils.checkNewDisabled(new Date(), 'none', 'venueId', '<p></p>', '', '', '')).toBe(true);
+    expect(utils.checkNewDisabled(new Date(), 'none', 'venueId', 'valid venue', '', '', '')).toBe(false);
+    expect(utils.checkNewDisabled(new Date(), 'invalid' as any, 'venueId', 'venue', '', '', '')).toBe(true);
   });
   it('clickToEdit when isAdmin', () => {
     const setEditGig = vi.fn();


### PR DESCRIPTION
## Summary
- Widen `createGig`, `updateGig`, and `deleteGig` return type to `GigOpResult` (`'success' | 'error' | 'unconfirmed'`).
- Subscribe to broadcast publish channels (`gigCreated`, `gigUpdated`, `gigDeleted`) before transmitting to socket.
- `Promise.race` direct transmit `socketError` vs publish success channel vs 5s safety timeout.
- Show neutral info toast and refetch list on timeout (`'unconfirmed'`), show error toast on `'error'`, and close dialog on `'success'` or `'unconfirmed'`.
- Ensure `socket.disconnect()` is called in a `finally` block on all execution paths.
- Bump package version from 2.18.2 to 2.18.3 and update `AppTemplate` snapshot.
- Add comprehensive unit tests covering success, error, timeout, cancel, and exception branches across all gig CRUD operations.

Closes #1264

## How to test locally
Run:
```sh
npm test
```
Expect: lint, typecheck, copy-paste check, and unit test suite pass with coverage above 90/90/80/80.

## Test evidence
```
Test Files  69 passed (69)
     Tests  533 passed (533)
Snapshots  1 updated
```

🤖 Work by agy — Gemini 3.6 Flash (High)