### PR TITLE
https://web-jam.com/music  Gigs datatable is all screwed up now!

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,7 @@ from a `<lane>/<issue#>-<slug>` branch.
   typed as `number`. Comparing a numeric state variable against string empty (`form.gigInterval !== ''`) will cause a compilation error
   `TS2367: This comparison appears to be unintentional because the types 'number' and 'string' have no overlap.` Ensure you check
   `typeof form.field === 'number'` or keep form states properly type-separated.
+- **Testing Library Jest-DOM Import**: In Vitest unit tests using DOM element matchers such as `toHaveAttribute`, `toBeInTheDocument`, or `toHaveTextContent`, always include `import '@testing-library/jest-dom';` at the top of the spec file to extend Vitest's `expect` matchers.
 
 ## Branch & memory hygiene
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.19.1",
+  "version": "2.19.2",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/Music/Gigs/gigs.scss
+++ b/src/containers/Music/Gigs/gigs.scss
@@ -58,6 +58,14 @@
   color: var(--fg);
 }
 
+.MuiDataGrid-root .MuiDataGrid-cell a {
+  color: var(--nav-link);
+
+  &:hover {
+    color: var(--nav-link-hover);
+  }
+}
+
 .MuiDataGrid-root .MuiDataGrid-row:hover {
   background-color: var(--sidebar-hover-bg);
 }

--- a/src/containers/Music/Gigs/gigs.utils.tsx
+++ b/src/containers/Music/Gigs/gigs.utils.tsx
@@ -366,6 +366,36 @@ const makeVenueValue = (value: string) => {
   return <div>{parsed}</div>;
 };
 
+export const normalizeUrl = (url: string): string => {
+  const trimmed = url.trim();
+  if (!trimmed) return '';
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(trimmed)) {
+    return trimmed;
+  }
+  return `https://${trimmed}`;
+};
+
+export const normalizeTextForComparison = (text?: string): string => {
+  if (!text) return '';
+  return text
+    .replace(/<[^>]*>/g, '')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;|&apos;/gi, "'")
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+};
+
+export const isFreeTextRenderable = (venue?: string, linkedName?: string): boolean => {
+  if (!venue || venue === '<p></p>' || venue.trim() === '') return false;
+  const normalizedFreeText = normalizeTextForComparison(venue);
+  if (!normalizedFreeText) return false;
+  const normalizedVenueName = normalizeTextForComparison(linkedName);
+  return normalizedFreeText !== normalizedVenueName;
+};
+
 const renderVenueCell = (params: GridRenderCellParams) => {
   const row = params?.row;
   if (!row) {
@@ -376,22 +406,21 @@ const renderVenueCell = (params: GridRenderCellParams) => {
     return <span className="ourPastPerformances">{HtmlReactParser(venue)}</span>;
   }
   if (venueId && typeof venueId === 'object') {
-    const { name, city, usState, website } = venueId;
-    const resolvedLink = website ? (
-      <a href={website} target="_blank" rel="noopener" style={{ fontWeight: 'bold', textDecoration: 'underline' }}>
+    const { name, website } = venueId;
+    const hrefUrl = website ? normalizeUrl(website) : '';
+    const resolvedLink = hrefUrl ? (
+      <a href={hrefUrl} target="_blank" rel="noopener" style={{ fontWeight: 'bold', textDecoration: 'underline' }}>
         {name}
       </a>
     ) : (
       <span style={{ fontWeight: 'bold' }}>{name}</span>
     );
-    const locationStr = `${city || ''}, ${usState || ''}`.trim().replace(/^,\s*|,\s*$/g, '');
     return (
       <div>
         <div>
           {resolvedLink}
-          {locationStr ? ` - ${locationStr}` : ''}
         </div>
-        {venue && venue !== '<p></p>' && venue.trim() !== '' && (
+        {isFreeTextRenderable(venue, name) && (
           <div style={{ fontSize: '0.875rem', marginTop: '4px', opacity: 0.9 }}>
             {HtmlReactParser(venue)}
           </div>
@@ -429,4 +458,8 @@ export default {
   deleteGig,
   orderGigs,
   usStateOptions,
+  normalizeUrl,
+  normalizeTextForComparison,
+  isFreeTextRenderable,
+  renderVenueCell,
 };

--- a/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
+++ b/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
@@ -136,7 +136,7 @@ exports[`AppTemplate > renders the component 1`] = `
             <strong>
               Version
                
-              2.19.1
+              2.19.2
             </strong>
           </div>
           <p

--- a/test/containers/Music/Gigs/gigs.utils.spec.tsx
+++ b/test/containers/Music/Gigs/gigs.utils.spec.tsx
@@ -1,3 +1,5 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import scc from 'socketcluster-client';
 import utils from 'src/containers/Music/Gigs/gigs.utils';
 import commonUtils from 'src/lib/utils';
@@ -412,5 +414,123 @@ describe('gigs.utils', () => {
       },
     } as any);
     expect(cellFallback.type).toBe('div');
+  });
+
+  describe('normalizeUrl', () => {
+    it('prefixes https:// when URL has no scheme', () => {
+      expect(utils.normalizeUrl('www.petedyerivercourse.com')).toBe('https://www.petedyerivercourse.com');
+      expect(utils.normalizeUrl('petedyerivercourse.com')).toBe('https://petedyerivercourse.com');
+    });
+
+    it('preserves existing http:// and https:// schemes', () => {
+      expect(utils.normalizeUrl('http://www.petedyerivercourse.com')).toBe('http://www.petedyerivercourse.com');
+      expect(utils.normalizeUrl('https://www.petedyerivercourse.com')).toBe('https://www.petedyerivercourse.com');
+    });
+
+    it('handles empty and whitespace strings', () => {
+      expect(utils.normalizeUrl('')).toBe('');
+      expect(utils.normalizeUrl('   ')).toBe('');
+    });
+  });
+
+  describe('isFreeTextRenderable', () => {
+    it('returns false when free-text venue merely restates linked venue name', () => {
+      const freeText = '<a href="http://old.com">Pete Dye River Course</a>';
+      expect(utils.isFreeTextRenderable(freeText, 'Pete Dye River Course')).toBe(false);
+    });
+
+    it('returns false when free-text differs only in whitespace, HTML tags, or case', () => {
+      expect(utils.isFreeTextRenderable('<p>  PETE DYE RIVER COURSE </p>', 'Pete Dye River Course')).toBe(false);
+    });
+
+    it('returns true when free-text holds genuinely different extra info', () => {
+      expect(utils.isFreeTextRenderable('<p>Patio Stage (Outdoors)</p>', 'Pete Dye River Course')).toBe(true);
+    });
+
+    it('returns false for empty, whitespace, or empty HTML paragraph free-text', () => {
+      expect(utils.isFreeTextRenderable('', 'Pete Dye River Course')).toBe(false);
+      expect(utils.isFreeTextRenderable('<p></p>', 'Pete Dye River Course')).toBe(false);
+      expect(utils.isFreeTextRenderable('   ', 'Pete Dye River Course')).toBe(false);
+    });
+  });
+
+  describe('renderVenueCell detailed behavior (Defects 1-4)', () => {
+    it('renders a venue link with normalized https:// href for schemeless website, without trailing city/state (Defects 1 & 3)', () => {
+      const renderCell = utils.makeVenue().renderCell as any;
+      const cell = renderCell({
+        row: {
+          venue: '<a href="http://old.com">Pete Dye River Course</a>',
+          venueId: {
+            name: 'Pete Dye River Course',
+            city: 'Radford',
+            usState: 'VA',
+            website: 'www.petedyerivercourse.com',
+          },
+        },
+      });
+
+      render(cell);
+      const link = screen.getByRole('link', { name: 'Pete Dye River Course' });
+      expect(link).toHaveAttribute('href', 'https://www.petedyerivercourse.com');
+      expect(screen.queryByText(/- Radford, VA/i)).toBeNull();
+    });
+
+    it('renders venue name once when free-text merely restates linked venue name (Defect 4)', () => {
+      const renderCell = utils.makeVenue().renderCell as any;
+      const cell = renderCell({
+        row: {
+          venue: '<a href="http://old.com">Pete Dye River Course</a>',
+          venueId: {
+            name: 'Pete Dye River Course',
+            city: 'Radford',
+            usState: 'VA',
+            website: 'https://www.petedyerivercourse.com',
+          },
+        },
+      });
+
+      render(cell);
+      const links = screen.getAllByRole('link');
+      expect(links).toHaveLength(1);
+      expect(links[0]).toHaveTextContent('Pete Dye River Course');
+    });
+
+    it('renders extra info block when free-text carries genuinely different info (Defect 4)', () => {
+      const renderCell = utils.makeVenue().renderCell as any;
+      const cell = renderCell({
+        row: {
+          venue: 'Side Stage / Patio',
+          venueId: {
+            name: 'Pete Dye River Course',
+            city: 'Radford',
+            usState: 'VA',
+            website: 'https://www.petedyerivercourse.com',
+          },
+        },
+      });
+
+      render(cell);
+      expect(screen.getByRole('link', { name: 'Pete Dye River Course' })).toBeInTheDocument();
+      expect(screen.getByText('Side Stage / Patio')).toBeInTheDocument();
+    });
+
+    it('renders bold name without anchor link when venue has no website (Defect 1 & no website)', () => {
+      const renderCell = utils.makeVenue().renderCell as any;
+      const cell = renderCell({
+        row: {
+          venue: '',
+          venueId: {
+            name: 'Salem Farmers Market',
+            city: 'Salem',
+            usState: 'VA',
+          },
+        },
+      });
+
+      render(cell);
+      expect(screen.queryByRole('link')).toBeNull();
+      expect(screen.getByText('Salem Farmers Market')).toBeInTheDocument();
+      expect(screen.queryByText(/- Salem, VA/i)).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Remove trailing city/state (`- ${city}, ${usState}`) from the Venue cell render in `renderVenueCell` since the Location column independently resolves and displays location for both mobile and desktop views.
- Add CSS rule `.MuiDataGrid-root .MuiDataGrid-cell a` in `gigs.scss` with `color: var(--nav-link)` and `color: var(--nav-link-hover)` hover state so venue links use theme tokens and render clearly as clickable links in both light and dark mode.
- Normalize venue website URLs at render-time in `normalizeUrl` so schemeless values (e.g. `www.petedyerivercourse.com`) are prefixed with `https://` before being used as the anchor `href`, keeping relative link resolution from breaking.
- Implement free-text restatement comparison heuristic `isFreeTextRenderable` to compare normalized HTML-stripped free-text against the linked venue name, suppressing duplicated venue name blocks on backfilled migrated gigs while preserving distinct extra venue details.
- Add comprehensive unit test coverage in `gigs.utils.spec.tsx` for URL normalization, free-text restatement detection, no-website fallback rendering, and location string omission.

Closes #1268

## How to test locally
1. Run `npm test` to verify linting, type-checking, duplicate code detection (`jscpd`), and unit tests with coverage pass cleanly.
2. Start the local dev server with `npm run dev` and navigate to `https://localhost:5173/music` (or `https://web-jam.com/music`).
3. Observe the Gigs datatable:
   - Verify venue-linked rows display the venue name as a styled, colored link in both light and dark mode.
   - Verify the Venue column no longer shows `- City, ST` next to the venue name, while the Location column still displays `City, ST`.
   - Hover over and click a venue link with a schemeless URL (e.g., `www.petedyerivercourse.com`) and verify it opens `https://www.petedyerivercourse.com` in a new tab rather than resolving under `web-jam.com`.
   - Verify migrated gigs whose free-text restated the venue name show the venue name only once.
   - Verify gigs with distinct extra info in free-text still display that extra info block below the venue link.

## Test evidence
```
 Test Files  69 passed (69)
      Tests  550 passed (550)
   Start at  01:09:10
   Duration  69.32s (transform 7.89s, setup 11.79s, import 273.60s, tests 150.93s, environment 193.36s)

 % Coverage report from v8
-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------|---------|----------|---------|---------|-------------------
All files          |   91.55 |    81.05 |   88.71 |   93.31 |                   
 src               |       0 |      100 |     100 |       0 |                   
  polyfills.ts     |       0 |      100 |     100 |       0 | 4-5               
 src/App           |     100 |       80 |     100 |     100 |                   
  index.tsx        |     100 |       50 |     100 |     100 | 18                
 ...pp/AppTemplate |   95.78 |    95.23 |   87.87 |   96.47 |                   
  ...erSection.tsx |     100 |       50 |     100 |     100 | 15                
  index.tsx        |   85.18 |    66.66 |   69.23 |   86.95 | 25,38,46          
 .../GoogleButtons |      90 |       60 |     100 |   91.66 |                   
  utils.tsx        |   84.61 |       50 |     100 |      88 | 30-31,60          
 src/components    |     100 |    91.66 |     100 |     100 |                   
  YearField.tsx    |     100 |       50 |     100 |     100 | 18                
 .../AdminOutreach |   95.01 |    84.56 |   98.92 |   98.19 |                   
  index.tsx        |   94.11 |    81.06 |    98.7 |   97.91 | ...64,447,452,509 
 ...AdminTemplates |   89.21 |    79.14 |      84 |      90 |                   
  ...ates.utils.ts |   98.91 |    92.42 |     100 |     100 | 27-29,152         
  index.tsx        |   85.04 |     73.1 |   78.94 |   86.27 | ...64,515-651,732 
 ...ers/AdminUsers |   85.18 |    71.22 |   84.37 |   87.15 |                   
  ...eUserForm.tsx |   80.76 |     61.9 |   82.35 |   84.21 | 77-80,93,142      
  ...serDialog.tsx |   88.46 |    81.39 |   88.88 |   93.18 | 62-63,110         
  UsersTable.tsx   |   80.76 |       54 |     100 |   80.43 | ...27-29,57,68,83 
  index.tsx        |      80 |    93.33 |    37.5 |   81.48 | 58-72             
 ...rs/AdminVenues |   89.67 |    80.33 |   85.07 |   90.83 |                   
  ...nueDialog.tsx |   88.58 |    82.78 |      90 |   89.32 | ...08-409,436,443 
  VenuesTable.tsx  |   91.44 |    84.65 |   83.67 |   91.24 | ...36,824-825,892 
  ...nues.utils.ts |   94.73 |    67.88 |    90.9 |   96.55 | 126-130           
  index.tsx        |    80.7 |       70 |   64.28 |      86 | ...27,153,186-199 
 ...iners/Homepage |   92.72 |    88.67 |   91.42 |      94 |                   
  FacebookFeed.tsx |   96.42 |    89.47 |     100 |     100 | 29,46             
  ...bookPosts.tsx |     100 |    85.71 |     100 |     100 | 36,54             
  ...tFacebook.tsx |      60 |       50 |   66.66 |   55.55 | 14-18             
  ...ook.utils.tsx |    92.1 |    94.44 |      75 |   94.28 | 19,37             
 ...mepage/Inquiry |     100 |    97.14 |     100 |     100 |                   
  utils.tsx        |     100 |    95.65 |     100 |     100 | 22                
 ...ntainers/Music |     100 |    81.08 |     100 |     100 |                   
  index.tsx        |     100 |       80 |     100 |     100 | 81,96,116-150     
  joshBio.tsx      |     100 |       50 |     100 |     100 | 30                
  mariaBio.tsx     |     100 |       50 |     100 |     100 | 31                
 ...ers/Music/Gigs |   92.32 |    79.86 |   85.26 |      95 |                   
  ...GigDialog.tsx |   79.03 |    77.77 |   71.42 |   87.03 | ...33,251,268-276 
  ...GigDialog.tsx |   81.39 |    77.33 |   70.83 |   85.71 | ...69,177,299-321 
  gigs.utils.tsx   |   98.11 |    85.15 |   96.77 |   99.47 | 109               
  index.tsx        |     100 |       72 |     100 |     100 | ...35,40-49,54-55 
 ...Music/Pictures |   96.66 |    85.71 |      88 |   96.55 |                   
  ...PicDialog.tsx |   93.33 |      100 |   83.33 |   92.85 | 27                
  ...PicDialog.tsx |   93.75 |    83.33 |    87.5 |   93.75 | 31                
  EditPicTable.tsx |    90.9 |      100 |      75 |      90 | 56                
  ...res.utils.tsx |     100 |       75 |     100 |     100 | 101               
 ...ntainers/Songs |    95.2 |    91.17 |   84.61 |   94.82 |                   
  ...ongDialog.tsx |   93.33 |       75 |   83.33 |    93.1 | 44,129            
  ...ongDialog.tsx |   91.89 |       90 |      80 |   91.42 | 54,148-156        
  index.tsx        |   94.73 |      100 |   85.71 |   94.44 | 51                
  songs.utils.tsx  |     100 |    92.85 |     100 |     100 | 34                
 ...gs/MusicPlayer |   76.68 |    71.53 |    65.3 |   80.89 |                   
  index.tsx        |    63.7 |    61.11 |   54.05 |   69.69 | ...89,301,311-322 
  utils.tsx        |     100 |       95 |     100 |     100 | 8-13              
 ...tainers/Tipjar |     100 |       50 |     100 |     100 |                   
  index.tsx        |     100 |       50 |     100 |     100 | 9-17              
 src/lib           |   99.05 |    96.15 |     100 |   98.82 |                   
  tokenExpiry.ts   |   94.11 |      100 |     100 |   92.85 | 15                
  venueTimezone.ts |     100 |    88.88 |     100 |     100 | 155,176           
 src/providers     |   92.85 |    68.57 |   97.82 |   95.23 |                   
  ....provider.tsx |   83.63 |       50 |     100 |   86.95 | 54-61,93          
  ....provider.tsx |   96.29 |      100 |    92.3 |     100 |                   
  ....provider.tsx |   94.73 |       75 |     100 |     100 | 14,41             
  fetchSongs.tsx   |     100 |    83.33 |     100 |     100 | 7                 
-------------------|---------|----------|---------|---------|-------------------

=============================== Coverage summary ===============================
Statements   : 91.55% ( 2797/3055 )
Branches     : 81.05% ( 1733/2138 )
Functions    : 88.71% ( 684/771 )
Lines        : 93.31% ( 2525/2706 )
================================================================================
```

🤖 Work by agy — Gemini 3.6 Flash (Medium)