### PR TITLE
EditGigDialog wipes city/usState on one-off (no-venue) gigs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,10 @@ from a `<lane>/<issue#>-<slug>` branch.
 - **Draft PR Script Requirements**: The workspace `create-draft-pr.sh` script strictly requires the `--author`, `--summary`, `--test-plan`, and `--test-evidence` flags. Leaving any of these empty or as a default placeholder will cause the script to abort and refuse to open the draft PR.
 - **Vitest Unit Tests and Environment Variables**: Local unit tests depend on `process.env.userRoles` being defined. If `.env` is missing or does not contain `userRoles`, tests like `test/containers/Music/index.spec.tsx` will fail with `TypeError: Cannot read properties of undefined (reading '0')`. Always copy `.env.example` to `.env` in any new worktree before running `npm test`.
 - **Worktree node_modules Symlink**: In temporary git worktrees, `node_modules` is not symlinked by default. Symlink the main repo's `node_modules` (`ln -s /home/joshua/WebJamApps/JaMmusic/node_modules node_modules`) so test tools (`tsc`, `stylelint`, `vitest`) are available. Unlink or exclude the symlink before committing.
-
+- **TypeScript Number Comparison in Form States**: In `@mui/material` dialog forms, numeric fields (such as `gigInterval` inside form state) are
+  typed as `number`. Comparing a numeric state variable against string empty (`form.gigInterval !== ''`) will cause a compilation error
+  `TS2367: This comparison appears to be unintentional because the types 'number' and 'string' have no overlap.` Ensure you check
+  `typeof form.field === 'number'` or keep form states properly type-separated.
 
 ## Branch & memory hygiene
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jammusic",
-  "version": "2.18.2",
+  "version": "2.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jammusic",
-      "version": "2.18.2",
+      "version": "2.19.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.19.0",
+  "version": "2.19.1",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/Music/Gigs/EditGigDialog.tsx
+++ b/src/containers/Music/Gigs/EditGigDialog.tsx
@@ -102,8 +102,7 @@ export function EditGigDialog(props: IeditGigDialogProps) {
       const updatedGig = {
         ...editGig,
         venueId: finalVenueId,
-        city: '',
-        usState: '',
+        ...(finalVenueId ? { city: '', usState: '' } : {}),
       };
 
       const result = await utils.updateGig(getGigs, setEditGig, setEditChanged, updatedGig, auth.token);

--- a/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
+++ b/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
@@ -136,7 +136,7 @@ exports[`AppTemplate > renders the component 1`] = `
             <strong>
               Version
                
-              2.19.0
+              2.19.1
             </strong>
           </div>
           <p

--- a/test/containers/Music/Gigs/EditGigDialog.spec.tsx
+++ b/test/containers/Music/Gigs/EditGigDialog.spec.tsx
@@ -106,6 +106,8 @@ describe('EditGigDialog', () => {
       expect.any(Function),
       expect.objectContaining({
         venueId: 'v2',
+        city: '',
+        usState: '',
       }),
       'tk',
     ));
@@ -164,6 +166,8 @@ describe('EditGigDialog', () => {
       expect.any(Function),
       expect.objectContaining({
         venueId: 'new-venue-123',
+        city: '',
+        usState: '',
       }),
       'tk',
     ));
@@ -206,6 +210,97 @@ describe('EditGigDialog', () => {
       expect.any(Function),
       expect.objectContaining({
         venueId: undefined,
+      }),
+      'tk',
+    ));
+  });
+
+  it('preserves city and usState when saving a one-off (no venueId) gig', async () => {
+    vi.spyOn(adminVenuesUtils, 'listVenues').mockResolvedValue(activeVenues);
+    const updateSpy = vi.spyOn(utils, 'updateGig').mockResolvedValue('success');
+
+    const editGig = {
+      _id: 'gig123',
+      datetime: new Date('2025-01-01T12:00:00Z'),
+      venue: 'Some Venue',
+      city: 'Austin',
+      usState: 'Texas',
+    } as any;
+
+    render(
+      <EditGigDialog
+        editGig={editGig}
+        setEditGig={vi.fn()}
+        setShowDialog={vi.fn()}
+        setEditChanged={vi.fn()}
+        editChanged={true}
+        getGigs={vi.fn()}
+        auth={{ token: 'tk' } as any}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByLabelText('No Venue (One-off)')).toBeInTheDocument());
+
+    // Click Update directly (starts on No Venue path)
+    fireEvent.click(screen.getByRole('button', { name: /update/i }));
+
+    await waitFor(() => expect(updateSpy).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(Function),
+      expect.any(Function),
+      expect.objectContaining({
+        venueId: undefined,
+        city: 'Austin',
+        usState: 'Texas',
+      }),
+      'tk',
+    ));
+  });
+
+  it('blanks city and usState when switching an existing one-off gig to a real venue during edit', async () => {
+    vi.spyOn(adminVenuesUtils, 'listVenues').mockResolvedValue(activeVenues);
+    const updateSpy = vi.spyOn(utils, 'updateGig').mockResolvedValue('success');
+
+    const editGig = {
+      _id: 'gig123',
+      datetime: new Date('2025-01-01T12:00:00Z'),
+      venue: '',
+      city: 'Austin',
+      usState: 'Texas',
+    } as any;
+
+    render(
+      <EditGigDialog
+        editGig={editGig}
+        setEditGig={vi.fn()}
+        setShowDialog={vi.fn()}
+        setEditChanged={vi.fn()}
+        editChanged={true}
+        getGigs={vi.fn()}
+        auth={{ token: 'tk' } as any}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByLabelText('Pick Existing Venue')).toBeInTheDocument());
+
+    // Switch path from No Venue to Pick Existing Venue
+    fireEvent.click(screen.getByLabelText('Pick Existing Venue'));
+
+    // Select v1 venue
+    const select = screen.getByTestId('mock-autocomplete');
+    fireEvent.change(select, { target: { value: 'v1' } });
+
+    // Click Update
+    fireEvent.click(screen.getByRole('button', { name: /update/i }));
+
+    await waitFor(() => expect(updateSpy).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(Function),
+      expect.any(Function),
+      expect.objectContaining({
+        venueId: 'v1',
+        city: '',
+        usState: '',
       }),
       'tk',
     ));


### PR DESCRIPTION
## Summary
- Prevent unconditionally blanking `city` and `usState` in `EditGigDialog.tsx` when saving gigs on the "No Venue (One-off)" path (`path === 'none'`).
- Only blank `city` and `usState` when `finalVenueId` is set (i.e. venue-linked gigs on `existing` or `new` paths).
- Update unit tests in `EditGigDialog.spec.tsx` to assert that:
  - Saving a venue-linked gig blanks `city` and `usState`.
  - Saving a one-off gig preserves existing `city` and `usState` in the payload.
  - Switching a one-off gig to a venue during edit blanks `city` and `usState`.
- Update snapshot in `AppTemplate/index.spec.tsx.snap` for patch version bump (2.19.1).
- Carry over `AGENTS.md`'s "TypeScript Number Comparison in Form States" troubleshooting rule (commit `a4ad520`), which was committed to `gemini/1237-adminvenues-inputs` after WebJamApps/JaMmusic#1256 "AdminVenues: gigInterval + resumeBooking inputs; bookingStatus becomes read-only badge; drop manual booking/doNotContact controls" had already merged and so never reached `dev`. Docs only — no code impact on this PR's fix.

Closes #1275

## How to test locally
1. Run `npm test` in `JaMmusic` repository root to verify lint, typecheck, duplicate check (jscpd), and unit test coverage.
   - Expected: All checks pass clean and vitest coverage meets the 90/90/80/80 threshold.
2. Verify `EditGigDialog` behavior for one-off gigs via unit tests:
   - Editing a gig with no `venueId` preserves its `city` and `usState` properties in the `updateGig` call payload.
   - Editing a gig with a `venueId` sends `city: ''` and `usState: ''` alongside `venueId`.
   - Switching a gig from one-off path to a venue blanks `city` and `usState`.

## Test evidence
```
> jammusic@2.19.1 test
> npm run test:lint && npm run typecheck && npm run jscpd && npm run test:unit

> jammusic@2.19.1 test:lint
> npm run test:stylelint && eslint .

> jammusic@2.19.1 test:stylelint
> stylelint "src/styles/**/*.scss"

✖ 943 problems (0 errors, 943 warnings)

> jammusic@2.19.1 typecheck
> tsc --noEmit

> jammusic@2.19.1 jscpd
> jscpd src

Found 34 clones.

> jammusic@2.19.1 test:unit
> TZ=UTC vitest run --coverage

 RUN  v4.1.7 /tmp/agy-worktrees/JaMmusic-agy-1275-editgigdialog-wipes-city-usstate-on-one
      Coverage enabled with v8

 Test Files  69 passed (69)
      Tests  539 passed (539)
   Start at  00:23:21
   Duration  32.50s

=============================== Coverage summary ===============================
Statements   : 91.56% ( 2780/3036 )
Branches     : 80.94% ( 1725/2131 )
Functions    : 88.67% ( 681/768 )
Lines        : 93.27% ( 2510/2691 )
================================================================================
```

🤖 Work by agy — Gemini 3.6 Flash (Medium)
