### PR TITLE
should not skip should use a default template and send, please fix !!!!

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.19.2",
+  "version": "2.19.3",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/AdminOutreach/index.tsx
+++ b/src/containers/AdminOutreach/index.tsx
@@ -1221,7 +1221,10 @@ export function AdminOutreach() {
               </Typography>
               {result.skipped.map((s) => (
                 <Typography key={s.venueId} variant="caption" sx={{ display: 'block', color: 'text.secondary' }}>
-                  {s.venueId}: {s.reason}
+                  <Box component="span" sx={{ fontWeight: 'bold', color: 'text.primary' }}>{s.venueName}</Box>
+                  {': '}{s.reason}
+                  {' '}
+                  <Box component="span" sx={{ color: 'text.secondary' }}>({s.venueId})</Box>
                 </Typography>
               ))}
             </Box>

--- a/src/containers/AdminOutreach/outreach.utils.ts
+++ b/src/containers/AdminOutreach/outreach.utils.ts
@@ -19,7 +19,7 @@ export interface Icandidate {
   };
 }
 
-export interface IbatchSkip { venueId: string; reason: string }
+export interface IbatchSkip { venueId: string; venueName: string; reason: string }
 export interface IbatchResult {
   requested: number;
   sent: number;

--- a/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
+++ b/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
@@ -136,7 +136,7 @@ exports[`AppTemplate > renders the component 1`] = `
             <strong>
               Version
                
-              2.19.2
+              2.19.3
             </strong>
           </div>
           <p

--- a/test/containers/AdminOutreach/index.spec.tsx
+++ b/test/containers/AdminOutreach/index.spec.tsx
@@ -176,14 +176,20 @@ describe('AdminOutreach', () => {
 
   it('renders skip reasons in the result', async () => {
     outreachUtils.sendBatch = vi.fn(() => Promise.resolve({
-      requested: 2, sent: 1, skipped: [{ venueId: 'c2', reason: 'not outreach-eligible' }], records: [],
+      requested: 2,
+      sent: 1,
+      skipped: [{ venueId: 'c2', venueName: 'Venue B', reason: 'not outreach-eligible' }],
+      records: [],
     })) as any;
     await renderPage();
     typeDates();
     await act(async () => { fireEvent.click(screen.getByTestId('outreach-load')); });
     await act(async () => { fireEvent.click(screen.getByTestId('outreach-open-dialog')); });
     await act(async () => { fireEvent.click(screen.getByTestId('outreach-dialog-send')); });
-    expect(screen.getByTestId('outreach-result').textContent).toContain('not outreach-eligible');
+    const resultText = screen.getByTestId('outreach-result').textContent;
+    expect(resultText).toContain('Venue B');
+    expect(resultText).toContain('not outreach-eligible');
+    expect(resultText).toContain('c2');
   });
 
   it('shows an error when loading candidates fails', async () => {


### PR DESCRIPTION
## Summary
- Skipped outreach-batch rows rendered only a Mongo ObjectId, so Josh had no way to identify which venue failed and go fix it (WebJamApps/JaMmusic#1250)
- Add `venueName: string` to `IbatchSkip` (`src/containers/AdminOutreach/outreach.utils.ts`)
- Lead each skipped row with the venue name (bold, primary text) followed by the reason, keeping the ObjectId visible but visually secondary in parentheses (`src/containers/AdminOutreach/index.tsx`)
- Pairs with the backend contract change on web-jam-back branch `claude/1250-default-template-fallback`, which adds `venueName` to every skipped entry (falling back to the placeholder `'(unknown venue)'` when no venue doc could be loaded) — **this PR should merge after that one**, since the field is sourced from the backend response
- Bump patch version to 2.19.3

Closes #1250

## How to test locally
Manual verification of the change itself:
```sh
npm run dev
```
Then: open the Admin Outreach page, load candidates, select venues whose `venueType`/`templateOverride` will fail to resolve on the backend, and send a batch. In the result panel, confirm each skipped row now reads `**Venue Name**: reason (ObjectId)` — the venue name is bold and immediately readable, the reason follows it, and the ObjectId is present but visually secondary in parentheses at the end.

Automated:
```sh
npm test
```
Expect: lint (0 errors), typecheck, jscpd, and the full unit suite all green.

## Test evidence
```
✖ 948 problems (0 errors, 948 warnings)

 Test Files  69 passed (69)
      Tests  550 passed (550)

=============================== Coverage summary ===============================
Statements   : 91.94% ( 2809/3055 )
Branches     : 81.24% ( 1737/2138 )
Functions    : 88.84% ( 685/771 )
Lines        : 93.71% ( 2536/2706 )
================================================================================
```
(App snapshot updated via `npm run test:unit-u` to reflect the 2.19.2 -> 2.19.3 version-string bump; no other snapshots changed.)

🤖 Work by Claude Code — Sonnet 5