### PR TITLE
Batch Outreach: pre-check only conflict-free candidates (warned venues load unchecked)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.18.3",
+  "version": "2.18.4",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/AdminOutreach/index.tsx
+++ b/src/containers/AdminOutreach/index.tsx
@@ -325,7 +325,10 @@ export function AdminOutreach() {
       });
 
       setCandidates(availableCandidates);
-      setSelected(new Set(availableCandidates.map((c) => c._id)));
+      const conflictFreeCandidates = availableCandidates.filter(
+        (c) => checkWeekendGigs(c.name, structuredDate).length === 0,
+      );
+      setSelected(new Set(conflictFreeCandidates.map((c) => c._id)));
     } catch (e) {
       setError((e as { message?: string }).message || 'Failed to load candidates');
     } finally {

--- a/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
+++ b/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
@@ -136,7 +136,7 @@ exports[`AppTemplate > renders the component 1`] = `
             <strong>
               Version
                
-              2.18.3
+              2.18.4
             </strong>
           </div>
           <p

--- a/test/containers/AdminOutreach/index.spec.tsx
+++ b/test/containers/AdminOutreach/index.spec.tsx
@@ -100,6 +100,33 @@ describe('AdminOutreach', () => {
     expect(screen.getByTestId('outreach-candidates').textContent).toContain('1 of 2');
   });
 
+  it('loads candidates carrying a +/- 2-month conflict warning as unchecked', async () => {
+    const mockFetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('/gig')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([
+            { datetime: '2026-09-01T20:00:00.000Z', venue: 'Venue A' },
+          ]),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    await renderPage();
+    typeDates();
+    await act(async () => { fireEvent.click(screen.getByTestId('outreach-load')); });
+
+    expect(screen.getByTestId('outreach-candidates').textContent).toContain('1 of 2');
+    const cbA = screen.getByRole('checkbox', { name: /Venue A/i });
+    const cbB = screen.getByRole('checkbox', { name: /Venue B/i });
+    expect(cbA).not.toBeChecked();
+    expect(cbB).toBeChecked();
+
+    vi.unstubAllGlobals();
+  });
+
   it('renders qualification reasons next to checkbox when provided', async () => {
     await renderPage();
     typeDates();


### PR DESCRIPTION
## Summary
- Update `loadCandidates` in `AdminOutreach` so candidates with a ±2-month gig conflict warning load unchecked by default.
- Retain pre-checking default for conflict-free candidates (candidates with no gig within ±2 months).
- Add unit test verifying candidates carrying a conflict warning load unchecked while conflict-free candidates load checked.
- Bump package.json version to 2.18.4 and update snapshot.

Closes #1259

## How to test locally
1. Run full test suite:
```sh
npm test
```
Expect: stylelint, eslint, typecheck, jscpd, and all 534 unit tests pass cleanly.

2. Manual verification:
- Navigate to Admin Outreach dashboard (`/admin/outreach`).
- Select a weekend date and enter target dates, then click "Load Candidates".
- Verify candidates with no gig conflicts arrive checked.
- Verify candidates flagged with a ±2-month gig conflict warning arrive unchecked.

## Test evidence
```
> jammusic@2.18.4 test
> npm run test:lint && npm run typecheck && npm run jscpd && npm run test:unit

> jammusic@2.18.4 test:lint
> npm run test:stylelint && eslint .

> jammusic@2.18.4 test:stylelint
> stylelint "src/styles/**/*.scss"

> jammusic@2.18.4 typecheck
> tsc --noEmit

> jammusic@2.18.4 jscpd
> jscpd src

> jammusic@2.18.4 test:unit
> vitest run --coverage

  Snapshots  1 updated 
 Test Files  69 passed (69)
      Tests  534 passed (534)
   Start at  12:08:26
   Duration  34.61s
```

🤖 Work by agy — Gemini 3.6 Flash (Medium)