### PR TITLE
fix(providers): surface async socket connection failures instead of hanging silently

### DIFF
--- a/__mocks__/socketcluster-client.tsx
+++ b/__mocks__/socketcluster-client.tsx
@@ -5,6 +5,9 @@ export const create = (options: any): any => {
   return {
     subscribe: () => ({ createConsumer: () => ({ next: () => Promise.resolve({ value: 1, done: true }) }) }),
     receiver: () => ({ createConsumer: () => ({ next: () => Promise.resolve({ value: 'connected', done: true }) }) }),
+    // Default mock never signals a connection failure, so the data path always
+    // wins the race in socketClusterMessages.tsx unless a test overrides this.
+    listener: () => ({ createConsumer: () => ({ next: () => new Promise(() => { /* never resolves */ }) }) }),
     transmit: () => { },
     disconnect: () => {},
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jammusic",
-  "version": "2.19.3",
+  "version": "2.19.4",
   "description": "joshandmariamusic.com",
   "main": "dist/index.html",
   "repository": {

--- a/src/providers/socketClusterMessages.tsx
+++ b/src/providers/socketClusterMessages.tsx
@@ -1,4 +1,16 @@
 import scc from 'socketcluster-client';
+import commonUtils from 'src/lib/utils';
+
+// A dead/unreachable SocketCluster backend fails to connect *asynchronously* —
+// scc.create() itself never throws, so wrapping only that call in try/catch
+// can't see the failure. Without a bound, an initial message that never gets
+// a reply (no data, no error, no connectAbort) hangs forever and the UI just
+// sits empty. This timeout guarantees we always tell the visitor something.
+// (JaMmusic outage 2026-08-01: webjamsocket crash-looped for ~1.5 days and
+// web-jam.com/music silently rendered with no gigs/pictures and no error.)
+export const CONNECTION_TIMEOUT_MS = 8000;
+
+const CONNECTION_FAILED_MESSAGE = 'We could not load this content from the server. Please refresh or try again shortly.';
 
 const validateData = (
   receiver: IteratorResult<unknown[]>,
@@ -13,21 +25,49 @@ const validateData = (
   setFunc(dataArr);
 };
 
+type DataConsumer = ReturnType<ReturnType<scc.AGClientSocket['receiver']>['createConsumer']>;
+
 const listenForData = (
   socket: scc.AGClientSocket,
-  message: string,
+  consumer: DataConsumer,
   setFunc: (_arg0: unknown[] | null) => void,
+  firstReceiver: IteratorResult<unknown[]>,
 ): boolean => {
   (async () => {
-    const consumer = socket.receiver(message).createConsumer();
+    let receiver = firstReceiver;
     while (true) { // eslint-disable-line no-constant-condition
-      const receiver = await consumer.next();// eslint-disable-line no-await-in-loop
       validateData(receiver, setFunc);
       socket.disconnect();
       /* istanbul ignore else */if (receiver.done) break;
+      receiver = await consumer.next(); // eslint-disable-line no-await-in-loop
     }
   })();
   return true;
+};
+
+type ConnectionOutcome =
+  | { kind: 'data'; receiver: IteratorResult<unknown[]> }
+  | { kind: 'failed'; reason: string };
+
+// Races the first data message against the async failure signals SocketCluster
+// actually emits for an unreachable/crash-looping server ('error', 'connectAbort')
+// and a hard timeout, so a hung connection can never fail silently.
+const waitForConnection = (
+  socket: scc.AGClientSocket,
+  consumer: DataConsumer,
+): Promise<ConnectionOutcome> => {
+  const dataOutcome = consumer.next()
+    .then((receiver): ConnectionOutcome => ({ kind: 'data', receiver }));
+  const errorOutcome = socket.listener('error').createConsumer().next()
+    .then(({ value }): ConnectionOutcome => (
+      { kind: 'failed', reason: value?.error?.message || 'socket error' }
+    ));
+  const abortOutcome = socket.listener('connectAbort').createConsumer().next()
+    .then((): ConnectionOutcome => ({ kind: 'failed', reason: 'connect aborted' }));
+  const timeoutOutcome = new Promise<ConnectionOutcome>((resolve) => {
+    setTimeout(() => resolve({ kind: 'failed', reason: 'timed out' }), CONNECTION_TIMEOUT_MS);
+  });
+  return Promise.race([dataOutcome, errorOutcome, abortOutcome, timeoutOutcome]);
 };
 
 const initialMessage = (setFunc: (arg0: any[] | null) => void, message: string) => {
@@ -39,8 +79,24 @@ const initialMessage = (setFunc: (arg0: any[] | null) => void, message: string) 
       secure: process.env.SOCKETCLUSTER_SECURE !== 'false',
     });
     socket.transmit('initial message', 123);
-    return listenForData(socket, message, setFunc);
-  } catch (err) { console.log((err as Error).message); return false; }
+    const consumer = socket.receiver(message).createConsumer();
+    (async () => {
+      const outcome = await waitForConnection(socket, consumer);
+      if (outcome.kind === 'data') {
+        listenForData(socket, consumer, setFunc, outcome.receiver);
+        return;
+      }
+      // Two independent signals, on purpose: console for developer diagnosis,
+      // notify() for the visitor. Neither alone is enough — the console is
+      // invisible to a visitor, and a toast with no logged detail is useless
+      // to debug. This pairing is what was missing during the outage.
+      console.error(`socketClusterMessages: failed to load "${message}" (${outcome.reason})`); // eslint-disable-line no-console
+      commonUtils.notify('Could not load data', CONNECTION_FAILED_MESSAGE, 'danger');
+      setFunc(null);
+      socket.disconnect();
+    })();
+    return true;
+  } catch (err) { console.log((err as Error).message); return false; } // eslint-disable-line no-console
 };
 
 export default { initialMessage, validateData };

--- a/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
+++ b/test/App/AppTemplate/__snapshots__/index.spec.tsx.snap
@@ -136,7 +136,7 @@ exports[`AppTemplate > renders the component 1`] = `
             <strong>
               Version
                
-              2.19.3
+              2.19.4
             </strong>
           </div>
           <p

--- a/test/providers/socketClusterMessages.spec.tsx
+++ b/test/providers/socketClusterMessages.spec.tsx
@@ -1,11 +1,141 @@
-import socketClusterMessages from 'src/providers/socketClusterMessages';
+import { waitFor } from '@testing-library/react';
+import socketClusterMessages, { CONNECTION_TIMEOUT_MS } from 'src/providers/socketClusterMessages';
+import scc from 'socketcluster-client';
+import commonUtils from 'src/lib/utils';
+
+const neverResolves = () => new Promise(() => { /* server never replies */ });
 
 describe('socketClusterMessages', () => {
+  afterEach(() => {
+    // Restore the baseline fake-timer config set up globally in
+    // test/vitest.setup.ts, in case a test in this file swapped it out.
+    vi.useFakeTimers({ now: 1483228800000, toFake: ['Date'] });
+  });
+
   it('validateData when it is an array', () => {
     let dataArr = null;
     const setFunc = jest.fn((d) => { dataArr = d; });
     const receiver = { value: [{}] };
     socketClusterMessages.validateData(receiver, setFunc);
     expect(Array.isArray(dataArr)).toBeTruthy();
+  });
+
+  it('initialMessage success path is unchanged: data resolves, setFunc gets it, socket disconnects', async () => {
+    const disconnect = jest.fn();
+    const dataNext = jest.fn().mockResolvedValue({ value: [{ a: 1 }], done: true });
+    const receiver = jest.fn(() => ({ createConsumer: () => ({ next: dataNext }) }));
+    const listener = jest.fn(() => ({ createConsumer: () => ({ next: neverResolves }) }));
+    const transmit = jest.fn();
+    scc.create = jest.fn(() => ({
+      transmit, receiver, listener, disconnect,
+    })) as any;
+    const setFunc = jest.fn();
+
+    const result = socketClusterMessages.initialMessage(setFunc, 'allGigs');
+
+    expect(result).toBe(true);
+    await waitFor(() => expect(setFunc).toHaveBeenCalledWith([{ a: 1, id: 0 }]));
+    expect(disconnect).toHaveBeenCalled();
+  });
+
+  it('initialMessage success path keeps streaming subsequent messages on the same consumer (unchanged)', async () => {
+    const disconnect = jest.fn();
+    const dataNext = jest.fn()
+      .mockResolvedValueOnce({ value: [{ a: 1 }], done: false })
+      .mockResolvedValueOnce({ value: [{ b: 2 }], done: true });
+    const receiver = jest.fn(() => ({ createConsumer: () => ({ next: dataNext }) }));
+    const listener = jest.fn(() => ({ createConsumer: () => ({ next: neverResolves }) }));
+    const transmit = jest.fn();
+    scc.create = jest.fn(() => ({
+      transmit, receiver, listener, disconnect,
+    })) as any;
+    const setFunc = jest.fn();
+
+    socketClusterMessages.initialMessage(setFunc, 'allGigs');
+
+    await waitFor(() => expect(setFunc).toHaveBeenCalledWith([{ b: 2, id: 0 }]));
+    expect(setFunc).toHaveBeenCalledWith([{ a: 1, id: 0 }]);
+    expect(disconnect).toHaveBeenCalledTimes(2);
+  });
+
+  it('initialMessage surfaces an async "error" event as a user-visible failure instead of hanging silently', async () => {
+    commonUtils.notify = jest.fn();
+    const disconnect = jest.fn();
+    const receiver = jest.fn(() => ({ createConsumer: () => ({ next: neverResolves }) }));
+    const errorNext = jest.fn().mockResolvedValue({ value: { error: new Error('connect ECONNREFUSED 10.0.0.1:8000') }, done: false });
+    const listener = jest.fn((eventName: string) => ({
+      createConsumer: () => ({ next: eventName === 'error' ? errorNext : neverResolves }),
+    }));
+    const transmit = jest.fn();
+    scc.create = jest.fn(() => ({
+      transmit, receiver, listener, disconnect,
+    })) as any;
+    const setFunc = jest.fn();
+
+    const result = socketClusterMessages.initialMessage(setFunc, 'allGigs');
+
+    expect(result).toBe(true);
+    await waitFor(() => expect(commonUtils.notify).toHaveBeenCalled());
+    expect(commonUtils.notify).toHaveBeenCalledWith(
+      'Could not load data',
+      expect.any(String),
+      'danger',
+    );
+    const visitorMessage = (commonUtils.notify as ReturnType<typeof jest.fn>).mock.calls[0][1] as string;
+    // The visitor-facing message must never leak the raw error, host, or port.
+    expect(visitorMessage).not.toMatch(/ECONNREFUSED|10\.0\.0\.1|8000/);
+    expect(setFunc).toHaveBeenCalledWith(null);
+    expect(disconnect).toHaveBeenCalled();
+  });
+
+  it('initialMessage surfaces a "connectAbort" as a user-visible failure', async () => {
+    commonUtils.notify = jest.fn();
+    const disconnect = jest.fn();
+    const receiver = jest.fn(() => ({ createConsumer: () => ({ next: neverResolves }) }));
+    const abortNext = jest.fn().mockResolvedValue({ value: { code: 4001, reason: 'refused' }, done: false });
+    const listener = jest.fn((eventName: string) => ({
+      createConsumer: () => ({ next: eventName === 'connectAbort' ? abortNext : neverResolves }),
+    }));
+    const transmit = jest.fn();
+    scc.create = jest.fn(() => ({
+      transmit, receiver, listener, disconnect,
+    })) as any;
+    const setFunc = jest.fn();
+
+    socketClusterMessages.initialMessage(setFunc, 'allGigs');
+
+    await waitFor(() => expect(commonUtils.notify).toHaveBeenCalled());
+    expect(setFunc).toHaveBeenCalledWith(null);
+    expect(disconnect).toHaveBeenCalled();
+  });
+
+  it('initialMessage times out and surfaces a failure when the server never responds at all (JaMmusic outage 2026-08-01)', async () => {
+    vi.useFakeTimers({ now: 1483228800000, toFake: ['Date', 'setTimeout'] });
+    commonUtils.notify = jest.fn();
+    const disconnect = jest.fn();
+    const receiver = jest.fn(() => ({ createConsumer: () => ({ next: neverResolves }) }));
+    const listener = jest.fn(() => ({ createConsumer: () => ({ next: neverResolves }) }));
+    const transmit = jest.fn();
+    scc.create = jest.fn(() => ({
+      transmit, receiver, listener, disconnect,
+    })) as any;
+    const setFunc = jest.fn();
+
+    const result = socketClusterMessages.initialMessage(setFunc, 'allGigs');
+    expect(result).toBe(true);
+
+    // Nothing should have fired yet — this is exactly the silent-hang defect:
+    // no data, no error, no connectAbort, and (before the fix) no timeout either.
+    expect(commonUtils.notify).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(CONNECTION_TIMEOUT_MS);
+
+    expect(commonUtils.notify).toHaveBeenCalledWith(
+      'Could not load data',
+      expect.any(String),
+      'danger',
+    );
+    expect(setFunc).toHaveBeenCalledWith(null);
+    expect(disconnect).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Fix a silent-failure defect in `src/providers/socketClusterMessages.tsx`: an unreachable/crash-looping SocketCluster backend fails to connect *asynchronously*, but the old code only wrapped the synchronous `scc.create()` call in try/catch — so `listenForData` awaited `consumer.next()` forever, `setFunc` was never called, and `web-jam.com/music` rendered HTTP 200 with no gigs/pictures and nothing in the console. This is the exact mechanism behind the 2026-08-01 webjamsocket outage going unnoticed for ~1.5 days.
- Race the first data message against `socket.listener('error')` and `socket.listener('connectAbort')` (the real async failure events `socketcluster-client` v20 exposes) plus a new named `CONNECTION_TIMEOUT_MS` (8s) bound, so a hung connection can never fail silently.
- On any failure outcome: `console.error` the underlying reason for developer diagnosis, `commonUtils.notify(...)` a generic non-leaky danger toast for the visitor (no hostname/port/stack), `setFunc(null)`, and always `socket.disconnect()` — mirroring the existing `deletePic` pattern in `pictures.utils.tsx` (JaMmusic#1199).
- "No data" vs "could not connect": both still render as an empty grid/slider — `Data.provider.tsx`, `Gigs`, and `Pictures` already treat `null` as "nothing to show" and this fix deliberately doesn't touch that contract (out of scope per the proportionate-fix ask). What's new is that a connection failure now always fires a visible danger toast plus a distinct `console.error` line, while a genuinely empty dataset does neither — that pairing is the signal a visitor and a developer use to tell the two apart.
- Updated `__mocks__/socketcluster-client.tsx` with a `listener` stub (a never-resolving stream) so the default mock still represents a healthy connection and every pre-existing success-path test is unchanged.
- Added tests in `test/providers/socketClusterMessages.spec.tsx` covering the `error` event, `connectAbort` event, and the timeout — each verified to FAIL against the pre-fix code — plus single-message and multi-message success paths.

## How to test locally
Automated:
```sh
npm run test:lint
npm run typecheck
TZ=UTC npx vitest run --coverage
```
Expect: 0 lint errors, clean typecheck, full suite green, coverage above the 90/90/80/80 gate.

Manual (exercise the actual failure path):
1. Set `SCS_HOST` to an unreachable host (or stop the local `webjamsocket` dev server).
2. Run `npm run dev` and open `/music`.
3. Expect: a red "Could not load data" toast appears within ~8s, and the browser console shows a `socketClusterMessages: failed to load ...` line — instead of the page silently sitting empty forever with zero signal.
4. With `webjamsocket` reachable, repeat and confirm gigs/pictures load normally with no toast (success path unchanged).

## Test evidence
New/changed tests, run in isolation — each of the 3 new failure-mode tests was first verified to FAIL against the pre-fix source (`git show origin/dev:src/providers/socketClusterMessages.tsx`), proving they exercise the real bug:
```
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

Full lint (0 errors, pre-existing repo-wide style warnings only):
```
✖ 951 problems (0 errors, 951 warnings)
```

Full typecheck:
```
> jammusic@2.19.4 typecheck
> tsc --noEmit
(clean, no output)
```

Full coverage run (jsdom; `--coverage.reportOnFailure=true` used only to force the report table past one PRE-EXISTING, unrelated local-env failure in `test/containers/Music/index.spec.tsx` — "checkIsAdmin when true" fails identically on a clean `origin/dev` checkout, unrelated to this change):
```
 Test Files  1 failed | 68 passed (69)
      Tests  1 failed | 553 passed (554)

=============================== Coverage summary ===============================
Statements   : 91.45% ( 2815/3078 )
Branches     : 80.76% ( 1730/2142 )
Functions    : 88.81% ( 691/778 )
Lines        : 93.21% ( 2543/2728 )
================================================================================
```
Gate is 90/90/80/80 (statements/lines/branches/functions) — all four met.

🤖 Work by Claude Sonnet 5