### PR TITLE
AdminVenues form: add street address input (chain locations)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ from a `<lane>/<issue#>-<slug>` branch.
   3. Run E2E tests pointing to the preview server: `BASE_URL=http://localhost:4173 npm run test:e2e`
 - **Draft PR Script Requirements**: The workspace `create-draft-pr.sh` script strictly requires the `--author`, `--summary`, `--test-plan`, and `--test-evidence` flags. Leaving any of these empty or as a default placeholder will cause the script to abort and refuse to open the draft PR.
 - **Vitest Unit Tests and Environment Variables**: Local unit tests depend on `process.env.userRoles` being defined. If `.env` is missing or does not contain `userRoles`, tests like `test/containers/Music/index.spec.tsx` will fail with `TypeError: Cannot read properties of undefined (reading '0')`. Always copy `.env.example` to `.env` in any new worktree before running `npm test`.
+- **Worktree node_modules Symlink**: In temporary git worktrees, `node_modules` is not symlinked by default. Symlink the main repo's `node_modules` (`ln -s /home/joshua/WebJamApps/JaMmusic/node_modules node_modules`) so test tools (`tsc`, `stylelint`, `vitest`) are available. Unlink or exclude the symlink before committing.
 
 
 ## Branch & memory hygiene

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.18.4",
+  "version": "2.19.0",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/AdminVenues/EditVenueDialog.tsx
+++ b/src/containers/AdminVenues/EditVenueDialog.tsx
@@ -214,8 +214,11 @@ export function EditVenueDialog({
     return () => clearTimeout(delayDebounceFn);
   }, [form.address, mapsLoaded, autocompleteService, form.country]);
 
+  const [notice, setNotice] = useState('');
+
   useEffect(() => {
     if (open) {
+      setNotice('');
       if (venue) {
         setForm({
           name: venue.name || '',
@@ -282,9 +285,20 @@ export function EditVenueDialog({
 
   const handleSave = async () => {
     if (!form.name || !form.name.trim()) { setError('Name is required'); return; }
-    if (!form.address || !form.address.trim()) { setError('Address is required'); return; }
 
     const isCreate = !venue;
+    const hadAddress = !!(venue && venue.address && venue.address.trim());
+    const addressTrimmed = form.address ? form.address.trim() : '';
+
+    if (isCreate && !addressTrimmed) {
+      setError('Street address is required');
+      return;
+    }
+    if (!isCreate && hadAddress && !addressTrimmed) {
+      setError("Address can't be removed — enter the corrected address");
+      return;
+    }
+
     if (existingVenues) {
       const isDuplicate = existingVenues.some(
         (v) => v.name.trim().toLowerCase() === form.name!.trim().toLowerCase() && (isCreate || v._id !== venue?._id)
@@ -339,7 +353,7 @@ export function EditVenueDialog({
     const finalForm: IvenueUpdate = {
       ...form,
       name: form.name.trim(),
-      address: form.address.trim(),
+      address: addressTrimmed,
       email: primaryEmail,
       secondaryEmail: secondaryEmail,
       venueType: form.venueType || undefined,
@@ -357,17 +371,26 @@ export function EditVenueDialog({
 
     setSubmitting(true);
     setError('');
+    setNotice('');
     try {
+      let savedVenue: Ivenue;
       if (venue) {
         // Edit mode
-        await adminVenuesUtils.updateVenue(token, venue._id, {
+        savedVenue = await adminVenuesUtils.updateVenue(token, venue._id, {
           ...finalForm,
         });
       } else {
         // Create mode
-        await adminVenuesUtils.createVenue(token, {
+        savedVenue = await adminVenuesUtils.createVenue(token, {
           ...finalForm,
         });
+      }
+      if (savedVenue && savedVenue.address !== undefined) {
+        setForm((f) => ({ ...f, address: savedVenue.address || '' }));
+      }
+      const rawRes = savedVenue as any;
+      if (rawRes?.notice || rawRes?.emailNotice) {
+        setNotice(rawRes.notice || rawRes.emailNotice);
       }
       onSaved();
     } catch (e) {
@@ -700,6 +723,7 @@ export function EditVenueDialog({
         <Help field="lastVerified" />
         <TextField label="Notes" fullWidth multiline rows={6} value={form.notes || ''} onChange={(e) => set('notes', e.target.value)}
           sx={{ marginTop: 2 }} data-testid="edit-venue-notes" />
+        {notice && <Typography color="info.main" sx={{ marginTop: 1 }} data-testid="edit-venue-notice">{notice}</Typography>}
         {error && <Typography color="error" sx={{ marginTop: 1 }} data-testid="edit-venue-error">{error}</Typography>}
       </DialogContent>
       <DialogActions>

--- a/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
+++ b/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
@@ -136,7 +136,7 @@ exports[`AppTemplate > renders the component 1`] = `
             <strong>
               Version
                
-              2.18.4
+              2.19.0
             </strong>
           </div>
           <p

--- a/test/containers/AdminVenues/EditVenueDialog.spec.tsx
+++ b/test/containers/AdminVenues/EditVenueDialog.spec.tsx
@@ -311,12 +311,54 @@ describe('EditVenueDialog', () => {
     confirmSpy.mockRestore();
   });
 
-  it('blocks save and shows an error when the address is empty', async () => {
-    const blankAddress: Ivenue = { ...venue, address: '' };
-    await act(async () => { render(<EditVenueDialog open venue={blankAddress} token="tk" onClose={vi.fn()} onSaved={vi.fn()} />); });
+  it('blocks save and shows an error when creating a venue with empty address', async () => {
+    await act(async () => { render(<EditVenueDialog open venue={null} token="tk" onClose={vi.fn()} onSaved={vi.fn()} />); });
+    await act(async () => { fireEvent.change(screen.getByTestId('edit-venue-name'), { target: { value: 'New Venue' } }); });
     await act(async () => { fireEvent.click(screen.getByTestId('edit-venue-save')); });
-    expect(screen.getByTestId('edit-venue-error').innerHTML).toBe('Address is required');
+    expect(screen.getByTestId('edit-venue-error').innerHTML).toBe('Street address is required');
+    expect(adminVenuesUtils.createVenue).not.toHaveBeenCalled();
+  });
+
+  it('blocks save and shows an error when clearing address on a venue that has one', async () => {
+    await act(async () => { render(<EditVenueDialog open venue={venue} token="tk" onClose={vi.fn()} onSaved={vi.fn()} />); });
+    await act(async () => { fireEvent.change(screen.getByTestId('edit-venue-address'), { target: { value: '' } }); });
+    await act(async () => { fireEvent.click(screen.getByTestId('edit-venue-save')); });
+    expect(screen.getByTestId('edit-venue-error').innerHTML).toBe("Address can't be removed — enter the corrected address");
     expect(adminVenuesUtils.updateVenue).not.toHaveBeenCalled();
+  });
+
+  it('allows saving an existing venue that has no address with an empty address', async () => {
+    const legacyVenue: Ivenue = { ...venue, address: '' };
+    const onSaved = vi.fn();
+    await act(async () => { render(<EditVenueDialog open venue={legacyVenue} token="tk" onClose={vi.fn()} onSaved={onSaved} />); });
+    await act(async () => { fireEvent.click(screen.getByTestId('edit-venue-save')); });
+    expect(adminVenuesUtils.updateVenue).toHaveBeenCalledWith('tk', 'v1', expect.objectContaining({ address: '' }));
+    expect(onSaved).toHaveBeenCalled();
+  });
+
+  it('surfaces backend notice and server-returned normalized address on save', async () => {
+    const onSaved = vi.fn();
+    adminVenuesUtils.createVenue = vi.fn(() => Promise.resolve({
+      _id: 'v2',
+      name: 'Macados',
+      address: '100 N Main St',
+      notice: 'email also used by Macados Roanoke',
+    } as any)) as any;
+
+    await act(async () => { render(<EditVenueDialog open venue={null} token="tk" onClose={vi.fn()} onSaved={onSaved} />); });
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('edit-venue-name'), { target: { value: 'Macados' } });
+      fireEvent.change(screen.getByTestId('edit-venue-address'), { target: { value: '100 North Main Street' } });
+      fireEvent.change(screen.getByTestId('edit-venue-state'), { target: { value: 'VA' } });
+    });
+    await act(async () => { fireEvent.click(screen.getByTestId('edit-venue-save')); });
+
+    expect(adminVenuesUtils.createVenue).toHaveBeenCalledWith('tk', expect.objectContaining({
+      name: 'Macados',
+      address: '100 North Main Street',
+    }));
+    expect(screen.getByTestId('edit-venue-notice').innerHTML).toBe('email also used by Macados Roanoke');
+    expect(onSaved).toHaveBeenCalled();
   });
 
   describe('Google Places Autocomplete', () => {


### PR DESCRIPTION
## Summary
- Enforce street address validation rules on AdminVenues venue form:
  - Required when creating a new venue (blocked client-side with inline error `Street address is required`).
  - Not removable once set on existing venue (blocked client-side with inline error `Address can't be removed — enter the corrected address`).
  - Optional when editing existing legacy venue with no address on file.
- Update form state with server-returned (normalized) address after save.
- Surface non-blocking backend inline notices (such as email duplication notices) if returned on save.
- Add unit test coverage in `EditVenueDialog.spec.tsx` for all street address validation scenarios.
- Bump package.json version to 2.19.0 and update test snapshots.
- Fold `/learn` updates into `AGENTS.md`.

Closes #1241

## How to test locally
1. Run full test suite:
```sh
npm test
```
Expect: stylelint, eslint, typecheck, jscpd, and all 537 unit tests pass cleanly.

2. Manual verification:
- Navigate to Admin Venues dashboard (`/admin/venues`).
- Click "Create" to open venue creation form. Submit with empty address -> verify inline error `Street address is required`.
- Fill address and save -> verify record shows server-returned normalized address.
- Edit existing venue with address and clear address field -> verify inline error `Address can't be removed — enter the corrected address`.
- Edit existing legacy venue with no address and save -> verify edit saves cleanly with empty address.

## Test evidence
```
> jammusic@2.19.0 test
> npm run test:lint && npm run typecheck && npm run jscpd && npm run test:unit

> jammusic@2.19.0 test:lint
> npm run test:stylelint && eslint .

> jammusic@2.19.0 test:stylelint
> stylelint "src/styles/**/*.scss"

> jammusic@2.19.0 typecheck
> tsc --noEmit

> jammusic@2.19.0 jscpd
> jscpd src

> jammusic@2.19.0 test:unit
> vitest run --coverage

  Snapshots  1 updated 
 Test Files  69 passed (69)
      Tests  537 passed (537)
   Start at  13:14:50
   Duration  31.22s
```

🤖 Work by agy — Gemini 3.6 Flash (Medium)